### PR TITLE
Library File Persistence

### DIFF
--- a/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/LibraryFile.kt
+++ b/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/LibraryFile.kt
@@ -1,0 +1,5 @@
+package ebi.ac.uk.model
+
+class LibraryFile(var name: String, val referencedFiles: MutableList<File> = mutableListOf()) {
+    fun addFile(file: File) = referencedFiles.add(file)
+}

--- a/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/LibraryFile.kt
+++ b/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/LibraryFile.kt
@@ -1,5 +1,5 @@
 package ebi.ac.uk.model
 
-class LibraryFile(var name: String, val referencedFiles: MutableList<File> = mutableListOf()) {
+class LibraryFile(var name: String, val referencedFiles: MutableSet<File> = mutableSetOf()) {
     fun addFile(file: File) = referencedFiles.add(file)
 }

--- a/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/Section.kt
+++ b/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/Section.kt
@@ -14,15 +14,14 @@ class Section(
     attributes: List<Attribute> = emptyList()
 ) : Attributable(attributes) {
     var parentAccNo: String? = null
-    var libraryFile: String? = null
-    var referencedFiles: MutableList<File> = mutableListOf()
+    var libraryFile: LibraryFile? = null
 
     fun addFile(file: File) = files.addLeft(file)
     fun addLink(link: Link) = links.addLeft(link)
     fun addSection(section: Section) = sections.addLeft(section)
     fun addFilesTable(table: FilesTable) = files.addRight(table)
     fun addLinksTable(table: LinksTable) = links.addRight(table)
-    fun addReferencedFile(file: File) = referencedFiles.add(file)
+    fun addReferencedFile(file: File) = libraryFile?.addFile(file)
     fun addSectionTable(table: SectionsTable) = sections.addRight(table)
 
     override fun equals(other: Any?) = when {
@@ -35,8 +34,8 @@ class Section(
             .and(Objects.equals(sections, other.sections))
             .and(Objects.equals(attributes, other.attributes))
             .and(Objects.equals(libraryFile, other.libraryFile))
-            .and(Objects.equals(referencedFiles, other.referencedFiles))
+            .and(Objects.equals(libraryFile, other.libraryFile))
     }
 
-    override fun hashCode() = Objects.hash(type, accNo, attributes)
+    override fun hashCode() = Objects.hash(type, accNo, files, links, sections, attributes, libraryFile, libraryFile)
 }

--- a/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/Section.kt
+++ b/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/Section.kt
@@ -14,12 +14,15 @@ class Section(
     attributes: List<Attribute> = emptyList()
 ) : Attributable(attributes) {
     var parentAccNo: String? = null
+    var libraryFile: String? = null
+    var referencedFiles: MutableList<File> = mutableListOf()
 
     fun addFile(file: File) = files.addLeft(file)
     fun addLink(link: Link) = links.addLeft(link)
     fun addSection(section: Section) = sections.addLeft(section)
     fun addFilesTable(table: FilesTable) = files.addRight(table)
     fun addLinksTable(table: LinksTable) = links.addRight(table)
+    fun addReferencedFile(file: File) = referencedFiles.add(file)
     fun addSectionTable(table: SectionsTable) = sections.addRight(table)
 
     override fun equals(other: Any?) = when {
@@ -31,6 +34,8 @@ class Section(
             .and(Objects.equals(links, other.links))
             .and(Objects.equals(sections, other.sections))
             .and(Objects.equals(attributes, other.attributes))
+            .and(Objects.equals(libraryFile, other.libraryFile))
+            .and(Objects.equals(referencedFiles, other.referencedFiles))
     }
 
     override fun hashCode() = Objects.hash(type, accNo, attributes)

--- a/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/extensions/SectionExt.kt
+++ b/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/extensions/SectionExt.kt
@@ -2,7 +2,6 @@ package ebi.ac.uk.model.extensions
 
 import ebi.ac.uk.model.File
 import ebi.ac.uk.model.Section
-import ebi.ac.uk.model.constants.SectionFields
 
 fun Section.allFiles(): List<File> {
     return files.map { it.fold({ file -> listOf(file) }, { table -> table.elements }) }.flatten()
@@ -11,9 +10,3 @@ fun Section.allFiles(): List<File> {
 fun Section.allSections(): List<Section> {
     return sections.map { it.fold({ section -> listOf(section) }, { table -> table.elements }) }.flatten()
 }
-
-var Section.libraryFile: String?
-    get() = this[SectionFields.LIB_FILE]
-    set(value) {
-        value?.let { this[SectionFields.LIB_FILE] = it }
-    }

--- a/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/extensions/SectionExt.kt
+++ b/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/extensions/SectionExt.kt
@@ -1,12 +1,10 @@
 package ebi.ac.uk.model.extensions
 
-import ebi.ac.uk.model.File
 import ebi.ac.uk.model.Section
 
-fun Section.allFiles(): List<File> {
-    return files.map { it.fold({ file -> listOf(file) }, { table -> table.elements }) }.flatten()
-}
+fun Section.allFiles() = files.map { it.fold({ file -> listOf(file) }, { table -> table.elements }) }.flatten()
 
-fun Section.allSections(): List<Section> {
-    return sections.map { it.fold({ section -> listOf(section) }, { table -> table.elements }) }.flatten()
-}
+fun Section.allReferencedFiles() = libraryFile?.referencedFiles?.toList() ?: listOf()
+
+fun Section.allSections() =
+    sections.map { it.fold({ section -> listOf(section) }, { table -> table.elements }) }.flatten()

--- a/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/extensions/SubExt.kt
+++ b/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/extensions/SubExt.kt
@@ -46,4 +46,6 @@ var Submission.title: String?
 
 fun Submission.allFiles() = section.allFiles() + section.allSections().flatMap { it.allFiles() }
 fun Submission.getSectionByType(name: String) = section.allSections().first { it.type == name }
-fun Submission.libFileSections() = (section.allSections() + section).filterNot { it.libraryFile.isNullOrBlank() }
+fun Submission.libFileSections() = (section.allSections() + section).filterNot { it.libraryFile == null }
+fun Submission.allReferencedFiles() =
+    section.allReferencedFiles() + section.allSections().flatMap { it.allReferencedFiles() }

--- a/commons/commons-bio/src/test/kotlin/ebi/ac/uk/model/extensions/SectionExtTest.kt
+++ b/commons/commons-bio/src/test/kotlin/ebi/ac/uk/model/extensions/SectionExtTest.kt
@@ -4,10 +4,8 @@ import ebi.ac.uk.dsl.file
 import ebi.ac.uk.dsl.filesTable
 import ebi.ac.uk.dsl.section
 import ebi.ac.uk.dsl.sectionsTable
-import ebi.ac.uk.model.Attribute
 import ebi.ac.uk.model.File
 import ebi.ac.uk.model.Section
-import ebi.ac.uk.model.constants.SectionFields
 import ebi.ac.uk.util.collections.second
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -39,15 +37,5 @@ class SectionExtTest {
         assertThat(allSubsections).hasSize(2)
         assertThat(allSubsections.first()).isEqualTo((Section("Subsection 1", "SUB-SECT-001")))
         assertThat(allSubsections.second()).isEqualTo((Section("Subsection 2", "SUB-SECT-002")))
-    }
-
-    @Test
-    fun `library file`() {
-        val subsection = Section("Section 1")
-        subsection.libraryFile = "LibFile.tsv"
-
-        assertThat(subsection.libraryFile).isEqualTo("LibFile.tsv")
-        assertThat(subsection.attributes).hasSize(1)
-        assertThat(subsection.attributes.first()).isEqualTo(Attribute(SectionFields.LIB_FILE, "LibFile.tsv"))
     }
 }

--- a/commons/commons-bio/src/test/kotlin/ebi/ac/uk/model/extensions/SubExtTest.kt
+++ b/commons/commons-bio/src/test/kotlin/ebi/ac/uk/model/extensions/SubExtTest.kt
@@ -1,6 +1,5 @@
 package ebi.ac.uk.model.extensions
 
-import ebi.ac.uk.dsl.attribute
 import ebi.ac.uk.dsl.file
 import ebi.ac.uk.dsl.filesTable
 import ebi.ac.uk.dsl.section
@@ -8,7 +7,6 @@ import ebi.ac.uk.dsl.submission
 import ebi.ac.uk.model.Attribute
 import ebi.ac.uk.model.File
 import ebi.ac.uk.model.Submission
-import ebi.ac.uk.model.constants.SectionFields
 import ebi.ac.uk.model.constants.SubFields
 import ebi.ac.uk.util.collections.second
 import org.assertj.core.api.Assertions.assertThat
@@ -96,7 +94,7 @@ class SubExtTest {
     fun `get library file sections`() {
         val submission = submission("ABC-123") {
             section("Study") {
-                attribute(SectionFields.LIB_FILE.value, "LibFile1.tsv")
+                libraryFile = "LibFile1.tsv"
 
                 section("Data") {
                     accNo = "DT-1"
@@ -104,7 +102,7 @@ class SubExtTest {
 
                 section("Experiment") {
                     accNo = "EXP-1"
-                    attribute(SectionFields.LIB_FILE.value, "LibFile2.tsv")
+                    libraryFile = "LibFile2.tsv"
                 }
             }
         }

--- a/commons/commons-bio/src/test/kotlin/ebi/ac/uk/model/extensions/SubExtTest.kt
+++ b/commons/commons-bio/src/test/kotlin/ebi/ac/uk/model/extensions/SubExtTest.kt
@@ -6,6 +6,7 @@ import ebi.ac.uk.dsl.section
 import ebi.ac.uk.dsl.submission
 import ebi.ac.uk.model.Attribute
 import ebi.ac.uk.model.File
+import ebi.ac.uk.model.LibraryFile
 import ebi.ac.uk.model.Submission
 import ebi.ac.uk.model.constants.SubFields
 import ebi.ac.uk.util.collections.second
@@ -94,7 +95,7 @@ class SubExtTest {
     fun `get library file sections`() {
         val submission = submission("ABC-123") {
             section("Study") {
-                libraryFile = "LibFile1.tsv"
+                libraryFile = LibraryFile("LibFile1.tsv")
 
                 section("Data") {
                     accNo = "DT-1"
@@ -102,7 +103,7 @@ class SubExtTest {
 
                 section("Experiment") {
                     accNo = "EXP-1"
-                    libraryFile = "LibFile2.tsv"
+                    libraryFile = LibraryFile("LibFile2.tsv")
                 }
             }
         }
@@ -110,7 +111,7 @@ class SubExtTest {
         val libFileSections = submission.libFileSections()
 
         assertThat(libFileSections).hasSize(2)
-        assertThat(libFileSections.first().libraryFile).isEqualTo("LibFile2.tsv")
-        assertThat(libFileSections.second().libraryFile).isEqualTo("LibFile1.tsv")
+        assertThat(libFileSections.first().libraryFile?.name).isEqualTo("LibFile2.tsv")
+        assertThat(libFileSections.second().libraryFile?.name).isEqualTo("LibFile1.tsv")
     }
 }

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/SerializationService.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/SerializationService.kt
@@ -23,6 +23,18 @@ class SerializationService(
 
     fun serializeSubmission(submission: Submission, format: SubFormat) = serializeElement(submission, format)
 
+    inline fun <reified T> deserializeElement(
+        element: String,
+        format: SubFormat
+    ) = deserializeElement(element, format, T::class.java) as T
+
+    fun <T> deserializeElement(element: String, format: SubFormat, type: Class<out T>? = null) = when (format) {
+        XML -> xmlSerializer.deserialize(element)
+        JSON -> jsonSerializer.deserialize(element)
+        JSON_PRETTY -> jsonSerializer.deserialize(element)
+        TSV -> tsvSerializer.deserializeElement(element, type!!)
+    }
+
     fun deserializeSubmission(submission: String, format: SubFormat) = when (format) {
         XML -> xmlSerializer.deserialize(submission)
         JSON -> jsonSerializer.deserialize(submission)

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/TsvSerializer.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/TsvSerializer.kt
@@ -14,8 +14,7 @@ class TsvSerializer(
 
     inline fun <reified T> deserializeElement(pageTab: String) = deserializeElement(pageTab, T::class.java)
 
-    fun <T> deserializeElement(pageTab: String, type: Class<out T>) =
-        tsvDeserializer.deserializeElement(pageTab, type::class.java)
+    fun <T> deserializeElement(pageTab: String, type: Class<out T>) = tsvDeserializer.deserializeElement(pageTab, type)
 
     fun deserialize(submission: String) = tsvDeserializer.deserialize(submission)
 

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/ChunkProcessor.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/ChunkProcessor.kt
@@ -7,6 +7,7 @@ import ac.uk.ebi.biostd.tsv.deserialization.common.toAttributes
 import ac.uk.ebi.biostd.tsv.deserialization.common.validate
 import ac.uk.ebi.biostd.tsv.deserialization.model.FileChunk
 import ac.uk.ebi.biostd.tsv.deserialization.model.FileTableChunk
+import ac.uk.ebi.biostd.tsv.deserialization.model.LibFileChunk
 import ac.uk.ebi.biostd.tsv.deserialization.model.LinkChunk
 import ac.uk.ebi.biostd.tsv.deserialization.model.LinksTableChunk
 import ac.uk.ebi.biostd.tsv.deserialization.model.RootSectionTableChunk
@@ -51,6 +52,7 @@ class ChunkProcessor {
         is FileChunk -> chunk.asFile() as T
         is LinksTableChunk -> chunk.asTable() as T
         is FileTableChunk -> chunk.asTable() as T
+        is LibFileChunk -> chunk.asLibraryFile() as T
         is SectionChunk -> TODO("Implement section chunk isolated deserialization")
         is SectionTableChunk -> TODO("Implement section table chunk isolated deserialization")
     }
@@ -61,6 +63,7 @@ class ChunkProcessor {
             is FileChunk -> sectionContext.addFile(chunk)
             is LinksTableChunk -> sectionContext.addLinksTable(chunk)
             is FileTableChunk -> sectionContext.addFilesTable(chunk)
+            is LibFileChunk -> sectionContext.setLibraryFile(chunk)
             is SectionTableChunk -> processSectionTable(chunk, sectionContext)
             is SectionChunk -> processSection(chunk, sectionContext)
         }

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/TsvDeserializer.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/TsvDeserializer.kt
@@ -3,6 +3,7 @@ package ac.uk.ebi.biostd.tsv.deserialization
 import ac.uk.ebi.biostd.tsv.TSV_CHUNK_BREAK
 import ac.uk.ebi.biostd.tsv.deserialization.model.FileChunk
 import ac.uk.ebi.biostd.tsv.deserialization.model.FileTableChunk
+import ac.uk.ebi.biostd.tsv.deserialization.model.LibFileChunk
 import ac.uk.ebi.biostd.tsv.deserialization.model.LinkChunk
 import ac.uk.ebi.biostd.tsv.deserialization.model.LinksTableChunk
 import ac.uk.ebi.biostd.tsv.deserialization.model.RootSectionTableChunk
@@ -60,6 +61,7 @@ class TsvDeserializer(private val chunkProcessor: ChunkProcessor = ChunkProcesso
             type like FileFields.FILE -> FileChunk(body)
             type like SectionFields.LINKS -> LinksTableChunk(body)
             type like SectionFields.FILES -> FileTableChunk(body)
+            type like SectionFields.LIB_FILE -> LibFileChunk(body)
             type.matches(TABLE_REGEX) -> TABLE_REGEX.findGroup(type, 1).fold(
                 { RootSectionTableChunk(body) },
                 { SubSectionTableChunk(body, it) })

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/TsvSerializationContext.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/TsvSerializationContext.kt
@@ -2,6 +2,7 @@ package ac.uk.ebi.biostd.tsv.deserialization
 
 import ac.uk.ebi.biostd.tsv.deserialization.model.FileChunk
 import ac.uk.ebi.biostd.tsv.deserialization.model.FileTableChunk
+import ac.uk.ebi.biostd.tsv.deserialization.model.LibFileChunk
 import ac.uk.ebi.biostd.tsv.deserialization.model.LinkChunk
 import ac.uk.ebi.biostd.tsv.deserialization.model.LinksTableChunk
 import ac.uk.ebi.biostd.tsv.deserialization.model.SectionChunk
@@ -43,6 +44,9 @@ class TsvSerializationContext {
 
     fun addFilesTable(chunk: FileTableChunk) =
         execute(currentSection, chunk) { currentSection.addFilesTable(chunk.asTable()) }
+
+    fun setLibraryFile(chunk: LibFileChunk) =
+        execute(currentSection, chunk) { currentSection.libraryFile = chunk.asLibraryFile() }
 
     fun addSectionTable(chunk: SectionTableChunk) =
         execute(rootSection, chunk) { rootSection.addSectionTable(chunk.asTable()) }

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/model/TsvChunk.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/model/TsvChunk.kt
@@ -7,9 +7,11 @@ import ac.uk.ebi.biostd.tsv.deserialization.common.getType
 import ac.uk.ebi.biostd.tsv.deserialization.common.toAttributes
 import ac.uk.ebi.biostd.validation.InvalidElementException
 import ac.uk.ebi.biostd.validation.REQUIRED_FILE_PATH
+import ac.uk.ebi.biostd.validation.REQUIRED_LIB_FILE_PATH
 import ac.uk.ebi.biostd.validation.REQUIRED_LINK_URL
 import ebi.ac.uk.model.File
 import ebi.ac.uk.model.FilesTable
+import ebi.ac.uk.model.LibraryFile
 import ebi.ac.uk.model.Link
 import ebi.ac.uk.model.LinksTable
 import ebi.ac.uk.model.Section
@@ -47,6 +49,10 @@ class FileChunk(body: List<TsvChunkLine>) : TsvChunk(body) {
         val attributes = toAttributes(lines)
         return File(fileName, attributes = attributes)
     }
+}
+
+class LibFileChunk(body: List<TsvChunkLine>) : TsvChunk(body) {
+    fun asLibraryFile() = LibraryFile(getIdOrElse(InvalidElementException(REQUIRED_LIB_FILE_PATH)))
 }
 
 class LinksTableChunk(body: List<TsvChunkLine>) : TsvChunk(body) {

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/serialization/BuilderSecExtensions.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/serialization/BuilderSecExtensions.kt
@@ -2,10 +2,12 @@ package ac.uk.ebi.biostd.tsv.serialization
 
 import ebi.ac.uk.model.Attribute
 import ebi.ac.uk.model.File
+import ebi.ac.uk.model.LibraryFile
 import ebi.ac.uk.model.Link
 
 internal const val LINK_KEY = "Link"
 internal const val FILE_KEY = "File"
+internal const val LIB_FILE_KEY = "LibraryFile"
 
 fun TsvBuilder.addSecDescriptor(type: String, accNo: String?) {
     append(type)
@@ -13,17 +15,13 @@ fun TsvBuilder.addSecDescriptor(type: String, accNo: String?) {
     append("\n")
 }
 
-fun TsvBuilder.addSecLink(link: Link) {
-    with(LINK_KEY, link.url)
-}
+fun TsvBuilder.addSecLink(link: Link) = with(LINK_KEY, link.url)
 
-fun TsvBuilder.addSecFile(file: File) {
-    with(FILE_KEY, file.path)
-}
+fun TsvBuilder.addSecFile(file: File) = with(FILE_KEY, file.path)
 
-fun TsvBuilder.addAttributes(attributes: List<Attribute>) {
-    attributes.forEach { with(it.name, it.value) }
-}
+fun TsvBuilder.addLibFile(libFile: LibraryFile) = with(LIB_FILE_KEY, libFile.name)
+
+fun TsvBuilder.addAttributes(attributes: List<Attribute>) = attributes.forEach { with(it.name, it.value) }
 
 fun TsvBuilder.addAttr(attr: Attribute) {
     with(if (attr.reference) "<${attr.name}>" else attr.name, attr.value)

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/serialization/TsvToStringSerializer.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/serialization/TsvToStringSerializer.kt
@@ -35,6 +35,12 @@ class TsvToStringSerializer {
 
         section.links.forEach { either -> either.fold({ addLink(builder, it) }, { addTable(builder, it) }) }
         section.files.forEach { either -> either.fold({ addFile(builder, it) }, { addTable(builder, it) }) }
+
+        section.libraryFile?.let {
+            builder.addSeparator()
+            builder.addLibFile(it)
+        }
+
         section.sections.forEach { either -> either.fold({ serializeSection(builder, it) }) { addTable(builder, it) } }
     }
 
@@ -52,8 +58,8 @@ class TsvToStringSerializer {
 
     private fun <T : Any> addTable(builder: TsvBuilder, table: Table<T>) {
         builder.addSeparator()
-        builder.addTableRow(table.headers.flatMap {
-            listOf(it.name) + it.termNames.map { "($it)" } + it.termValues.map { "[$it]" } })
+        builder.addTableRow(table.headers.flatMap { header ->
+            listOf(header.name) + header.termNames.map { "($it)" } + header.termValues.map { "[$it]" } })
 
         table.rows.forEach { builder.addTableRow(it) }
     }

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/validation/Messages.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/validation/Messages.kt
@@ -2,6 +2,7 @@ package ac.uk.ebi.biostd.validation
 
 internal const val REQUIRED_LINK_URL = "Link Url is required"
 internal const val REQUIRED_FILE_PATH = "File Path is required"
+internal const val REQUIRED_LIB_FILE_PATH = "Library file path is required"
 internal const val REQUIRED_ROOT_SECTION = "Root Section type is required"
 internal const val REQUIRED_ATTR_VALUE = "Attribute value must NOT be empty"
 internal const val MISPLACED_ATTR_NAME = "Attribute name qualifier must be after a valid attribute"

--- a/infrastructure/src/main/resources/setup/database/Schema.sql
+++ b/infrastructure/src/main/resources/setup/database/Schema.sql
@@ -57,26 +57,28 @@ CREATE TABLE ReferencedFileAttribute (
     ord                  INT      NULL
 );
 
-CREATE INDEX FKek4om17ruuhrjo2gmirdxexyz ON ReferencedFileAttribute (referenced_file_id);
+CREATE INDEX ReferencedFileAttrFileIdIdx ON ReferencedFileAttribute (referenced_file_id);
 
 CREATE TABLE ReferencedFile (
     id             BIGINT AUTO_INCREMENT PRIMARY KEY,
     name           VARCHAR(255) NULL,
     size           BIGINT       NOT NULL,
-    libraryFile    VARCHAR(255) NOT NULL,
+    libraryFile    VARCHAR(100) NOT NULL,
     path           VARCHAR(255) NULL
 );
 
-CREATE INDEX FK464kkuexjpycuic1n33q0yhe3 ON ReferencedFile (libFile);
+CREATE INDEX ReferencedFileIndex ON ReferencedFile (libraryFile);
 
 ALTER TABLE ReferencedFileAttribute
-ADD CONSTRAINT FKek4om17ruuhrjo2gmirdxeva1 FOREIGN KEY (referenced_file_id) REFERENCES ReferencedFile(id);
+ADD CONSTRAINT ReferencedFile_ReferencedFileAttr_FRG_KEY FOREIGN KEY (referenced_file_id) REFERENCES ReferencedFile(id);
 
 CREATE TABLE LibraryFile(
   name         VARCHAR(100) NOT NULL PRIMARY KEY,
   section_id   BIGINT NOT NULL
-  CONSTRAINT LibFile_Section FOREIGN KEY (section_id) REFERENCES Section (id)
 );
+
+ALTER TABLE ReferencedFile
+ADD CONSTRAINT ReferencedFile_LibraryFile_FRG_KEY FOREIGN KEY (libraryFile) REFERENCES LibraryFile(name);
 
 CREATE TABLE IdGen (
     id         BIGINT AUTO_INCREMENT PRIMARY KEY,
@@ -132,10 +134,10 @@ CREATE INDEX acc_idx ON Section (accNo);
 CREATE INDEX FK4bi0ld27mvrinwk6gleu9phf4 ON Section (submission_id);
 CREATE INDEX FKba6xolosvegauoq8xs1kj17ch ON Section (parent_id);
 CREATE INDEX section_type_index ON Section (type);
-ALTER TABLE FileRef ADD CONSTRAINT FK464kkuexjpycuic1n33q0yhe2
-FOREIGN KEY (sectionId) REFERENCES Section (id);
-ALTER TABLE Link ADD CONSTRAINT FKqhsnrwf0i6q08gt5l83fwchn8
-FOREIGN KEY (section_id) REFERENCES Section (id);
+
+ALTER TABLE Link ADD CONSTRAINT Link_Section_FRG_KEY FOREIGN KEY (section_id) REFERENCES Section (id);
+ALTER TABLE FileRef ADD CONSTRAINT FileRef_Section_FRG_KEY FOREIGN KEY (sectionId) REFERENCES Section (id);
+ALTER TABLE LibraryFile ADD CONSTRAINT LibFile_Section_FRG_KEY FOREIGN KEY (section_id) REFERENCES Section (id);
 
 CREATE TABLE SectionAttribute (
     id                   BIGINT AUTO_INCREMENT PRIMARY KEY,

--- a/infrastructure/src/main/resources/setup/database/Schema.sql
+++ b/infrastructure/src/main/resources/setup/database/Schema.sql
@@ -122,7 +122,6 @@ CREATE TABLE Section (
     parentAccNo   VARCHAR(255) NULL,
     tableIndex    INT          NOT NULL,
     type          VARCHAR(255) NULL,
-    libraryFile   VARCHAR(255) NULL,
     parent_id     BIGINT       NULL,
     submission_id BIGINT       NULL,
     ord           INT          NULL,

--- a/infrastructure/src/main/resources/setup/database/Schema.sql
+++ b/infrastructure/src/main/resources/setup/database/Schema.sql
@@ -46,6 +46,38 @@ CREATE INDEX FK464kkuexjpycuic1n33q0yhe2 ON FileRef (sectionId);
 
 ALTER TABLE FileAttribute ADD CONSTRAINT FKek4om17ruuhrjo2gmirdxevay FOREIGN KEY (file_id) REFERENCES FileRef (id);
 
+CREATE TABLE ReferencedFileAttribute (
+    id                   BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name                 LONGTEXT NULL,
+    nameQualifierString  LONGTEXT NULL,
+    reference            BIT      NOT NULL,
+    value                LONGTEXT NULL,
+    valueQualifierString LONGTEXT NULL,
+    referenced_file_id   BIGINT   NULL,
+    ord                  INT      NULL
+);
+
+CREATE INDEX FKek4om17ruuhrjo2gmirdxexyz ON ReferencedFileAttribute (referenced_file_id);
+
+CREATE TABLE ReferencedFile (
+    id             BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name           VARCHAR(255) NULL,
+    size           BIGINT       NOT NULL,
+    libraryFile    VARCHAR(255) NOT NULL,
+    path           VARCHAR(255) NULL
+);
+
+CREATE INDEX FK464kkuexjpycuic1n33q0yhe3 ON ReferencedFile (libFile);
+
+ALTER TABLE ReferencedFileAttribute
+ADD CONSTRAINT FKek4om17ruuhrjo2gmirdxeva1 FOREIGN KEY (referenced_file_id) REFERENCES ReferencedFile(id);
+
+CREATE TABLE LibraryFile(
+  name         VARCHAR(100) NOT NULL PRIMARY KEY,
+  section_id   BIGINT NOT NULL
+  CONSTRAINT LibFile_Section FOREIGN KEY (section_id) REFERENCES Section (id)
+);
+
 CREATE TABLE IdGen (
     id         BIGINT AUTO_INCREMENT PRIMARY KEY,
     prefix     VARCHAR(255) NULL,
@@ -90,11 +122,11 @@ CREATE TABLE Section (
     parentAccNo   VARCHAR(255) NULL,
     tableIndex    INT          NOT NULL,
     type          VARCHAR(255) NULL,
+    libraryFile   VARCHAR(255) NULL,
     parent_id     BIGINT       NULL,
     submission_id BIGINT       NULL,
     ord           INT          NULL,
-    CONSTRAINT FKba6xolosvegauoq8xs1kj17ch
-    FOREIGN KEY (parent_id) REFERENCES Section (id)
+    CONSTRAINT FKba6xolosvegauoq8xs1kj17ch FOREIGN KEY (parent_id) REFERENCES Section (id)
 );
 
 CREATE INDEX acc_idx ON Section (accNo);

--- a/infrastructure/src/main/resources/setup/database/SetUpDatabase.sh
+++ b/infrastructure/src/main/resources/setup/database/SetUpDatabase.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-echo "holi Dockerfile.$1";
 docker build -t biostudies-mysql:0.2 -f Dockerfile.$1 .;
 docker run -d \
   --name biostudies-mysql \

--- a/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/mapping/SubmissionDbMapper.kt
+++ b/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/mapping/SubmissionDbMapper.kt
@@ -33,9 +33,7 @@ import java.time.ZoneOffset.UTC
 import ac.uk.ebi.biostd.persistence.model.Attribute as AttributeDb
 import ac.uk.ebi.biostd.persistence.model.AttributeDetail as AttributeDetailDb
 import ac.uk.ebi.biostd.persistence.model.File as FileDb
-import ac.uk.ebi.biostd.persistence.model.LibraryFile as LibraryFileDb
 import ac.uk.ebi.biostd.persistence.model.Link as LinkDb
-import ac.uk.ebi.biostd.persistence.model.ReferencedFile as ReferencedFileDb
 import ac.uk.ebi.biostd.persistence.model.Section as SectionDb
 import ac.uk.ebi.biostd.persistence.model.Submission as SubmissionDb
 import ac.uk.ebi.biostd.persistence.model.User as UserDb
@@ -74,10 +72,7 @@ private object DbSectionMapper {
             files = toFiles(sectionDb.files.toList()),
             sections = toSections(sectionDb.sections.toList()),
             attributes = toAttributes(sectionDb.attributes)).apply {
-            sectionDb.libraryFile?.let {
-                val libFile = sectionDb.libraryFile as LibraryFileDb
-                libraryFile = LibraryFile(libFile.name)
-            }
+            sectionDb.libraryFile?.let { libraryFile = LibraryFile(it.name) }
         }
 }
 
@@ -113,7 +108,6 @@ private object DbEitherMapper {
 private object DbEntityMapper {
     internal fun toLink(link: LinkDb) = Link(link.url, toAttributes(link.attributes))
     internal fun toFile(file: FileDb) = File(file.name, file.size, toAttributes(file.attributes))
-    internal fun toFile(file: ReferencedFileDb) = File(file.name, file.size, toAttributes(file.attributes))
     internal fun toUser(owner: UserDb) = User(owner.id, owner.email, owner.secret)
 }
 

--- a/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/mapping/SubmissionDbMapper.kt
+++ b/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/mapping/SubmissionDbMapper.kt
@@ -20,6 +20,7 @@ import ebi.ac.uk.model.AttributeDetail
 import ebi.ac.uk.model.ExtendedSubmission
 import ebi.ac.uk.model.File
 import ebi.ac.uk.model.FilesTable
+import ebi.ac.uk.model.LibraryFile
 import ebi.ac.uk.model.Link
 import ebi.ac.uk.model.LinksTable
 import ebi.ac.uk.model.Section
@@ -32,15 +33,14 @@ import java.time.ZoneOffset.UTC
 import ac.uk.ebi.biostd.persistence.model.Attribute as AttributeDb
 import ac.uk.ebi.biostd.persistence.model.AttributeDetail as AttributeDetailDb
 import ac.uk.ebi.biostd.persistence.model.File as FileDb
-import ac.uk.ebi.biostd.persistence.model.Link as LinkDb
 import ac.uk.ebi.biostd.persistence.model.LibraryFile as LibraryFileDb
+import ac.uk.ebi.biostd.persistence.model.Link as LinkDb
 import ac.uk.ebi.biostd.persistence.model.ReferencedFile as ReferencedFileDb
 import ac.uk.ebi.biostd.persistence.model.Section as SectionDb
 import ac.uk.ebi.biostd.persistence.model.Submission as SubmissionDb
 import ac.uk.ebi.biostd.persistence.model.User as UserDb
 
 class SubmissionDbMapper {
-
     fun toExtSubmission(submissionDb: SubmissionDb) =
         ExtendedSubmission(submissionDb.accNo, toUser(submissionDb.owner)).apply {
             version = submissionDb.version
@@ -67,7 +67,6 @@ class SubmissionDbMapper {
 }
 
 private object DbSectionMapper {
-
     internal fun toSection(sectionDb: SectionDb): Section =
         Section(accNo = sectionDb.accNo,
             type = sectionDb.type,
@@ -77,15 +76,12 @@ private object DbSectionMapper {
             attributes = toAttributes(sectionDb.attributes)).apply {
             sectionDb.libraryFile?.let {
                 val libFile = sectionDb.libraryFile as LibraryFileDb
-
-                libraryFile = libFile.name
-                libFile.files.forEach { file -> addReferencedFile(toFile(file)) }
+                libraryFile = LibraryFile(libFile.name)
             }
         }
 }
 
 private object DbEitherMapper {
-
     internal fun toLinks(links: List<LinkDb>) = toEitherList(links, DbEntityMapper::toLink, ::LinksTable)
     internal fun toFiles(files: List<FileDb>) = toEitherList(files, DbEntityMapper::toFile, ::FilesTable)
     internal fun toSections(sections: List<SectionDb>) =
@@ -115,7 +111,6 @@ private object DbEitherMapper {
 }
 
 private object DbEntityMapper {
-
     internal fun toLink(link: LinkDb) = Link(link.url, toAttributes(link.attributes))
     internal fun toFile(file: FileDb) = File(file.name, file.size, toAttributes(file.attributes))
     internal fun toFile(file: ReferencedFileDb) = File(file.name, file.size, toAttributes(file.attributes))
@@ -123,7 +118,6 @@ private object DbEntityMapper {
 }
 
 private object DbAttributeMapper {
-
     internal fun toAttributes(attrs: Set<AttributeDb>) = attrs.mapTo(mutableListOf()) { toAttribute(it) }
 
     private fun toAttribute(attrDb: AttributeDb) =

--- a/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/mapping/SubmissionDbMapper.kt
+++ b/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/mapping/SubmissionDbMapper.kt
@@ -5,6 +5,7 @@ import ac.uk.ebi.biostd.persistence.mapping.DbAttributeMapper.toAttributes
 import ac.uk.ebi.biostd.persistence.mapping.DbEitherMapper.toFiles
 import ac.uk.ebi.biostd.persistence.mapping.DbEitherMapper.toLinks
 import ac.uk.ebi.biostd.persistence.mapping.DbEitherMapper.toSections
+import ac.uk.ebi.biostd.persistence.mapping.DbEntityMapper.toFile
 import ac.uk.ebi.biostd.persistence.mapping.DbEntityMapper.toUser
 import ac.uk.ebi.biostd.persistence.mapping.DbSectionMapper.toSection
 import ac.uk.ebi.biostd.persistence.model.AccessTag
@@ -32,6 +33,8 @@ import ac.uk.ebi.biostd.persistence.model.Attribute as AttributeDb
 import ac.uk.ebi.biostd.persistence.model.AttributeDetail as AttributeDetailDb
 import ac.uk.ebi.biostd.persistence.model.File as FileDb
 import ac.uk.ebi.biostd.persistence.model.Link as LinkDb
+import ac.uk.ebi.biostd.persistence.model.LibraryFile as LibraryFileDb
+import ac.uk.ebi.biostd.persistence.model.ReferencedFile as ReferencedFileDb
 import ac.uk.ebi.biostd.persistence.model.Section as SectionDb
 import ac.uk.ebi.biostd.persistence.model.Submission as SubmissionDb
 import ac.uk.ebi.biostd.persistence.model.User as UserDb
@@ -71,7 +74,14 @@ private object DbSectionMapper {
             links = toLinks(sectionDb.links.toList()),
             files = toFiles(sectionDb.files.toList()),
             sections = toSections(sectionDb.sections.toList()),
-            attributes = toAttributes(sectionDb.attributes))
+            attributes = toAttributes(sectionDb.attributes)).apply {
+            sectionDb.libraryFile?.let {
+                val libFile = sectionDb.libraryFile as LibraryFileDb
+
+                libraryFile = libFile.name
+                libFile.files.forEach { file -> addReferencedFile(toFile(file)) }
+            }
+        }
 }
 
 private object DbEitherMapper {
@@ -108,6 +118,7 @@ private object DbEntityMapper {
 
     internal fun toLink(link: LinkDb) = Link(link.url, toAttributes(link.attributes))
     internal fun toFile(file: FileDb) = File(file.name, file.size, toAttributes(file.attributes))
+    internal fun toFile(file: ReferencedFileDb) = File(file.name, file.size, toAttributes(file.attributes))
     internal fun toUser(owner: UserDb) = User(owner.id, owner.email, owner.secret)
 }
 

--- a/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/mapping/SubmissionMapper.kt
+++ b/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/mapping/SubmissionMapper.kt
@@ -11,7 +11,9 @@ import ac.uk.ebi.biostd.persistence.mapping.TableMapper.toFiles
 import ac.uk.ebi.biostd.persistence.mapping.TableMapper.toLinks
 import ac.uk.ebi.biostd.persistence.mapping.TableMapper.toSections
 import ac.uk.ebi.biostd.persistence.model.FileAttribute
+import ac.uk.ebi.biostd.persistence.model.LibraryFile
 import ac.uk.ebi.biostd.persistence.model.LinkAttribute
+import ac.uk.ebi.biostd.persistence.model.ReferencedFileAttribute
 import ac.uk.ebi.biostd.persistence.model.SectionAttribute
 import ac.uk.ebi.biostd.persistence.model.SubmissionAttribute
 import ac.uk.ebi.biostd.persistence.repositories.TagsDataRepository
@@ -33,6 +35,7 @@ import ac.uk.ebi.biostd.persistence.model.Attribute as AttributeDb
 import ac.uk.ebi.biostd.persistence.model.AttributeDetail as AttributeDetailDb
 import ac.uk.ebi.biostd.persistence.model.File as FileDb
 import ac.uk.ebi.biostd.persistence.model.Link as LinkDb
+import ac.uk.ebi.biostd.persistence.model.ReferencedFile as ReferencedFileDb
 import ac.uk.ebi.biostd.persistence.model.Section as SectionDb
 import ac.uk.ebi.biostd.persistence.model.Submission as SubmissionDb
 import ac.uk.ebi.biostd.persistence.model.User as UserDb
@@ -68,6 +71,8 @@ private object SectionMapper {
         links = section.links.mapIndexed(::toLinks).flatten().toSortedSet()
         files = section.files.mapIndexed(::toFiles).flatten().toSortedSet()
         sections = section.sections.mapIndexed(::toSections).flatten().toSortedSet()
+
+        section.libraryFile?.let { libraryFile = getLibraryFile(section) }
     }
 
     fun toTableSection(section: Section, index: Int, sectionTableIndex: Int) =
@@ -76,6 +81,10 @@ private object SectionMapper {
             tableIndex = sectionTableIndex
             order = index
         }
+
+    fun getLibraryFile(section: Section) = LibraryFile(section.libraryFile!!).apply {
+        files = section.referencedFiles.mapTo(sortedSetOf(), EntityMapper::toRefFile)
+    }
 }
 
 private object TableMapper {
@@ -103,6 +112,9 @@ private object EntityMapper {
 
     fun toFile(file: File, order: Int, tableIndex: Int = NO_TABLE_INDEX) = FileDb(
         file.path, order, file.size, toAttributes(file.attributes).mapTo(sortedSetOf(), ::FileAttribute), tableIndex)
+
+    fun toRefFile(file: File) = ReferencedFileDb(
+        file.path, file.size, toAttributes(file.attributes).mapTo(sortedSetOf(), ::ReferencedFileAttribute))
 }
 
 private object AttributeMapper {

--- a/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/mapping/SubmissionMapper.kt
+++ b/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/mapping/SubmissionMapper.kt
@@ -82,7 +82,7 @@ private object SectionMapper {
         }
 
     fun toLibraryFileDb(libraryFile: LibraryFile) = LibraryFileDb(libraryFile.name).apply {
-        files = libraryFile.referencedFiles.mapTo(mutableListOf(), EntityMapper::toRefFile)
+        files = libraryFile.referencedFiles.mapTo(mutableSetOf(), EntityMapper::toRefFile)
     }
 }
 

--- a/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/model/Attribute.kt
+++ b/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/model/Attribute.kt
@@ -37,6 +37,15 @@ class FileAttribute(attribute: Attribute) :
 }
 
 @Entity
+class ReferencedFileAttribute(attribute: Attribute) :
+    Attribute(attribute.name, attribute.value, attribute.order, attribute.reference) {
+    init {
+        this.nameQualifier = attribute.nameQualifier
+        this.valueQualifier = attribute.valueQualifier
+    }
+}
+
+@Entity
 class SubmissionAttribute(attribute: Attribute) :
     Attribute(attribute.name, attribute.value, attribute.order, attribute.reference) {
     init {

--- a/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/model/LibraryFile.kt
+++ b/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/model/LibraryFile.kt
@@ -23,7 +23,7 @@ class LibraryFile(
     @JoinColumn(name = "libraryFile")
     @OrderBy("order ASC")
     @Basic(fetch = FetchType.LAZY)
-    var files: SortedSet<ReferencedFile> = sortedSetOf()
+    var files: MutableList<ReferencedFile> = mutableListOf()
 }
 
 @Entity

--- a/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/model/LibraryFile.kt
+++ b/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/model/LibraryFile.kt
@@ -1,9 +1,11 @@
 package ac.uk.ebi.biostd.persistence.model
 
 import java.util.SortedSet
+import javax.persistence.Basic
 import javax.persistence.CascadeType
 import javax.persistence.Column
 import javax.persistence.Entity
+import javax.persistence.FetchType
 import javax.persistence.GeneratedValue
 import javax.persistence.Id
 import javax.persistence.JoinColumn
@@ -20,6 +22,7 @@ class LibraryFile(
     @OneToMany(cascade = [CascadeType.ALL])
     @JoinColumn(name = "libraryFile")
     @OrderBy("order ASC")
+    @Basic(fetch = FetchType.LAZY)
     var files: SortedSet<ReferencedFile> = sortedSetOf()
 }
 

--- a/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/model/LibraryFile.kt
+++ b/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/model/LibraryFile.kt
@@ -23,7 +23,7 @@ class LibraryFile(
     @JoinColumn(name = "libraryFile")
     @OrderBy("order ASC")
     @Basic(fetch = FetchType.LAZY)
-    var files: MutableList<ReferencedFile> = mutableListOf()
+    var files: Set<ReferencedFile> = setOf()
 }
 
 @Entity

--- a/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/model/LibraryFile.kt
+++ b/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/model/LibraryFile.kt
@@ -1,0 +1,47 @@
+package ac.uk.ebi.biostd.persistence.model
+
+import java.util.SortedSet
+import javax.persistence.CascadeType
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.GeneratedValue
+import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.OneToMany
+import javax.persistence.OrderBy
+import javax.persistence.Table
+
+@Entity
+@Table(name = "LibraryFile")
+class LibraryFile(
+    @Id
+    var name: String
+) {
+    @OneToMany(cascade = [CascadeType.ALL])
+    @JoinColumn(name = "libraryFile")
+    @OrderBy("order ASC")
+    var files: SortedSet<ReferencedFile> = sortedSetOf()
+}
+
+@Entity
+@Table(name = "ReferencedFile")
+class ReferencedFile(
+    @Column
+    val name: String
+) {
+    @Id
+    @GeneratedValue
+    var id: Long = 0L
+
+    var size: Long = 0L
+
+    @OneToMany(cascade = [CascadeType.ALL])
+    @JoinColumn(name = "file_id")
+    @OrderBy("order ASC")
+    var attributes: SortedSet<ReferencedFileAttribute> = sortedSetOf()
+
+    constructor(name: String, size: Long, attributes: SortedSet<ReferencedFileAttribute>) : this(name) {
+        this.size = size
+        this.attributes = attributes
+    }
+}

--- a/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/model/Section.kt
+++ b/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/model/Section.kt
@@ -38,6 +38,10 @@ class Section(
     @Convert(converter = NullableIntConverter::class)
     override var order: Int = 0
 
+    @Column
+    @JoinColumn(name = "sectionId")
+    var libraryFile: LibraryFile? = null
+
     @OneToMany(cascade = [CascadeType.ALL])
     @JoinColumn(name = "section_id")
     @OrderBy("order ASC")

--- a/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/model/Section.kt
+++ b/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/model/Section.kt
@@ -12,6 +12,7 @@ import javax.persistence.GeneratedValue
 import javax.persistence.Id
 import javax.persistence.JoinColumn
 import javax.persistence.OneToMany
+import javax.persistence.OneToOne
 import javax.persistence.OrderBy
 import javax.persistence.Table
 
@@ -39,7 +40,7 @@ class Section(
     override var order: Int = 0
 
     @Column
-    @OneToMany(cascade = [CascadeType.ALL])
+    @OneToOne(cascade = [CascadeType.ALL])
     @JoinColumn(name = "sectionId")
     var libraryFile: LibraryFile? = null
 

--- a/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/model/Section.kt
+++ b/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/model/Section.kt
@@ -39,6 +39,7 @@ class Section(
     override var order: Int = 0
 
     @Column
+    @OneToMany(cascade = [CascadeType.ALL])
     @JoinColumn(name = "sectionId")
     var libraryFile: LibraryFile? = null
 

--- a/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/model/Section.kt
+++ b/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/model/Section.kt
@@ -39,7 +39,6 @@ class Section(
     @Convert(converter = NullableIntConverter::class)
     override var order: Int = 0
 
-    @Column
     @OneToOne(cascade = [CascadeType.ALL])
     @JoinColumn(name = "sectionId")
     var libraryFile: LibraryFile? = null

--- a/submission/submission-webapp/src/itest/resources/application.yml
+++ b/submission/submission-webapp/src/itest/resources/application.yml
@@ -5,6 +5,12 @@ spring:
     hibernate:
       naming:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+
+  servlet:
+    multipart:
+      max-file-size: 10240MB
+      max-request-size: 10240MB
+
 app:
   basepath: {BASE_PATH}
   environment: TEST

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/common/config/SubmitterConfig.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/common/config/SubmitterConfig.kt
@@ -6,7 +6,11 @@ import ac.uk.ebi.biostd.common.config.SubmitterConfig.ProcessorConfig
 import ac.uk.ebi.biostd.common.config.SubmitterConfig.ValidatorConfig
 import ac.uk.ebi.biostd.common.property.ApplicationProperties
 import ac.uk.ebi.biostd.submission.SubmissionSubmitter
+import ac.uk.ebi.biostd.submission.handlers.FilesCopier
 import ac.uk.ebi.biostd.submission.handlers.FilesHandler
+import ac.uk.ebi.biostd.submission.handlers.FilesValidator
+import ac.uk.ebi.biostd.submission.handlers.LibraryFilesHandler
+import ac.uk.ebi.biostd.submission.handlers.OutputFilesGenerator
 import ac.uk.ebi.biostd.submission.processors.AccNoProcessor
 import ac.uk.ebi.biostd.submission.processors.AccessTagProcessor
 import ac.uk.ebi.biostd.submission.processors.PropertiesProcessor
@@ -43,7 +47,20 @@ class SubmitterConfig {
         fun serializationService() = SerializationService()
 
         @Bean
-        fun filesHandler() = FilesHandler(folderResolver(), serializationService())
+        fun filesHandler() = FilesHandler(
+            folderResolver(), filesValidator(), filesCopier(), libraryFilesHandler(), outputFilesGenerator())
+
+        @Bean
+        fun libraryFilesHandler() = LibraryFilesHandler(serializationService())
+
+        @Bean
+        fun outputFilesGenerator() = OutputFilesGenerator(folderResolver(), serializationService())
+
+        @Bean
+        fun filesCopier() = FilesCopier(folderResolver())
+
+        @Bean
+        fun filesValidator() = FilesValidator()
     }
 
     @Configuration

--- a/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/exceptions/InvalidLibraryFileException.kt
+++ b/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/exceptions/InvalidLibraryFileException.kt
@@ -2,4 +2,5 @@ package ac.uk.ebi.biostd.submission.exceptions
 
 import ebi.ac.uk.model.Section
 
-class InvalidLibraryFileException(val sections: List<Section>, message: String) : RuntimeException(message)
+class InvalidLibraryFileException(sections: List<Section>) :
+    RuntimeException("The following sections contain invalid library files: ${sections.map { it.type }}")

--- a/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/handlers/FilesCopier.kt
+++ b/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/handlers/FilesCopier.kt
@@ -1,0 +1,31 @@
+package ac.uk.ebi.biostd.submission.handlers
+
+import ac.uk.ebi.biostd.submission.model.FilesSource
+import ebi.ac.uk.model.ExtendedSubmission
+import ebi.ac.uk.model.File
+import ebi.ac.uk.model.extensions.allFiles
+import ebi.ac.uk.model.extensions.allReferencedFiles
+import ebi.ac.uk.paths.FolderResolver
+import org.apache.commons.io.FileUtils
+
+class FilesCopier(private val folderResolver: FolderResolver) {
+    fun copy(submission: ExtendedSubmission, filesSource: FilesSource) {
+        copySubmissionFiles(submission, filesSource)
+        copyReferencedFiles(submission, filesSource)
+    }
+
+    private fun copySubmissionFiles(submission: ExtendedSubmission, filesSource: FilesSource) =
+        copy(submission.allFiles(), submission, filesSource)
+
+    private fun copyReferencedFiles(submission: ExtendedSubmission, filesSource: FilesSource) =
+        copy(submission.allReferencedFiles(), submission, filesSource)
+
+    private fun copy(files: List<File>, submission: ExtendedSubmission, filesSource: FilesSource) {
+        files.forEach { targetFile ->
+            val submissionFile = folderResolver.getSubFilePath(submission.relPath, targetFile.path).toFile()
+
+            targetFile.size = filesSource.size(targetFile.path)
+            FileUtils.copyInputStreamToFile(filesSource.getInputStream(targetFile.path), submissionFile)
+        }
+    }
+}

--- a/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/handlers/FilesHandler.kt
+++ b/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/handlers/FilesHandler.kt
@@ -1,90 +1,31 @@
 package ac.uk.ebi.biostd.submission.handlers
 
-import ac.uk.ebi.biostd.SerializationService
-import ac.uk.ebi.biostd.SubFormat.JSON_PRETTY
-import ac.uk.ebi.biostd.SubFormat.TSV
-import ac.uk.ebi.biostd.SubFormat.XML
-import ac.uk.ebi.biostd.submission.exceptions.InvalidFilesException
-import ac.uk.ebi.biostd.submission.exceptions.InvalidLibraryFileException
-import ac.uk.ebi.biostd.submission.model.FilesSource
 import ac.uk.ebi.biostd.submission.model.ListFilesSource
 import ac.uk.ebi.biostd.submission.model.PathFilesSource
 import ac.uk.ebi.biostd.submission.model.ResourceFile
 import ebi.ac.uk.model.ExtendedSubmission
-import ebi.ac.uk.model.File
-import ebi.ac.uk.model.FilesTable
-import ebi.ac.uk.model.extensions.allFiles
-import ebi.ac.uk.model.extensions.allReferencedFiles
-import ebi.ac.uk.model.extensions.libFileSections
 import ebi.ac.uk.paths.FolderResolver
-import ebi.ac.uk.util.collections.ifNotEmpty
-import org.apache.commons.io.FileUtils
 
 const val INVALID_FILES_ERROR_MSG = "Submission contains invalid files"
 
-class FilesHandler(private val folderResolver: FolderResolver, private val serializationService: SerializationService) {
-
+class FilesHandler(
+    private val folderResolver: FolderResolver,
+    private val filesValidator: FilesValidator,
+    private val filesCopier: FilesCopier,
+    private val libraryFilesHandler: LibraryFilesHandler,
+    private val outputFilesGenerator: OutputFilesGenerator
+) {
     /**
      * In charge of generate submission json/tsv/xml representation files and validate all submission specified files
      * are provided or exists in  user repository or in the list of provided files.
      */
     fun processFiles(submission: ExtendedSubmission, files: List<ResourceFile>) {
-        val fileSource = if (files.isEmpty()) PathFilesSource(getUserFolder(submission)) else ListFilesSource(files)
+        val userFolder = folderResolver.getUserMagicFolderPath(submission.user.id, submission.user.secretKey)
+        val fileSource = if (files.isEmpty()) PathFilesSource(userFolder) else ListFilesSource(files)
 
-        validateFiles(submission, fileSource)
-        copyFiles(submission.allFiles(), submission, fileSource)
-
-        validateLibraryFiles(submission, fileSource)
-        processLibraryFiles(submission, fileSource)
-        copyFiles(submission.allReferencedFiles(), submission, fileSource)
-
-        generateOutputFiles(submission.asSubmission(), submission, submission.accNo)
+        filesValidator.validate(submission, fileSource)
+        libraryFilesHandler.processLibraryFiles(submission, fileSource)
+        filesCopier.copy(submission, fileSource)
+        outputFilesGenerator.generate(submission, fileSource)
     }
-
-    private fun <T> generateOutputFiles(element: T, submission: ExtendedSubmission, outputFileName: String) {
-        val json = serializationService.serializeElement(element, JSON_PRETTY)
-        val xml = serializationService.serializeElement(element, XML)
-        val tsv = serializationService.serializeElement(element, TSV)
-        val submissionPath = folderResolver.getSubmissionFolder(submission)
-
-        FileUtils.writeStringToFile(submissionPath.resolve("$outputFileName.json").toFile(), json, Charsets.UTF_8)
-        FileUtils.writeStringToFile(submissionPath.resolve("$outputFileName.xml").toFile(), xml, Charsets.UTF_8)
-        FileUtils.writeStringToFile(submissionPath.resolve("$outputFileName.tsv").toFile(), tsv, Charsets.UTF_8)
-    }
-
-    private fun validateLibraryFiles(submission: ExtendedSubmission, filesSource: FilesSource) {
-        submission.libFileSections()
-            .filterNot { section -> filesSource.exists(section.libraryFile!!.name) }
-            .ifNotEmpty { throw InvalidLibraryFileException(it) }
-    }
-
-    private fun processLibraryFiles(submission: ExtendedSubmission, filesSource: FilesSource) {
-        submission.libFileSections().forEach { section ->
-            val libFileName = "${submission.accNo}.${section.accNo}.files"
-            val libFileContent = filesSource.readText(section.libraryFile!!.name)
-            val filesTable = serializationService.deserializeElement<FilesTable>(libFileContent, TSV)
-
-            filesTable.elements.forEach { file -> section.addReferencedFile(file) }
-            generateOutputFiles(filesTable, submission, libFileName)
-            section.libraryFile?.name = "$libFileName.tsv"
-        }
-    }
-
-    private fun validateFiles(submission: ExtendedSubmission, filesSource: FilesSource) {
-        submission.allFiles()
-            .filter { file -> filesSource.exists(file.path).not() }
-            .ifNotEmpty { throw InvalidFilesException(it, INVALID_FILES_ERROR_MSG) }
-    }
-
-    private fun copyFiles(files: List<File>, submission: ExtendedSubmission, filesSource: FilesSource) {
-        files.forEach { file ->
-            val submissionFile = folderResolver.getSubFilePath(submission.relPath, file.path).toFile()
-
-            file.size = filesSource.size(file.path)
-            FileUtils.copyInputStreamToFile(filesSource.getInputStream(file.path), submissionFile)
-        }
-    }
-
-    private fun getUserFolder(submission: ExtendedSubmission) =
-        folderResolver.getUserMagicFolderPath(submission.user.id, submission.user.secretKey)
 }

--- a/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/handlers/FilesHandler.kt
+++ b/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/handlers/FilesHandler.kt
@@ -1,14 +1,21 @@
 package ac.uk.ebi.biostd.submission.handlers
 
 import ac.uk.ebi.biostd.SerializationService
-import ac.uk.ebi.biostd.SubFormat
+import ac.uk.ebi.biostd.SubFormat.JSON_PRETTY
+import ac.uk.ebi.biostd.SubFormat.TSV
+import ac.uk.ebi.biostd.SubFormat.XML
 import ac.uk.ebi.biostd.submission.exceptions.InvalidFilesException
+import ac.uk.ebi.biostd.submission.exceptions.InvalidLibraryFileException
 import ac.uk.ebi.biostd.submission.model.FilesSource
 import ac.uk.ebi.biostd.submission.model.ListFilesSource
 import ac.uk.ebi.biostd.submission.model.PathFilesSource
 import ac.uk.ebi.biostd.submission.model.ResourceFile
 import ebi.ac.uk.model.ExtendedSubmission
+import ebi.ac.uk.model.File
+import ebi.ac.uk.model.FilesTable
 import ebi.ac.uk.model.extensions.allFiles
+import ebi.ac.uk.model.extensions.allReferencedFiles
+import ebi.ac.uk.model.extensions.libFileSections
 import ebi.ac.uk.paths.FolderResolver
 import ebi.ac.uk.util.collections.ifNotEmpty
 import org.apache.commons.io.FileUtils
@@ -25,32 +32,52 @@ class FilesHandler(private val folderResolver: FolderResolver, private val seria
         val fileSource = if (files.isEmpty()) PathFilesSource(getUserFolder(submission)) else ListFilesSource(files)
 
         validateFiles(submission, fileSource)
-        copyFiles(submission, fileSource)
-        generateOutputFiles(submission)
+        copyFiles(submission.allFiles(), submission, fileSource)
+
+        validateLibraryFiles(submission, fileSource)
+        processLibraryFiles(submission, fileSource)
+        copyFiles(submission.allReferencedFiles(), submission, fileSource)
+
+        generateOutputFiles(submission.asSubmission(), submission, submission.accNo)
     }
 
-    private fun generateOutputFiles(submission: ExtendedSubmission) {
-        val simpleSubmission = submission.asSubmission()
-        val json = serializationService.serializeSubmission(simpleSubmission, SubFormat.JSON_PRETTY)
-        val xml = serializationService.serializeSubmission(simpleSubmission, SubFormat.XML)
-        val tsv = serializationService.serializeSubmission(simpleSubmission, SubFormat.TSV)
-
-        val accNo: String = submission.accNo
+    private fun <T> generateOutputFiles(element: T, submission: ExtendedSubmission, outputFileName: String) {
+        val json = serializationService.serializeElement(element, JSON_PRETTY)
+        val xml = serializationService.serializeElement(element, XML)
+        val tsv = serializationService.serializeElement(element, TSV)
         val submissionPath = folderResolver.getSubmissionFolder(submission)
 
-        FileUtils.writeStringToFile(submissionPath.resolve("$accNo.json").toFile(), json, Charsets.UTF_8)
-        FileUtils.writeStringToFile(submissionPath.resolve("$accNo.xml").toFile(), xml, Charsets.UTF_8)
-        FileUtils.writeStringToFile(submissionPath.resolve("$accNo.tsv").toFile(), tsv, Charsets.UTF_8)
+        FileUtils.writeStringToFile(submissionPath.resolve("$outputFileName.json").toFile(), json, Charsets.UTF_8)
+        FileUtils.writeStringToFile(submissionPath.resolve("$outputFileName.xml").toFile(), xml, Charsets.UTF_8)
+        FileUtils.writeStringToFile(submissionPath.resolve("$outputFileName.tsv").toFile(), tsv, Charsets.UTF_8)
+    }
+
+    private fun validateLibraryFiles(submission: ExtendedSubmission, filesSource: FilesSource) {
+        submission.libFileSections()
+            .filterNot { section -> filesSource.exists(section.libraryFile!!.name) }
+            .ifNotEmpty { throw InvalidLibraryFileException(it) }
+    }
+
+    private fun processLibraryFiles(submission: ExtendedSubmission, filesSource: FilesSource) {
+        submission.libFileSections().forEach { section ->
+            val libFileName = "${submission.accNo}.${section.accNo}.files"
+            val libFileContent = filesSource.readText(section.libraryFile!!.name)
+            val filesTable = serializationService.deserializeElement<FilesTable>(libFileContent, TSV)
+
+            filesTable.elements.forEach { file -> section.addReferencedFile(file) }
+            generateOutputFiles(filesTable, submission, libFileName)
+            section.libraryFile?.name = "$libFileName.tsv"
+        }
     }
 
     private fun validateFiles(submission: ExtendedSubmission, filesSource: FilesSource) {
         submission.allFiles()
-                .filter { file -> filesSource.exists(file.path).not() }
-                .ifNotEmpty { throw InvalidFilesException(it, INVALID_FILES_ERROR_MSG) }
+            .filter { file -> filesSource.exists(file.path).not() }
+            .ifNotEmpty { throw InvalidFilesException(it, INVALID_FILES_ERROR_MSG) }
     }
 
-    private fun copyFiles(submission: ExtendedSubmission, filesSource: FilesSource) {
-        submission.allFiles().forEach { file ->
+    private fun copyFiles(files: List<File>, submission: ExtendedSubmission, filesSource: FilesSource) {
+        files.forEach { file ->
             val submissionFile = folderResolver.getSubFilePath(submission.relPath, file.path).toFile()
 
             file.size = filesSource.size(file.path)

--- a/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/handlers/FilesValidator.kt
+++ b/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/handlers/FilesValidator.kt
@@ -1,0 +1,28 @@
+package ac.uk.ebi.biostd.submission.handlers
+
+import ac.uk.ebi.biostd.submission.exceptions.InvalidFilesException
+import ac.uk.ebi.biostd.submission.exceptions.InvalidLibraryFileException
+import ac.uk.ebi.biostd.submission.model.FilesSource
+import ebi.ac.uk.model.ExtendedSubmission
+import ebi.ac.uk.model.extensions.allFiles
+import ebi.ac.uk.model.extensions.libFileSections
+import ebi.ac.uk.util.collections.ifNotEmpty
+
+class FilesValidator {
+    fun validate(submission: ExtendedSubmission, filesSource: FilesSource) {
+        validateFiles(submission, filesSource)
+        validateLibraryFiles(submission, filesSource)
+    }
+
+    private fun validateLibraryFiles(submission: ExtendedSubmission, filesSource: FilesSource) {
+        submission.libFileSections()
+            .filterNot { section -> filesSource.exists(section.libraryFile!!.name) }
+            .ifNotEmpty { throw InvalidLibraryFileException(it) }
+    }
+
+    private fun validateFiles(submission: ExtendedSubmission, filesSource: FilesSource) {
+        submission.allFiles()
+            .filter { file -> filesSource.exists(file.path).not() }
+            .ifNotEmpty { throw InvalidFilesException(it, INVALID_FILES_ERROR_MSG) }
+    }
+}

--- a/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/handlers/LibraryFilesHandler.kt
+++ b/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/handlers/LibraryFilesHandler.kt
@@ -1,0 +1,21 @@
+package ac.uk.ebi.biostd.submission.handlers
+
+import ac.uk.ebi.biostd.SerializationService
+import ac.uk.ebi.biostd.SubFormat
+import ac.uk.ebi.biostd.submission.model.FilesSource
+import ebi.ac.uk.model.ExtendedSubmission
+import ebi.ac.uk.model.FilesTable
+import ebi.ac.uk.model.extensions.libFileSections
+
+class LibraryFilesHandler(private val serializationService: SerializationService) {
+    fun processLibraryFiles(submission: ExtendedSubmission, filesSource: FilesSource) {
+        submission.libFileSections().forEach { section ->
+            val libFileContent = filesSource.readText(section.libraryFile!!.name)
+
+            // TODO support for all formats
+            val filesTable = serializationService.deserializeElement<FilesTable>(libFileContent, SubFormat.TSV)
+
+            filesTable.elements.forEach { section.addReferencedFile(it) }
+        }
+    }
+}

--- a/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/handlers/OutputFilesGenerator.kt
+++ b/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/handlers/OutputFilesGenerator.kt
@@ -1,0 +1,44 @@
+package ac.uk.ebi.biostd.submission.handlers
+
+import ac.uk.ebi.biostd.SerializationService
+import ac.uk.ebi.biostd.SubFormat
+import ac.uk.ebi.biostd.submission.model.FilesSource
+import ebi.ac.uk.model.ExtendedSubmission
+import ebi.ac.uk.model.FilesTable
+import ebi.ac.uk.model.extensions.libFileSections
+import ebi.ac.uk.paths.FolderResolver
+import org.apache.commons.io.FileUtils
+
+class OutputFilesGenerator(
+    private val folderResolver: FolderResolver,
+    private val serializationService: SerializationService
+) {
+    fun generate(submission: ExtendedSubmission, filesSource: FilesSource) {
+        generateSubmissionFiles(submission)
+        generateLibraryFiles(submission, filesSource)
+    }
+
+    private fun generateSubmissionFiles(submission: ExtendedSubmission) =
+        generateOutputFiles(submission.asSubmission(), submission, submission.accNo)
+
+    private fun generateLibraryFiles(submission: ExtendedSubmission, filesSource: FilesSource) =
+        submission.libFileSections().forEach {
+            val libFileName = "${submission.accNo}.${it.accNo}.files"
+            val libFileContent = filesSource.readText(it.libraryFile!!.name)
+            val filesTable = serializationService.deserializeElement<FilesTable>(libFileContent, SubFormat.TSV)
+
+            it.libraryFile!!.name = "$libFileName.tsv"
+            generateOutputFiles(filesTable, submission, libFileName)
+        }
+
+    private fun <T> generateOutputFiles(element: T, submission: ExtendedSubmission, outputFileName: String) {
+        val json = serializationService.serializeElement(element, SubFormat.JSON_PRETTY)
+        val xml = serializationService.serializeElement(element, SubFormat.XML)
+        val tsv = serializationService.serializeElement(element, SubFormat.TSV)
+        val submissionPath = folderResolver.getSubmissionFolder(submission)
+
+        FileUtils.writeStringToFile(submissionPath.resolve("$outputFileName.json").toFile(), json, Charsets.UTF_8)
+        FileUtils.writeStringToFile(submissionPath.resolve("$outputFileName.xml").toFile(), xml, Charsets.UTF_8)
+        FileUtils.writeStringToFile(submissionPath.resolve("$outputFileName.tsv").toFile(), tsv, Charsets.UTF_8)
+    }
+}

--- a/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/model/FilesSource.kt
+++ b/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/model/FilesSource.kt
@@ -11,6 +11,8 @@ interface FilesSource {
     fun getInputStream(filePath: String): InputStream
 
     fun size(filePath: String): Long
+
+    fun readText(filePath: String): String
 }
 
 class ListFilesSource(private val files: List<ResourceFile>) : FilesSource {
@@ -20,6 +22,8 @@ class ListFilesSource(private val files: List<ResourceFile>) : FilesSource {
     override fun getInputStream(filePath: String) = files.first { it.name == filePath }.inputStream
 
     override fun size(filePath: String) = files.first { it.name == filePath }.size
+
+    override fun readText(filePath: String) = files.first { it.name == filePath }.text
 }
 
 class PathFilesSource(private val path: Path) : FilesSource {
@@ -29,4 +33,6 @@ class PathFilesSource(private val path: Path) : FilesSource {
     override fun getInputStream(filePath: String) = path.resolve(filePath).toFile().inputStream()
 
     override fun size(filePath: String) = path.resolve(filePath).toFile().totalSpace
+
+    override fun readText(filePath: String) = path.resolve(filePath).toFile().readText()
 }

--- a/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/model/ResourceFile.kt
+++ b/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/model/ResourceFile.kt
@@ -2,4 +2,7 @@ package ac.uk.ebi.biostd.submission.model
 
 import java.io.InputStream
 
-data class ResourceFile(val name: String, val inputStream: InputStream, val size: Long)
+data class ResourceFile(val name: String, val inputStream: InputStream, val size: Long) {
+    val text: String
+        get() = inputStream.bufferedReader().use { it.readText() }
+}

--- a/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/model/ResourceFile.kt
+++ b/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/model/ResourceFile.kt
@@ -1,8 +1,12 @@
 package ac.uk.ebi.biostd.submission.model
 
+import ebi.ac.uk.io.asString
 import java.io.InputStream
 
 data class ResourceFile(val name: String, val inputStream: InputStream, val size: Long) {
-    val text: String
-        get() = inputStream.bufferedReader().use { it.readText() }
+    var text: String = ""
+
+    init {
+        text = inputStream.asString()
+    }
 }

--- a/submission/submitter/src/test/kotlin/ac/uk/ebi/biostd/submission/handlers/FilesHandlerTest.kt
+++ b/submission/submitter/src/test/kotlin/ac/uk/ebi/biostd/submission/handlers/FilesHandlerTest.kt
@@ -113,9 +113,9 @@ class FilesHandlerTest(
     }
 
     private fun initMockSerializationService() {
-        every { mockSerializationService.serializeSubmission(submission, SubFormat.JSON_PRETTY) } returns JSON_SUBMISSION
-        every { mockSerializationService.serializeSubmission(submission, SubFormat.XML) } returns XML_SUBMISSION
-        every { mockSerializationService.serializeSubmission(submission, SubFormat.TSV) } returns TSV_SUBMISSION
+        every { mockSerializationService.serializeElement(submission, SubFormat.JSON_PRETTY) } returns JSON_SUBMISSION
+        every { mockSerializationService.serializeElement(submission, SubFormat.XML) } returns XML_SUBMISSION
+        every { mockSerializationService.serializeElement(submission, SubFormat.TSV) } returns TSV_SUBMISSION
     }
 
     private fun initTestSubmissionFiles() {

--- a/submission/submitter/src/test/kotlin/ac/uk/ebi/biostd/submission/handlers/FilesHandlerTest.kt
+++ b/submission/submitter/src/test/kotlin/ac/uk/ebi/biostd/submission/handlers/FilesHandlerTest.kt
@@ -1,130 +1,74 @@
 package ac.uk.ebi.biostd.submission.handlers
 
-import ac.uk.ebi.biostd.SerializationService
-import ac.uk.ebi.biostd.SubFormat
-import ac.uk.ebi.biostd.submission.exceptions.InvalidFilesException
+import ac.uk.ebi.biostd.submission.model.PathFilesSource
 import ac.uk.ebi.biostd.submission.test.ACC_NO
 import ac.uk.ebi.biostd.submission.test.USER_ID
 import ac.uk.ebi.biostd.submission.test.USER_SECRET_KEY
 import ac.uk.ebi.biostd.submission.test.createBasicExtendedSubmission
 import ebi.ac.uk.model.ExtendedSubmission
-import ebi.ac.uk.model.Section
-import ebi.ac.uk.model.extensions.rootPath
 import ebi.ac.uk.paths.FolderResolver
 import io.github.glytching.junit.extension.folder.TemporaryFolder
 import io.github.glytching.junit.extension.folder.TemporaryFolderExtension
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.catchThrowable
+import io.mockk.verify
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import java.io.File
 import java.nio.file.Paths
-import ebi.ac.uk.model.File as SubmissionFile
-
-const val TEST_FILE_1 = "file.txt"
-const val TEST_FILE_2 = "file2.txt"
-const val TEST_FOLDER = "folder1"
-const val NON_EXISTING_FILE = "GhostFile.txt"
-const val JSON_SUBMISSION = "{ \"accNo\": \"$ACC_NO\" }"
-const val XML_SUBMISSION = "<submission accNo=\"$ACC_NO\"></submission>"
-const val TSV_SUBMISSION = "Submission\t$ACC_NO"
 
 @ExtendWith(TemporaryFolderExtension::class, MockKExtension::class)
 class FilesHandlerTest(
     private val temporaryFolder: TemporaryFolder,
+    @MockK private val mockFilesCopier: FilesCopier,
     @MockK private val mockFolderResolver: FolderResolver,
-    @MockK private val mockSerializationService: SerializationService
+    @MockK private val mockFilesValidator: FilesValidator,
+    @MockK private val mockLibraryFilesHandler: LibraryFilesHandler,
+    @MockK private val mockOutputFilesGenerator: OutputFilesGenerator
 ) {
     private lateinit var submission: ExtendedSubmission
     private lateinit var testInstance: FilesHandler
-
-    private val submissionFolderPath: String = "${temporaryFolder.root.absolutePath}/$ACC_NO"
-    private val testSubFile1Path: String = "$submissionFolderPath/$TEST_FILE_1"
-    private val testSubFile2Path: String = "$submissionFolderPath/$TEST_FOLDER/$TEST_FILE_2"
 
     @BeforeAll
     fun beforeAll() {
         temporaryFolder.createDirectory(ACC_NO)
         temporaryFolder.createDirectory(USER_SECRET_KEY)
-        temporaryFolder.createDirectory("$USER_SECRET_KEY/$TEST_FOLDER")
-        temporaryFolder.createFile("$USER_SECRET_KEY/$TEST_FILE_1")
-        temporaryFolder.createFile("$USER_SECRET_KEY/$TEST_FOLDER/$TEST_FILE_2")
     }
 
     @BeforeEach
     fun beforeEach() {
         submission = createBasicExtendedSubmission()
-        testInstance = FilesHandler(mockFolderResolver, mockSerializationService)
+        testInstance =
+            FilesHandler(
+                mockFolderResolver,
+                mockFilesValidator,
+                mockFilesCopier,
+                mockLibraryFilesHandler,
+                mockOutputFilesGenerator)
 
-        initMockFileResolver()
-        initMockSerializationService()
-        initTestSubmissionFiles()
+        initMocks()
     }
 
+    // TODO add unit tests for the individual processors
     @Test
     fun `process submission files`() {
         testInstance.processFiles(submission, emptyList())
 
-        assertSubmissionFile("$ACC_NO.tsv", TSV_SUBMISSION)
-        assertSubmissionFile("$ACC_NO.xml", XML_SUBMISSION)
-        assertSubmissionFile("$ACC_NO.json", JSON_SUBMISSION)
-
-        assertSubmissionFile(TEST_FILE_1, "")
-        assertSubmissionFile("$TEST_FOLDER/$TEST_FILE_2", "")
+        verify(exactly = 1) { mockFilesCopier.copy(submission, any<PathFilesSource>()) }
+        verify(exactly = 1) { mockFilesValidator.validate(submission, any<PathFilesSource>()) }
+        verify(exactly = 1) { mockOutputFilesGenerator.generate(submission, any<PathFilesSource>()) }
+        verify(exactly = 1) { mockLibraryFilesHandler.processLibraryFiles(submission, any<PathFilesSource>()) }
     }
 
-    @Test
-    fun `process submission with invalid files`() {
-        val nonExistingFile = SubmissionFile(NON_EXISTING_FILE)
-        submission.section.addFile(nonExistingFile)
-
-        val exception = catchThrowable { testInstance.processFiles(submission, emptyList()) }
-        assertThat(exception).isInstanceOf(InvalidFilesException::class.java)
-        assertThat(exception).hasMessage(INVALID_FILES_ERROR_MSG)
-        assertThat((exception as InvalidFilesException).invalidFiles).hasSize(1).contains(nonExistingFile)
-    }
-
-    private fun assertSubmissionFile(name: String, expectedContent: String) {
-        val file = File("$submissionFolderPath/$name")
-
-        assertThat(file.exists()).isTrue()
-        assertThat(file.readBytes()).isEqualTo(expectedContent.toByteArray())
-    }
-
-    private fun initMockFileResolver() {
-        every { mockFolderResolver.getSubmissionFolder(submission) } returns Paths.get(submissionFolderPath)
-
-        every {
-            mockFolderResolver.getSubFilePath(submissionFolderPath, TEST_FILE_1)
-        } returns Paths.get(testSubFile1Path)
-
-        every {
-            mockFolderResolver.getSubFilePath(submissionFolderPath, "$TEST_FOLDER/$TEST_FILE_2")
-        } returns Paths.get(testSubFile2Path)
-
+    private fun initMocks() {
+        every { mockFilesCopier.copy(submission, any<PathFilesSource>()) } answers { nothing }
+        every { mockFilesValidator.validate(submission, any<PathFilesSource>()) } answers { nothing }
+        every { mockOutputFilesGenerator.generate(submission, any<PathFilesSource>()) } answers { nothing }
+        every { mockLibraryFilesHandler.processLibraryFiles(submission, any<PathFilesSource>()) } answers { nothing }
         every {
             mockFolderResolver.getUserMagicFolderPath(USER_ID, USER_SECRET_KEY)
         } returns Paths.get("${temporaryFolder.root.absolutePath}/$USER_SECRET_KEY")
-    }
-
-    private fun initMockSerializationService() {
-        every { mockSerializationService.serializeElement(submission, SubFormat.JSON_PRETTY) } returns JSON_SUBMISSION
-        every { mockSerializationService.serializeElement(submission, SubFormat.XML) } returns XML_SUBMISSION
-        every { mockSerializationService.serializeElement(submission, SubFormat.TSV) } returns TSV_SUBMISSION
-    }
-
-    private fun initTestSubmissionFiles() {
-        val section = Section()
-        section.addFile(SubmissionFile(TEST_FILE_1))
-        section.addFile(SubmissionFile("$TEST_FOLDER/$TEST_FILE_2"))
-
-        submission.section = section
-        submission.relPath = submissionFolderPath
-        submission.rootPath = submissionFolderPath
     }
 }


### PR DESCRIPTION
- Add logic to process a submission containing a library file
- Persist the library file and the referenced files
- Generate the corresponding library files into the submission folder
- Create an integration test for a library file submission
- Fix database schema creation script