### PR TITLE
Section Extended

### DIFF
--- a/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/ExtendedSection.kt
+++ b/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/ExtendedSection.kt
@@ -1,0 +1,42 @@
+package ebi.ac.uk.model
+
+import arrow.core.Either
+import ebi.ac.uk.model.extensions.libraryFile
+import ebi.ac.uk.util.collections.addLeft
+import java.util.Objects
+
+class ExtendedSection(type: String) : Section(type) {
+    var libraryFile: LibraryFile? = null
+    var extendedSections: MutableList<Either<ExtendedSection, SectionsTable>> = mutableListOf()
+
+    constructor(section: Section) : this(section.type) {
+        accNo = section.accNo
+        files = section.files
+        links = section.links
+        sections = section.sections
+        attributes = section.attributes
+
+        section.libraryFile?.let { libraryFile = LibraryFile(it) }
+        section.sections.forEach { sect ->
+            sect.fold({ extendedSections.addLeft(ExtendedSection(it)) }, { addSectionTable(it) })
+        }
+    }
+
+    fun addReferencedFile(file: File) = libraryFile?.addFile(file)
+
+    override fun equals(other: Any?) = when {
+        other !is ExtendedSection -> false
+        other === this -> true
+        else -> Objects.equals(type, other.type)
+            .and(Objects.equals(accNo, other.accNo))
+            .and(Objects.equals(files, other.files))
+            .and(Objects.equals(links, other.links))
+            .and(Objects.equals(sections, other.sections))
+            .and(Objects.equals(attributes, other.attributes))
+            .and(Objects.equals(libraryFile, other.libraryFile))
+            .and(Objects.equals(extendedSections, other.extendedSections))
+    }
+
+    override fun hashCode() =
+        Objects.hash(type, accNo, files, links, sections, attributes, libraryFile, extendedSections)
+}

--- a/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/ExtendedSection.kt
+++ b/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/ExtendedSection.kt
@@ -3,6 +3,7 @@ package ebi.ac.uk.model
 import arrow.core.Either
 import ebi.ac.uk.model.extensions.libraryFile
 import ebi.ac.uk.util.collections.addLeft
+import ebi.ac.uk.util.collections.addRight
 import java.util.Objects
 
 class ExtendedSection(type: String) : Section(type) {
@@ -18,7 +19,7 @@ class ExtendedSection(type: String) : Section(type) {
 
         section.libraryFile?.let { libraryFile = LibraryFile(it) }
         section.sections.forEach { sect ->
-            sect.fold({ extendedSections.addLeft(ExtendedSection(it)) }, { addSectionTable(it) })
+            sect.fold({ extendedSections.addLeft(ExtendedSection(it)) }, { extendedSections.addRight(it) })
         }
     }
 

--- a/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/ExtendedSubmission.kt
+++ b/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/ExtendedSubmission.kt
@@ -5,24 +5,23 @@ import java.time.OffsetDateTime
 import java.util.Objects
 
 class ExtendedSubmission(accNo: String, val user: User) : Submission(accNo) {
-
     constructor(submission: Submission, user: User) : this(submission.accNo, user) {
         section = submission.section
         attributes = submission.attributes
         accessTags = submission.accessTags
+        extendedSection = ExtendedSection(submission.section)
     }
 
     var relPath = EMPTY
     var released = false
     var secretKey = EMPTY
     var version = 1
+    var extendedSection = ExtendedSection(section)
     var releaseTime: OffsetDateTime = OffsetDateTime.now()
     var modificationTime: OffsetDateTime = OffsetDateTime.now()
     var creationTime: OffsetDateTime = OffsetDateTime.now()
 
-    fun asSubmission(): Submission {
-        return Submission(this.accNo, this.section, this.attributes)
-    }
+    fun asSubmission() = Submission(accNo, section, attributes)
 
     override fun equals(other: Any?) = when {
         other !is ExtendedSubmission -> false

--- a/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/Section.kt
+++ b/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/Section.kt
@@ -5,7 +5,7 @@ import ebi.ac.uk.util.collections.addLeft
 import ebi.ac.uk.util.collections.addRight
 import java.util.Objects
 
-class Section(
+open class Section(
     var type: String = "",
     var accNo: String? = null,
     var sections: MutableList<Either<Section, SectionsTable>> = mutableListOf(),
@@ -14,14 +14,12 @@ class Section(
     attributes: List<Attribute> = emptyList()
 ) : Attributable(attributes) {
     var parentAccNo: String? = null
-    var libraryFile: LibraryFile? = null
 
     fun addFile(file: File) = files.addLeft(file)
     fun addLink(link: Link) = links.addLeft(link)
     fun addSection(section: Section) = sections.addLeft(section)
     fun addFilesTable(table: FilesTable) = files.addRight(table)
     fun addLinksTable(table: LinksTable) = links.addRight(table)
-    fun addReferencedFile(file: File) = libraryFile?.addFile(file)
     fun addSectionTable(table: SectionsTable) = sections.addRight(table)
 
     override fun equals(other: Any?) = when {
@@ -33,9 +31,7 @@ class Section(
             .and(Objects.equals(links, other.links))
             .and(Objects.equals(sections, other.sections))
             .and(Objects.equals(attributes, other.attributes))
-            .and(Objects.equals(libraryFile, other.libraryFile))
-            .and(Objects.equals(libraryFile, other.libraryFile))
     }
 
-    override fun hashCode() = Objects.hash(type, accNo, files, links, sections, attributes, libraryFile, libraryFile)
+    override fun hashCode() = Objects.hash(type, accNo, files, links, sections, attributes)
 }

--- a/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/extensions/ExtendedSectionExt.kt
+++ b/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/extensions/ExtendedSectionExt.kt
@@ -1,0 +1,19 @@
+package ebi.ac.uk.model.extensions
+
+import ebi.ac.uk.model.ExtendedSection
+import ebi.ac.uk.model.File
+import ebi.ac.uk.util.collections.ifLeft
+
+fun ExtendedSection.allReferencedFiles(): List<File> {
+    val refFiles: MutableList<File> = mutableListOf()
+    libraryFile?.let { refFiles.addAll(it.referencedFiles) }
+
+    return refFiles.toList()
+}
+
+fun ExtendedSection.allExtendedSections(): List<ExtendedSection> {
+    val allExtended: MutableList<ExtendedSection> = mutableListOf()
+    extendedSections.forEach { it.ifLeft { section -> allExtended.add(section) } }
+
+    return allExtended.toList()
+}

--- a/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/extensions/ExtendedSubExt.kt
+++ b/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/extensions/ExtendedSubExt.kt
@@ -1,0 +1,7 @@
+package ebi.ac.uk.model.extensions
+
+import ebi.ac.uk.model.ExtendedSubmission
+
+fun ExtendedSubmission.allExtendedSections() = extendedSection.allExtendedSections() + extendedSection
+fun ExtendedSubmission.allReferencedFiles() = allExtendedSections().flatMap { it.allReferencedFiles() }
+fun ExtendedSubmission.allLibraryFileSections() = allExtendedSections().filterNot { it.libraryFile == null }

--- a/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/extensions/SectionExt.kt
+++ b/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/extensions/SectionExt.kt
@@ -1,10 +1,32 @@
 package ebi.ac.uk.model.extensions
 
+import ebi.ac.uk.model.ExtendedSection
+import ebi.ac.uk.model.File
 import ebi.ac.uk.model.Section
+import ebi.ac.uk.model.constants.SectionFields
+import ebi.ac.uk.util.collections.ifLeft
+
+var Section.libraryFile: String?
+    get() = this[SectionFields.LIB_FILE]
+    set(value) {
+        value?.let { this[SectionFields.LIB_FILE] = it }
+    }
 
 fun Section.allFiles() = files.map { it.fold({ file -> listOf(file) }, { table -> table.elements }) }.flatten()
 
-fun Section.allReferencedFiles() = libraryFile?.referencedFiles?.toList() ?: listOf()
-
 fun Section.allSections() =
     sections.map { it.fold({ section -> listOf(section) }, { table -> table.elements }) }.flatten()
+
+fun ExtendedSection.allReferencedFiles(): List<File> {
+    val refFiles: MutableList<File> = mutableListOf()
+    libraryFile?.let { refFiles.addAll(it.referencedFiles) }
+
+    return refFiles.toList()
+}
+
+fun ExtendedSection.allExtendedSections(): List<ExtendedSection> {
+    val allExtended: MutableList<ExtendedSection> = mutableListOf()
+    extendedSections.forEach { it.ifLeft { section -> allExtended.add(section) } }
+
+    return allExtended.toList()
+}

--- a/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/extensions/SectionExt.kt
+++ b/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/extensions/SectionExt.kt
@@ -1,10 +1,7 @@
 package ebi.ac.uk.model.extensions
 
-import ebi.ac.uk.model.ExtendedSection
-import ebi.ac.uk.model.File
 import ebi.ac.uk.model.Section
 import ebi.ac.uk.model.constants.SectionFields
-import ebi.ac.uk.util.collections.ifLeft
 
 var Section.libraryFile: String?
     get() = this[SectionFields.LIB_FILE]
@@ -16,17 +13,3 @@ fun Section.allFiles() = files.map { it.fold({ file -> listOf(file) }, { table -
 
 fun Section.allSections() =
     sections.map { it.fold({ section -> listOf(section) }, { table -> table.elements }) }.flatten()
-
-fun ExtendedSection.allReferencedFiles(): List<File> {
-    val refFiles: MutableList<File> = mutableListOf()
-    libraryFile?.let { refFiles.addAll(it.referencedFiles) }
-
-    return refFiles.toList()
-}
-
-fun ExtendedSection.allExtendedSections(): List<ExtendedSection> {
-    val allExtended: MutableList<ExtendedSection> = mutableListOf()
-    extendedSections.forEach { it.ifLeft { section -> allExtended.add(section) } }
-
-    return allExtended.toList()
-}

--- a/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/extensions/SubExt.kt
+++ b/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/extensions/SubExt.kt
@@ -1,6 +1,5 @@
 package ebi.ac.uk.model.extensions
 
-import ebi.ac.uk.model.ExtendedSubmission
 import ebi.ac.uk.model.Submission
 import ebi.ac.uk.model.constants.SubFields
 import java.time.Instant
@@ -48,7 +47,3 @@ var Submission.title: String?
 fun Submission.allFiles() = section.allFiles() + section.allSections().flatMap { it.allFiles() }
 fun Submission.getSectionByType(name: String) = section.allSections().first { it.type == name }
 fun Submission.libFileSections() = (section.allSections() + section).filterNot { it.libraryFile.isNullOrBlank() }
-
-fun ExtendedSubmission.allExtendedSections() = extendedSection.allExtendedSections() + extendedSection
-fun ExtendedSubmission.allReferencedFiles() = allExtendedSections().flatMap { it.allReferencedFiles() }
-fun ExtendedSubmission.allLibraryFileSections() = allExtendedSections().filterNot { it.libraryFile == null }

--- a/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/extensions/SubExt.kt
+++ b/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/extensions/SubExt.kt
@@ -1,5 +1,6 @@
 package ebi.ac.uk.model.extensions
 
+import ebi.ac.uk.model.ExtendedSubmission
 import ebi.ac.uk.model.Submission
 import ebi.ac.uk.model.constants.SubFields
 import java.time.Instant
@@ -46,6 +47,8 @@ var Submission.title: String?
 
 fun Submission.allFiles() = section.allFiles() + section.allSections().flatMap { it.allFiles() }
 fun Submission.getSectionByType(name: String) = section.allSections().first { it.type == name }
-fun Submission.libFileSections() = (section.allSections() + section).filterNot { it.libraryFile == null }
-fun Submission.allReferencedFiles() =
-    section.allReferencedFiles() + section.allSections().flatMap { it.allReferencedFiles() }
+fun Submission.libFileSections() = (section.allSections() + section).filterNot { it.libraryFile.isNullOrBlank() }
+
+fun ExtendedSubmission.allExtendedSections() = extendedSection.allExtendedSections() + extendedSection
+fun ExtendedSubmission.allReferencedFiles() = allExtendedSections().flatMap { it.allReferencedFiles() }
+fun ExtendedSubmission.allLibraryFileSections() = allExtendedSections().filterNot { it.libraryFile == null }

--- a/commons/commons-bio/src/test/kotlin/ebi/ac/uk/model/extensions/SubExtTest.kt
+++ b/commons/commons-bio/src/test/kotlin/ebi/ac/uk/model/extensions/SubExtTest.kt
@@ -6,7 +6,6 @@ import ebi.ac.uk.dsl.section
 import ebi.ac.uk.dsl.submission
 import ebi.ac.uk.model.Attribute
 import ebi.ac.uk.model.File
-import ebi.ac.uk.model.LibraryFile
 import ebi.ac.uk.model.Submission
 import ebi.ac.uk.model.constants.SubFields
 import ebi.ac.uk.util.collections.second
@@ -95,7 +94,7 @@ class SubExtTest {
     fun `get library file sections`() {
         val submission = submission("ABC-123") {
             section("Study") {
-                libraryFile = LibraryFile("LibFile1.tsv")
+                libraryFile = "LibFile1.tsv"
 
                 section("Data") {
                     accNo = "DT-1"
@@ -103,7 +102,7 @@ class SubExtTest {
 
                 section("Experiment") {
                     accNo = "EXP-1"
-                    libraryFile = LibraryFile("LibFile2.tsv")
+                    libraryFile = "LibFile2.tsv"
                 }
             }
         }
@@ -111,7 +110,7 @@ class SubExtTest {
         val libFileSections = submission.libFileSections()
 
         assertThat(libFileSections).hasSize(2)
-        assertThat(libFileSections.first().libraryFile?.name).isEqualTo("LibFile2.tsv")
-        assertThat(libFileSections.second().libraryFile?.name).isEqualTo("LibFile1.tsv")
+        assertThat(libFileSections.first().libraryFile).isEqualTo("LibFile2.tsv")
+        assertThat(libFileSections.second().libraryFile).isEqualTo("LibFile1.tsv")
     }
 }

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/ChunkProcessor.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/ChunkProcessor.kt
@@ -7,7 +7,6 @@ import ac.uk.ebi.biostd.tsv.deserialization.common.toAttributes
 import ac.uk.ebi.biostd.tsv.deserialization.common.validate
 import ac.uk.ebi.biostd.tsv.deserialization.model.FileChunk
 import ac.uk.ebi.biostd.tsv.deserialization.model.FileTableChunk
-import ac.uk.ebi.biostd.tsv.deserialization.model.LibFileChunk
 import ac.uk.ebi.biostd.tsv.deserialization.model.LinkChunk
 import ac.uk.ebi.biostd.tsv.deserialization.model.LinksTableChunk
 import ac.uk.ebi.biostd.tsv.deserialization.model.RootSectionTableChunk
@@ -52,7 +51,6 @@ class ChunkProcessor {
         is FileChunk -> chunk.asFile() as T
         is LinksTableChunk -> chunk.asTable() as T
         is FileTableChunk -> chunk.asTable() as T
-        is LibFileChunk -> chunk.asLibraryFile() as T
         is SectionChunk -> TODO("Implement section chunk isolated deserialization")
         is SectionTableChunk -> TODO("Implement section table chunk isolated deserialization")
     }
@@ -63,7 +61,6 @@ class ChunkProcessor {
             is FileChunk -> sectionContext.addFile(chunk)
             is LinksTableChunk -> sectionContext.addLinksTable(chunk)
             is FileTableChunk -> sectionContext.addFilesTable(chunk)
-            is LibFileChunk -> sectionContext.setLibraryFile(chunk)
             is SectionTableChunk -> processSectionTable(chunk, sectionContext)
             is SectionChunk -> processSection(chunk, sectionContext)
         }

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/TsvDeserializer.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/TsvDeserializer.kt
@@ -3,7 +3,6 @@ package ac.uk.ebi.biostd.tsv.deserialization
 import ac.uk.ebi.biostd.tsv.TSV_CHUNK_BREAK
 import ac.uk.ebi.biostd.tsv.deserialization.model.FileChunk
 import ac.uk.ebi.biostd.tsv.deserialization.model.FileTableChunk
-import ac.uk.ebi.biostd.tsv.deserialization.model.LibFileChunk
 import ac.uk.ebi.biostd.tsv.deserialization.model.LinkChunk
 import ac.uk.ebi.biostd.tsv.deserialization.model.LinksTableChunk
 import ac.uk.ebi.biostd.tsv.deserialization.model.RootSectionTableChunk
@@ -61,7 +60,6 @@ class TsvDeserializer(private val chunkProcessor: ChunkProcessor = ChunkProcesso
             type like FileFields.FILE -> FileChunk(body)
             type like SectionFields.LINKS -> LinksTableChunk(body)
             type like SectionFields.FILES -> FileTableChunk(body)
-            type like SectionFields.LIB_FILE -> LibFileChunk(body)
             type.matches(TABLE_REGEX) -> TABLE_REGEX.findGroup(type, 1).fold(
                 { RootSectionTableChunk(body) },
                 { SubSectionTableChunk(body, it) })

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/TsvSerializationContext.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/TsvSerializationContext.kt
@@ -2,7 +2,6 @@ package ac.uk.ebi.biostd.tsv.deserialization
 
 import ac.uk.ebi.biostd.tsv.deserialization.model.FileChunk
 import ac.uk.ebi.biostd.tsv.deserialization.model.FileTableChunk
-import ac.uk.ebi.biostd.tsv.deserialization.model.LibFileChunk
 import ac.uk.ebi.biostd.tsv.deserialization.model.LinkChunk
 import ac.uk.ebi.biostd.tsv.deserialization.model.LinksTableChunk
 import ac.uk.ebi.biostd.tsv.deserialization.model.SectionChunk
@@ -44,9 +43,6 @@ class TsvSerializationContext {
 
     fun addFilesTable(chunk: FileTableChunk) =
         execute(currentSection, chunk) { currentSection.addFilesTable(chunk.asTable()) }
-
-    fun setLibraryFile(chunk: LibFileChunk) =
-        execute(currentSection, chunk) { currentSection.libraryFile = chunk.asLibraryFile() }
 
     fun addSectionTable(chunk: SectionTableChunk) =
         execute(rootSection, chunk) { rootSection.addSectionTable(chunk.asTable()) }

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/model/TsvChunk.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/model/TsvChunk.kt
@@ -7,11 +7,9 @@ import ac.uk.ebi.biostd.tsv.deserialization.common.getType
 import ac.uk.ebi.biostd.tsv.deserialization.common.toAttributes
 import ac.uk.ebi.biostd.validation.InvalidElementException
 import ac.uk.ebi.biostd.validation.REQUIRED_FILE_PATH
-import ac.uk.ebi.biostd.validation.REQUIRED_LIB_FILE_PATH
 import ac.uk.ebi.biostd.validation.REQUIRED_LINK_URL
 import ebi.ac.uk.model.File
 import ebi.ac.uk.model.FilesTable
-import ebi.ac.uk.model.LibraryFile
 import ebi.ac.uk.model.Link
 import ebi.ac.uk.model.LinksTable
 import ebi.ac.uk.model.Section
@@ -49,10 +47,6 @@ class FileChunk(body: List<TsvChunkLine>) : TsvChunk(body) {
         val attributes = toAttributes(lines)
         return File(fileName, attributes = attributes)
     }
-}
-
-class LibFileChunk(body: List<TsvChunkLine>) : TsvChunk(body) {
-    fun asLibraryFile() = LibraryFile(getIdOrElse(InvalidElementException(REQUIRED_LIB_FILE_PATH)))
 }
 
 class LinksTableChunk(body: List<TsvChunkLine>) : TsvChunk(body) {

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/serialization/TsvToStringSerializer.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/serialization/TsvToStringSerializer.kt
@@ -35,12 +35,6 @@ class TsvToStringSerializer {
 
         section.links.forEach { either -> either.fold({ addLink(builder, it) }, { addTable(builder, it) }) }
         section.files.forEach { either -> either.fold({ addFile(builder, it) }, { addTable(builder, it) }) }
-
-        section.libraryFile?.let {
-            builder.addSeparator()
-            builder.addLibFile(it)
-        }
-
         section.sections.forEach { either -> either.fold({ serializeSection(builder, it) }) { addTable(builder, it) } }
     }
 

--- a/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/mapping/SubmissionDbMapper.kt
+++ b/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/mapping/SubmissionDbMapper.kt
@@ -20,7 +20,6 @@ import ebi.ac.uk.model.AttributeDetail
 import ebi.ac.uk.model.ExtendedSubmission
 import ebi.ac.uk.model.File
 import ebi.ac.uk.model.FilesTable
-import ebi.ac.uk.model.LibraryFile
 import ebi.ac.uk.model.Link
 import ebi.ac.uk.model.LinksTable
 import ebi.ac.uk.model.Section
@@ -71,9 +70,7 @@ private object DbSectionMapper {
             links = toLinks(sectionDb.links.toList()),
             files = toFiles(sectionDb.files.toList()),
             sections = toSections(sectionDb.sections.toList()),
-            attributes = toAttributes(sectionDb.attributes)).apply {
-            sectionDb.libraryFile?.let { libraryFile = LibraryFile(it.name) }
-        }
+            attributes = toAttributes(sectionDb.attributes))
 }
 
 private object DbEitherMapper {

--- a/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/mapping/SubmissionMapper.kt
+++ b/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/mapping/SubmissionMapper.kt
@@ -23,7 +23,6 @@ import ebi.ac.uk.model.AttributeDetail
 import ebi.ac.uk.model.ExtendedSubmission
 import ebi.ac.uk.model.File
 import ebi.ac.uk.model.FilesTable
-import ebi.ac.uk.model.LibraryFile
 import ebi.ac.uk.model.Link
 import ebi.ac.uk.model.LinksTable
 import ebi.ac.uk.model.Section
@@ -34,7 +33,6 @@ import ebi.ac.uk.model.extensions.title
 import ac.uk.ebi.biostd.persistence.model.Attribute as AttributeDb
 import ac.uk.ebi.biostd.persistence.model.AttributeDetail as AttributeDetailDb
 import ac.uk.ebi.biostd.persistence.model.File as FileDb
-import ac.uk.ebi.biostd.persistence.model.LibraryFile as LibraryFileDb
 import ac.uk.ebi.biostd.persistence.model.Link as LinkDb
 import ac.uk.ebi.biostd.persistence.model.ReferencedFile as ReferencedFileDb
 import ac.uk.ebi.biostd.persistence.model.Section as SectionDb
@@ -70,8 +68,6 @@ private object SectionMapper {
         links = section.links.mapIndexed(::toLinks).flatten().toSortedSet()
         files = section.files.mapIndexed(::toFiles).flatten().toSortedSet()
         sections = section.sections.mapIndexed(::toSections).flatten().toSortedSet()
-
-        section.libraryFile?.let { libraryFile = toLibraryFileDb(it) }
     }
 
     fun toTableSection(section: Section, index: Int, sectionTableIndex: Int) =
@@ -80,10 +76,6 @@ private object SectionMapper {
             tableIndex = sectionTableIndex
             order = index
         }
-
-    fun toLibraryFileDb(libraryFile: LibraryFile) = LibraryFileDb(libraryFile.name).apply {
-        files = libraryFile.referencedFiles.mapTo(mutableSetOf(), EntityMapper::toRefFile)
-    }
 }
 
 private object TableMapper {

--- a/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/MultipartSubmissionApiTest.kt
+++ b/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/MultipartSubmissionApiTest.kt
@@ -89,9 +89,8 @@ internal class MultipartSubmissionApiTest(private val tempFolder: TemporaryFolde
 
                 line("Study", "SECT-001")
                 line("Title", "Root Section")
-                line()
-
                 line("LibraryFile", "LibraryFile.tsv")
+                line()
             }
 
             val libraryFile = tempFolder.createFile("LibraryFile.tsv").apply {

--- a/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/handlers/FilesHandler.kt
+++ b/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/handlers/FilesHandler.kt
@@ -26,6 +26,6 @@ class FilesHandler(
         filesValidator.validate(submission, fileSource)
         libraryFilesHandler.processLibraryFiles(submission, fileSource)
         filesCopier.copy(submission, fileSource)
-        outputFilesGenerator.generate(submission, fileSource)
+        outputFilesGenerator.generate(submission)
     }
 }

--- a/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/handlers/FilesValidator.kt
+++ b/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/handlers/FilesValidator.kt
@@ -6,6 +6,7 @@ import ac.uk.ebi.biostd.submission.model.FilesSource
 import ebi.ac.uk.model.ExtendedSubmission
 import ebi.ac.uk.model.extensions.allFiles
 import ebi.ac.uk.model.extensions.libFileSections
+import ebi.ac.uk.model.extensions.libraryFile
 import ebi.ac.uk.util.collections.ifNotEmpty
 
 class FilesValidator {
@@ -16,7 +17,7 @@ class FilesValidator {
 
     private fun validateLibraryFiles(submission: ExtendedSubmission, filesSource: FilesSource) {
         submission.libFileSections()
-            .filterNot { section -> filesSource.exists(section.libraryFile!!.name) }
+            .filterNot { section -> filesSource.exists(section.libraryFile!!) }
             .ifNotEmpty { throw InvalidLibraryFileException(it) }
     }
 

--- a/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/handlers/LibraryFilesHandler.kt
+++ b/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/handlers/LibraryFilesHandler.kt
@@ -5,11 +5,11 @@ import ac.uk.ebi.biostd.SubFormat
 import ac.uk.ebi.biostd.submission.model.FilesSource
 import ebi.ac.uk.model.ExtendedSubmission
 import ebi.ac.uk.model.FilesTable
-import ebi.ac.uk.model.extensions.libFileSections
+import ebi.ac.uk.model.extensions.allLibraryFileSections
 
 class LibraryFilesHandler(private val serializationService: SerializationService) {
     fun processLibraryFiles(submission: ExtendedSubmission, filesSource: FilesSource) {
-        submission.libFileSections().forEach { section ->
+        submission.allLibraryFileSections().forEach { section ->
             val libFileContent = filesSource.readText(section.libraryFile!!.name)
 
             // TODO support for all formats

--- a/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/handlers/OutputFilesGenerator.kt
+++ b/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/handlers/OutputFilesGenerator.kt
@@ -2,10 +2,9 @@ package ac.uk.ebi.biostd.submission.handlers
 
 import ac.uk.ebi.biostd.SerializationService
 import ac.uk.ebi.biostd.SubFormat
-import ac.uk.ebi.biostd.submission.model.FilesSource
 import ebi.ac.uk.model.ExtendedSubmission
 import ebi.ac.uk.model.FilesTable
-import ebi.ac.uk.model.extensions.libFileSections
+import ebi.ac.uk.model.extensions.allLibraryFileSections
 import ebi.ac.uk.paths.FolderResolver
 import org.apache.commons.io.FileUtils
 
@@ -13,19 +12,18 @@ class OutputFilesGenerator(
     private val folderResolver: FolderResolver,
     private val serializationService: SerializationService
 ) {
-    fun generate(submission: ExtendedSubmission, filesSource: FilesSource) {
+    fun generate(submission: ExtendedSubmission) {
         generateSubmissionFiles(submission)
-        generateLibraryFiles(submission, filesSource)
+        generateLibraryFiles(submission)
     }
 
     private fun generateSubmissionFiles(submission: ExtendedSubmission) =
         generateOutputFiles(submission.asSubmission(), submission, submission.accNo)
 
-    private fun generateLibraryFiles(submission: ExtendedSubmission, filesSource: FilesSource) =
-        submission.libFileSections().forEach {
+    private fun generateLibraryFiles(submission: ExtendedSubmission) =
+        submission.allLibraryFileSections().forEach {
             val libFileName = "${submission.accNo}.${it.accNo}.files"
-            val libFileContent = filesSource.readText(it.libraryFile!!.name)
-            val filesTable = serializationService.deserializeElement<FilesTable>(libFileContent, SubFormat.TSV)
+            val filesTable = FilesTable(it.libraryFile!!.referencedFiles.toList())
 
             it.libraryFile!!.name = "$libFileName.tsv"
             generateOutputFiles(filesTable, submission, libFileName)

--- a/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/model/ResourceFile.kt
+++ b/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/model/ResourceFile.kt
@@ -6,6 +6,7 @@ import java.io.InputStream
 data class ResourceFile(val name: String, val inputStream: InputStream, val size: Long) {
     var text: String = ""
 
+    // TODO Improve the file reading. This should performed only when necessary
     init {
         text = inputStream.asString()
     }

--- a/submission/submitter/src/test/kotlin/ac/uk/ebi/biostd/submission/handlers/FilesHandlerTest.kt
+++ b/submission/submitter/src/test/kotlin/ac/uk/ebi/biostd/submission/handlers/FilesHandlerTest.kt
@@ -58,14 +58,14 @@ class FilesHandlerTest(
 
         verify(exactly = 1) { mockFilesCopier.copy(submission, any<PathFilesSource>()) }
         verify(exactly = 1) { mockFilesValidator.validate(submission, any<PathFilesSource>()) }
-        verify(exactly = 1) { mockOutputFilesGenerator.generate(submission, any<PathFilesSource>()) }
+        verify(exactly = 1) { mockOutputFilesGenerator.generate(submission) }
         verify(exactly = 1) { mockLibraryFilesHandler.processLibraryFiles(submission, any<PathFilesSource>()) }
     }
 
     private fun initMocks() {
         every { mockFilesCopier.copy(submission, any<PathFilesSource>()) } answers { nothing }
         every { mockFilesValidator.validate(submission, any<PathFilesSource>()) } answers { nothing }
-        every { mockOutputFilesGenerator.generate(submission, any<PathFilesSource>()) } answers { nothing }
+        every { mockOutputFilesGenerator.generate(submission) } answers { nothing }
         every { mockLibraryFilesHandler.processLibraryFiles(submission, any<PathFilesSource>()) } answers { nothing }
         every {
             mockFolderResolver.getUserMagicFolderPath(USER_ID, USER_SECRET_KEY)


### PR DESCRIPTION
- Refactor submission model to use library file as a string element for simple model and as a LibraryFile object for the extended model
- Remove library file object from serialization since it's now an attribute
- Adjust unit tests