### PR TITLE
PMC Submitter Not Imported Only

### DIFF
--- a/commons-bio/src/main/kotlin/ebi/ac/uk/model/File.kt
+++ b/commons-bio/src/main/kotlin/ebi/ac/uk/model/File.kt
@@ -2,7 +2,7 @@ package ebi.ac.uk.model
 
 import java.util.Objects
 
-class File(var path: String, var size:Long = 0, attributes: List<Attribute> = emptyList()) : Attributable(attributes) {
+class File(var path: String, var size: Long = 0, attributes: List<Attribute> = emptyList()) : Attributable(attributes) {
 
     override fun equals(other: Any?): Boolean {
         if (other !is File) return false

--- a/commons-bio/src/main/kotlin/ebi/ac/uk/model/extensions/FileExt.kt
+++ b/commons-bio/src/main/kotlin/ebi/ac/uk/model/extensions/FileExt.kt
@@ -3,12 +3,6 @@ package ebi.ac.uk.model.extensions
 import ebi.ac.uk.model.File
 import ebi.ac.uk.model.constants.FileFields
 
-var File.size: Int
-    get() = this[FileFields.SIZE]
-    set(value) {
-        this[FileFields.SIZE] = value
-    }
-
 var File.type: String
     get() = this[FileFields.TYPE]
     set(value) {

--- a/scheduler/pmc-processor-task/src/main/kotlin/ac/uk/ebi/pmc/config/AppConfig.kt
+++ b/scheduler/pmc-processor-task/src/main/kotlin/ac/uk/ebi/pmc/config/AppConfig.kt
@@ -55,8 +55,11 @@ class AppConfig {
                     .getAuthenticatedClient(properties.bioStudiesUser, properties.bioStudiesPassword)
 
     @Bean
-    fun pmcSubmitter(bioWebClient: BioWebClient, submissionDocService: MongoDocService) =
-            PmcSubmitter(bioWebClient, submissionDocService)
+    fun pmcSubmitter(
+        bioWebClient: BioWebClient,
+        submissionDocService: MongoDocService,
+        pmcImporterProperties: PmcImporterProperties
+    ) = PmcSubmitter(bioWebClient, submissionDocService, pmcImporterProperties)
 
     @Bean
     fun pmcBatchImporter(pmcImporter: PmcImporter) = PmcBatchImporter(pmcImporter)

--- a/scheduler/pmc-processor-task/src/main/kotlin/ac/uk/ebi/pmc/data/MongoDocService.kt
+++ b/scheduler/pmc-processor-task/src/main/kotlin/ac/uk/ebi/pmc/data/MongoDocService.kt
@@ -20,9 +20,12 @@ class MongoDocService(
     private val dataRepository: MongoRepository,
     private val serializationService: SerializationService
 ) {
-    suspend fun getAllSubmissions() = dataRepository.getAllSubmissions().toList()
+    suspend fun getNotImportedSubmissions(sourceFile: String) =
+            dataRepository.getNotImportedSubmissionsBySourceFile(sourceFile).toList()
 
     suspend fun getSubFiles(ids: List<ObjectId>) = dataRepository.getSubFiles(ids)
+
+    suspend fun markAsImported(submission: SubmissionDoc) = dataRepository.update(submission.apply { imported = true })
 
     suspend fun saveSubmission(submission: Submission, sourceFile: String, files: List<File>) {
         val fileIds = files
@@ -33,10 +36,15 @@ class MongoDocService(
         logger.info { "finish processing submission with accNo = '${submission.accNo}' of file $sourceFile" }
     }
 
-    suspend fun reportError(submission: Submission, sourceFile: String, throwable: Throwable) {
-        logger.error { "problem processing submission ${submission.accNo} of file $sourceFile, ${throwable.message}" }
+    suspend fun reportError(submission: Submission, sourceFile: String, throwable: Throwable) =
+            saveError(submission.accNo, sourceFile, asJson(submission), throwable)
 
-        dataRepository.save(ErrorDoc(submission.accNo, asJson(submission), sourceFile, getStackTrace(throwable)))
+    suspend fun reportError(submission: SubmissionDoc, throwable: Throwable) =
+            saveError(submission.id, submission.sourceFile, submission.body, throwable)
+
+    private suspend fun saveError(accNo: String, sourceFile: String, submission: String, throwable: Throwable) {
+        logger.error { "Error processing submission $accNo of file $sourceFile, ${throwable.message}" }
+        dataRepository.save(ErrorDoc(accNo, submission, submission, getStackTrace(throwable)))
     }
 
     private fun asJson(submission: Submission) = serializationService.serializeSubmission(submission, SubFormat.JSON)

--- a/scheduler/pmc-processor-task/src/main/kotlin/ac/uk/ebi/pmc/data/MongoDocService.kt
+++ b/scheduler/pmc-processor-task/src/main/kotlin/ac/uk/ebi/pmc/data/MongoDocService.kt
@@ -21,7 +21,7 @@ class MongoDocService(
     private val serializationService: SerializationService
 ) {
     suspend fun getNotImportedSubmissions(sourceFile: String) =
-            dataRepository.getNotImportedSubmissionsBySourceFile(sourceFile).toList()
+            dataRepository.findSubmissions(sourceFile).toList()
 
     suspend fun getSubFiles(ids: List<ObjectId>) = dataRepository.getSubFiles(ids)
 

--- a/scheduler/pmc-processor-task/src/main/kotlin/ac/uk/ebi/pmc/data/MongoRepository.kt
+++ b/scheduler/pmc-processor-task/src/main/kotlin/ac/uk/ebi/pmc/data/MongoRepository.kt
@@ -5,10 +5,12 @@ import ac.uk.ebi.pmc.data.docs.FileDoc
 import ac.uk.ebi.pmc.data.docs.SubmissionDoc
 import com.mongodb.async.client.FindIterable
 import com.mongodb.async.client.MongoClient
-import com.mongodb.client.model.Filters
+import com.mongodb.client.model.Filters.and
+import com.mongodb.client.model.Filters.eq
 import org.bson.types.ObjectId
 import org.litote.kmongo.coroutine.findOne
 import org.litote.kmongo.coroutine.insertOne
+import org.litote.kmongo.coroutine.updateOne
 import java.io.File
 
 private const val SUBMISSION_COLLECTION = "submissions"
@@ -19,36 +21,32 @@ class MongoRepository(
     private val dataBase: String,
     private val mongoClient: MongoClient
 ) {
-    fun getAllSubmissions(): FindIterable<SubmissionDoc> {
-        val database = mongoClient.getDatabase(dataBase)
-        val collection = database.getCollection(SUBMISSION_COLLECTION, SubmissionDoc::class.java)
+    fun getNotImportedSubmissionsBySourceFile(sourceFile: String): FindIterable<SubmissionDoc> =
+            getSubmissionCollection().find(and(eq("sourceFile", sourceFile), eq("imported", false)))
 
-        return collection.find()
-    }
+    suspend fun save(submissionDoc: SubmissionDoc) = getSubmissionCollection().insertOne(submissionDoc)
 
-    suspend fun save(submissionDoc: SubmissionDoc) {
-        val database = mongoClient.getDatabase(dataBase)
-        val collection = database.getCollection(SUBMISSION_COLLECTION, SubmissionDoc::class.java)
-        collection.insertOne(submissionDoc)
-    }
+    suspend fun save(errorDoc: ErrorDoc) = getCollection(ERRORS_COLLECTION, ErrorDoc::class.java).insertOne(errorDoc)
 
-    suspend fun save(errorDoc: ErrorDoc) {
-        val database = mongoClient.getDatabase(dataBase)
-        val collection = database.getCollection(ERRORS_COLLECTION, ErrorDoc::class.java)
-        collection.insertOne(errorDoc)
-    }
+    suspend fun update(submissionDoc: SubmissionDoc) = getSubmissionCollection().updateOne(submissionDoc)
 
     suspend fun saveSubFile(file: File, accNo: String): ObjectId {
-        val database = mongoClient.getDatabase(dataBase)
-        val collection = database.getCollection(FILES_COLLECTION, FileDoc::class.java)
+        val collection = getFilesCollection()
+
         collection.insertOne(FileDoc(file.name, file.absolutePath, accNo))
-        return collection.findOne(Filters.eq("path", file.absolutePath))!!.id
+        return collection.findOne(eq("path", file.absolutePath))!!.id
     }
 
     suspend fun getSubFiles(ids: List<ObjectId>): List<FileDoc> {
-        val database = mongoClient.getDatabase(dataBase)
-        val collection = database.getCollection(FILES_COLLECTION, FileDoc::class.java)
+        val collection = getFilesCollection()
 
-        return ids.map { collection.findOne(Filters.eq("_id", it))!! }.toList()
+        return ids.map { collection.findOne(eq("_id", it))!! }.toList()
     }
+
+    private fun getFilesCollection() = getCollection(FILES_COLLECTION, FileDoc::class.java)
+
+    private fun getSubmissionCollection() = getCollection(SUBMISSION_COLLECTION, SubmissionDoc::class.java)
+
+    private fun <A, B : Class<A>> getCollection(name: String, documentClass: B) =
+            mongoClient.getDatabase(dataBase).getCollection(name, documentClass)
 }

--- a/scheduler/pmc-processor-task/src/main/kotlin/ac/uk/ebi/pmc/data/MongoRepository.kt
+++ b/scheduler/pmc-processor-task/src/main/kotlin/ac/uk/ebi/pmc/data/MongoRepository.kt
@@ -21,12 +21,12 @@ class MongoRepository(
     private val dataBase: String,
     private val mongoClient: MongoClient
 ) {
-    fun getNotImportedSubmissionsBySourceFile(sourceFile: String): FindIterable<SubmissionDoc> =
-            getSubmissionCollection().find(and(eq("sourceFile", sourceFile), eq("imported", false)))
+    fun findSubmissions(sourceFile: String, imported: Boolean = false): FindIterable<SubmissionDoc> =
+            getSubmissionCollection().find(and(eq("sourceFile", sourceFile), eq("imported", imported)))
 
     suspend fun save(submissionDoc: SubmissionDoc) = getSubmissionCollection().insertOne(submissionDoc)
 
-    suspend fun save(errorDoc: ErrorDoc) = getCollection(ERRORS_COLLECTION, ErrorDoc::class.java).insertOne(errorDoc)
+    suspend fun save(errorDoc: ErrorDoc) = getCollection<ErrorDoc>(ERRORS_COLLECTION).insertOne(errorDoc)
 
     suspend fun update(submissionDoc: SubmissionDoc) = getSubmissionCollection().updateOne(submissionDoc)
 
@@ -43,10 +43,10 @@ class MongoRepository(
         return ids.map { collection.findOne(eq("_id", it))!! }.toList()
     }
 
-    private fun getFilesCollection() = getCollection(FILES_COLLECTION, FileDoc::class.java)
+    private fun getFilesCollection() = getCollection<FileDoc>(FILES_COLLECTION)
 
-    private fun getSubmissionCollection() = getCollection(SUBMISSION_COLLECTION, SubmissionDoc::class.java)
+    private fun getSubmissionCollection() = getCollection<SubmissionDoc>(SUBMISSION_COLLECTION)
 
-    private fun <A, B : Class<A>> getCollection(name: String, documentClass: B) =
-            mongoClient.getDatabase(dataBase).getCollection(name, documentClass)
+    private inline fun <reified T> getCollection(name: String) =
+            mongoClient.getDatabase(dataBase).getCollection(name, T::class.java)
 }

--- a/scheduler/pmc-processor-task/src/main/kotlin/ac/uk/ebi/pmc/data/docs/SubmissionDoc.kt
+++ b/scheduler/pmc-processor-task/src/main/kotlin/ac/uk/ebi/pmc/data/docs/SubmissionDoc.kt
@@ -9,5 +9,6 @@ data class SubmissionDoc(
     val sourceFile: String,
     val files: List<ObjectId>,
     val uploaded: Instant = Instant.now(),
-    val imported: Boolean = false
+    var imported: Boolean = false,
+    val _id: ObjectId? = null
 )

--- a/scheduler/pmc-processor-task/src/main/kotlin/ac/uk/ebi/pmc/submit/PmcSubmitter.kt
+++ b/scheduler/pmc-processor-task/src/main/kotlin/ac/uk/ebi/pmc/submit/PmcSubmitter.kt
@@ -4,6 +4,7 @@ import ac.uk.ebi.biostd.client.integration.commons.SubmissionFormat
 import ac.uk.ebi.biostd.client.integration.web.BioWebClient
 import ac.uk.ebi.pmc.data.MongoDocService
 import ac.uk.ebi.pmc.data.docs.SubmissionDoc
+import ac.uk.ebi.scheduler.properties.PmcImporterProperties
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
@@ -14,18 +15,24 @@ private val logger = KotlinLogging.logger {}
 
 class PmcSubmitter(
     private val bioWebClient: BioWebClient,
-    private val submissionDocService: MongoDocService
+    private val submissionDocService: MongoDocService,
+    private val pmcImporterProperties: PmcImporterProperties
 ) {
-    suspend fun submit() =
-        submissionDocService.getAllSubmissions().map { GlobalScope.launch { processSubmission(it) } }
+    suspend fun submit() = submissionDocService
+            .getNotImportedSubmissions(pmcImporterProperties.sourceFile)
+            .map { GlobalScope.launch { processSubmission(it) } }
 
     private suspend fun processSubmission(submission: SubmissionDoc) = coroutineScope {
-        logger.info { "Submitting ${submission.id}" }
+        try {
+            val files = submissionDocService.getSubFiles(submission.files).map { File(it.path) }.toList()
 
-        val files = submissionDocService.getSubFiles(submission.files).map { File(it.path) }.toList()
-        val response = bioWebClient.submitSingle(submission.body.replace("\\", ""), SubmissionFormat.JSON, files)
+            bioWebClient.submitSingle(submission.body.replace("\\", ""), SubmissionFormat.JSON, files)
+            submissionDocService.markAsImported(submission)
 
-        logger.info { "Submission request response for ${submission.id}: ${response.statusCode}" }
-
+            logger.info { "Submission ${submission.id} successfully submitted" }
+        } catch (exception: Exception) {
+            logger.error { "Errors processing ${submission.id}" }
+            submissionDocService.reportError(submission, exception)
+        }
     }
 }

--- a/scheduler/pmc-processor-task/src/main/resources/application.yml
+++ b/scheduler/pmc-processor-task/src/main/resources/application.yml
@@ -3,6 +3,7 @@ app:
     mode: # Processing mode: FILE, FOLDER or SUBMIT
     path: # path to load files
     temp: # directory to store submission downloaded files
+    sourceFile: # Source file that will be used to submit
     mongodb-uri: # Mongo database connection string
     bio-studies-url: # URL pointing to the BioStudies instance where the data will be submitted
     bio-studies-user: # User under whom the submissions will be made

--- a/scheduler/pmc-processor-task/src/test/kotlin/ac/uk/ebi/pmc/importer.data/MongoDocServiceTest.kt
+++ b/scheduler/pmc-processor-task/src/test/kotlin/ac/uk/ebi/pmc/importer.data/MongoDocServiceTest.kt
@@ -36,7 +36,7 @@ internal class MongoDocServiceTest(
     @Test
     fun `save submission with file`(): Unit = runBlocking {
         coEvery { dataRepository.saveSubFile(exampleFile, submission.accNo) } returns fileId
-        coEvery { dataRepository.save(ofType(SubmissionDoc::class)) } returns Unit
+        coEvery { dataRepository.save(ofType(SubmissionDoc::class)) } returns null
         every { serializationService.serializeSubmission(submission, SubFormat.JSON) } returns submissionJson
 
         testInstance.saveSubmission(submission, "source file", listOf(exampleFile))

--- a/scheduler/scheduler/src/main/kotlin/ac/uk/ebi/pmc/scheduler/pmc/importer/PmcImporterService.kt
+++ b/scheduler/scheduler/src/main/kotlin/ac/uk/ebi/pmc/scheduler/pmc/importer/PmcImporterService.kt
@@ -26,7 +26,11 @@ class PmcImporterService(
             mode = ImportMode.GZ_FILE,
             path = file.absolutePath,
             temp = properties.temp,
-            mongodbUri = properties.mongoUri)
+            mongodbUri = properties.mongoUri,
+            sourceFile = "",
+            bioStudiesUrl = "",
+            bioStudiesUser = "",
+            bioStudiesPassword = "")
 
         val jobTry = clusterOperations.triggerJob(
             JobSpec(8, MemorySpec.SIXTEEN_GB, properties.asJavaCommand(appProperties.appsFolder), jobs))

--- a/scheduler/task-properties/src/main/kotlin/ac/uk/ebi/scheduler/properties/PmcImporterProperties.kt
+++ b/scheduler/task-properties/src/main/kotlin/ac/uk/ebi/scheduler/properties/PmcImporterProperties.kt
@@ -18,14 +18,14 @@ class PmcImporterProperties() : BaseAppProperty {
     }
 
     constructor(
-            mode: ImportMode,
-            path: String,
-            temp: String,
-            sourceFile: String,
-            mongodbUri: String,
-            bioStudiesUrl: String,
-            bioStudiesUser: String,
-            bioStudiesPassword: String
+        mode: ImportMode,
+        path: String,
+        temp: String,
+        sourceFile: String,
+        mongodbUri: String,
+        bioStudiesUrl: String,
+        bioStudiesUser: String,
+        bioStudiesPassword: String
     ) : this() {
         this.mode = mode
         this.path = path

--- a/scheduler/task-properties/src/main/kotlin/ac/uk/ebi/scheduler/properties/PmcImporterProperties.kt
+++ b/scheduler/task-properties/src/main/kotlin/ac/uk/ebi/scheduler/properties/PmcImporterProperties.kt
@@ -9,6 +9,7 @@ class PmcImporterProperties() : BaseAppProperty {
             --app.data.path=$path \
             --app.data.mode=$mode \
             --app.data.temp=$temp \
+            --app.data.sourceFile=$sourceFile \
             --app.data.mongodbUri=$mongodbUri \
             --app.data.bioStudiesUrl=$bioStudiesUrl \
             --app.data.bioStudiesUser=$bioStudiesUser \
@@ -20,6 +21,7 @@ class PmcImporterProperties() : BaseAppProperty {
             mode: ImportMode,
             path: String,
             temp: String,
+            sourceFile: String,
             mongodbUri: String,
             bioStudiesUrl: String,
             bioStudiesUser: String,
@@ -28,6 +30,7 @@ class PmcImporterProperties() : BaseAppProperty {
         this.mode = mode
         this.path = path
         this.temp = temp
+        this.sourceFile = sourceFile
         this.mongodbUri = mongodbUri
         this.bioStudiesUrl = bioStudiesUrl
         this.bioStudiesUser = bioStudiesUser
@@ -37,6 +40,7 @@ class PmcImporterProperties() : BaseAppProperty {
     lateinit var mode: ImportMode
     lateinit var path: String
     lateinit var temp: String
+    lateinit var sourceFile: String
     lateinit var mongodbUri: String
     lateinit var bioStudiesUrl: String
     lateinit var bioStudiesUser: String

--- a/serialization/src/main/kotlin/ac/uk/ebi/biostd/xml/serializer/FileSerializer.kt
+++ b/serialization/src/main/kotlin/ac/uk/ebi/biostd/xml/serializer/FileSerializer.kt
@@ -1,6 +1,7 @@
 package ac.uk.ebi.biostd.xml.serializer
 
 import ac.uk.ebi.biostd.xml.common.XmlStdSerializer
+import ac.uk.ebi.biostd.xml.common.writeXmlAttr
 import ac.uk.ebi.biostd.xml.common.writeXmlCollection
 import ac.uk.ebi.biostd.xml.common.writeXmlField
 import ac.uk.ebi.biostd.xml.common.writeXmlObj
@@ -14,6 +15,7 @@ class FileSerializer : XmlStdSerializer<File>(File::class.java) {
     override fun serializeXml(value: File, gen: ToXmlGenerator, provider: SerializerProvider) {
         with(gen) {
             writeXmlObj(FileFields.FILE, value) {
+                writeXmlAttr(FileFields.SIZE, value.size)
                 writeXmlField(FileFields.PATH, value.path)
                 writeXmlCollection(FileFields.ATTRIBUTES, value.attributes)
             }

--- a/serialization/src/test/kotlin/ac/uk/ebi/biostd/xml/serializer/SectionSerializerTest.kt
+++ b/serialization/src/test/kotlin/ac/uk/ebi/biostd/xml/serializer/SectionSerializerTest.kt
@@ -41,15 +41,12 @@ class SectionSerializerTest {
             }
             "files" {
                 "file" {
+                    attribute("size", FILE_SIZE)
                     "path" { -FILE_NAME }
                     "attributes" {
                         "attribute" {
                             "name" { -"type" }
                             "value" { -FILE_TYPE }
-                        }
-                        "attribute" {
-                            "name" { -"size" }
-                            "value" { -FILE_SIZE.toString() }
                         }
                     }
                 }

--- a/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/model/FilesSource.kt
+++ b/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/model/FilesSource.kt
@@ -20,7 +20,6 @@ class ListFilesSource(private val files: List<ResourceFile>) : FilesSource {
     override fun getInputStream(filePath: String) = files.first { it.name == filePath }.inputStream
 
     override fun size(filePath: String) = files.first { it.name == filePath }.size
-
 }
 
 class PathFilesSource(private val path: Path) : FilesSource {


### PR DESCRIPTION
- Properly process the errors in submission to log the problem instead of failing all the process
- Add a property to indicate the source file that will be used to submit
- Add logic to process only the submissions for a specific resource file that haven't been submitted yet
- Mark the submission as submitted in the Mongo DB once the process is finished
- Fix XML serializer unit test
- Remove unnecessary code