### PR TITLE
 Library File Formats Support

### DIFF
--- a/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/ExtendedSection.kt
+++ b/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/ExtendedSection.kt
@@ -25,6 +25,13 @@ class ExtendedSection(type: String) : Section(type) {
 
     fun addReferencedFile(file: File) = libraryFile?.addFile(file)
 
+    fun asSection() = Section(type, accNo, toSections(), files, links, attributes)
+
+    private fun toSections(): MutableList<Either<Section, SectionsTable>> =
+        extendedSections.mapTo(mutableListOf()) { extSect ->
+            extSect.fold({ Either.left(it.asSection()) }, { Either.right(it) })
+        }
+
     override fun equals(other: Any?) = when {
         other !is ExtendedSection -> false
         other === this -> true

--- a/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/ExtendedSubmission.kt
+++ b/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/ExtendedSubmission.kt
@@ -21,7 +21,7 @@ class ExtendedSubmission(accNo: String, val user: User) : Submission(accNo) {
     var modificationTime: OffsetDateTime = OffsetDateTime.now()
     var creationTime: OffsetDateTime = OffsetDateTime.now()
 
-    fun asSubmission() = Submission(accNo, section, attributes)
+    fun asSubmission() = Submission(accNo, extendedSection.asSection(), attributes)
 
     override fun equals(other: Any?) = when {
         other !is ExtendedSubmission -> false

--- a/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/extensions/ExtendedSectionExt.kt
+++ b/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/extensions/ExtendedSectionExt.kt
@@ -2,7 +2,14 @@ package ebi.ac.uk.model.extensions
 
 import ebi.ac.uk.model.ExtendedSection
 import ebi.ac.uk.model.File
+import ebi.ac.uk.model.constants.SectionFields
 import ebi.ac.uk.util.collections.ifLeft
+
+var ExtendedSection.libraryFileAttr: String?
+    get() = this[SectionFields.LIB_FILE]
+    set(value) {
+        value?.let { this[SectionFields.LIB_FILE] = it }
+    }
 
 fun ExtendedSection.allReferencedFiles(): List<File> {
     val refFiles: MutableList<File> = mutableListOf()

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/SerializationService.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/SerializationService.kt
@@ -26,13 +26,13 @@ class SerializationService(
     inline fun <reified T> deserializeElement(
         element: String,
         format: SubFormat
-    ) = deserializeElement(element, format, T::class.java) as T
+    ) = deserializeElement(element, format, T::class.java)
 
-    fun <T> deserializeElement(element: String, format: SubFormat, type: Class<out T>? = null) = when (format) {
-        XML -> xmlSerializer.deserialize(element)
-        JSON -> jsonSerializer.deserialize(element)
-        JSON_PRETTY -> jsonSerializer.deserialize(element)
-        TSV -> tsvSerializer.deserializeElement(element, type!!)
+    fun <T> deserializeElement(element: String, format: SubFormat, type: Class<out T>): T = when (format) {
+        XML -> xmlSerializer.deserialize(element, type)
+        JSON -> jsonSerializer.deserialize(element, type)
+        JSON_PRETTY -> jsonSerializer.deserialize(element, type)
+        TSV -> tsvSerializer.deserializeElement(element, type)
     }
 
     fun deserializeSubmission(submission: String, format: SubFormat) = when (format) {

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/json/JsonSerializer.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/json/JsonSerializer.kt
@@ -44,6 +44,8 @@ class JsonSerializer {
 
     inline fun <reified T> deserialize(value: String) = mapper.readValue<T>(value)
 
+    fun <T> deserialize(value: String, type: Class<out T>) =  mapper.readValue(value, type)
+
     companion object {
         val mapper = createMapper()
 

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/json/JsonSerializer.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/json/JsonSerializer.kt
@@ -44,7 +44,7 @@ class JsonSerializer {
 
     inline fun <reified T> deserialize(value: String) = mapper.readValue<T>(value)
 
-    fun <T> deserialize(value: String, type: Class<out T>) =  mapper.readValue(value, type)
+    fun <T> deserialize(value: String, type: Class<out T>) = mapper.readValue(value, type)
 
     companion object {
         val mapper = createMapper()

--- a/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/mapping/SubmissionDbMapper.kt
+++ b/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/mapping/SubmissionDbMapper.kt
@@ -17,6 +17,7 @@ import ebi.ac.uk.base.orFalse
 import ebi.ac.uk.functions.secondsToInstant
 import ebi.ac.uk.model.Attribute
 import ebi.ac.uk.model.AttributeDetail
+import ebi.ac.uk.model.ExtendedSection
 import ebi.ac.uk.model.ExtendedSubmission
 import ebi.ac.uk.model.File
 import ebi.ac.uk.model.FilesTable
@@ -50,6 +51,7 @@ class SubmissionDbMapper {
             releaseTime = toInstant(submissionDb.releaseTime)
 
             section = toSection(submissionDb.rootSection)
+            extendedSection = ExtendedSection(toSection(submissionDb.rootSection))
             attributes = toAttributes(submissionDb.attributes)
             accessTags = submissionDb.accessTags.mapTo(mutableListOf(), AccessTag::name)
         }

--- a/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/mapping/SubmissionMapper.kt
+++ b/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/mapping/SubmissionMapper.kt
@@ -20,6 +20,7 @@ import arrow.core.Either
 import ebi.ac.uk.base.orFalse
 import ebi.ac.uk.model.Attribute
 import ebi.ac.uk.model.AttributeDetail
+import ebi.ac.uk.model.ExtendedSection
 import ebi.ac.uk.model.ExtendedSubmission
 import ebi.ac.uk.model.File
 import ebi.ac.uk.model.FilesTable
@@ -52,7 +53,7 @@ class SubmissionMapper(private val tagsRepository: TagsDataRepository) {
         releaseTime = submission.releaseTime.toEpochSecond()
 
         owner = toUser(submission.user)
-        rootSection = toSection(submission.section, NO_TABLE_INDEX)
+        rootSection = toSection(submission.extendedSection, NO_TABLE_INDEX)
         attributes = toAttributes(submission.attributes).mapTo(sortedSetOf(), ::SubmissionAttribute)
         accessTags = toAccessTag(submission.accessTags)
     }
@@ -62,12 +63,12 @@ class SubmissionMapper(private val tagsRepository: TagsDataRepository) {
 }
 
 private object SectionMapper {
-    fun toSection(section: Section, index: Int) = SectionDb(section.accNo, section.type).apply {
+    fun toSection(section: ExtendedSection, index: Int) = SectionDb(section.accNo, section.type).apply {
         order = index
         attributes = toAttributes(section.attributes).mapTo(sortedSetOf(), ::SectionAttribute)
         links = section.links.mapIndexed(::toLinks).flatten().toSortedSet()
         files = section.files.mapIndexed(::toFiles).flatten().toSortedSet()
-        sections = section.sections.mapIndexed(::toSections).flatten().toSortedSet()
+        sections = section.extendedSections.mapIndexed(::toSections).flatten().toSortedSet()
     }
 
     fun toTableSection(section: Section, index: Int, sectionTableIndex: Int) =
@@ -79,7 +80,7 @@ private object SectionMapper {
 }
 
 private object TableMapper {
-    fun toSections(index: Int, either: Either<Section, SectionsTable>): List<SectionDb> =
+    fun toSections(index: Int, either: Either<ExtendedSection, SectionsTable>): List<SectionDb> =
         either.fold(
             { listOf(toSection(it, index)) },
             { it.elements.mapIndexed { tableIndex, file -> toTableSection(file, index + tableIndex, tableIndex) } })

--- a/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/MultipartSubmissionApiTest.kt
+++ b/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/MultipartSubmissionApiTest.kt
@@ -13,6 +13,8 @@ import arrow.core.Either
 import ebi.ac.uk.api.security.RegisterRequest
 import ebi.ac.uk.asserts.assertThat
 import ebi.ac.uk.dsl.file
+import ebi.ac.uk.dsl.json.jsonArray
+import ebi.ac.uk.dsl.json.jsonObj
 import ebi.ac.uk.dsl.line
 import ebi.ac.uk.dsl.section
 import ebi.ac.uk.dsl.submission
@@ -25,6 +27,7 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.redundent.kotlin.xml.xml
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.web.server.LocalServerPort
@@ -81,7 +84,7 @@ internal class MultipartSubmissionApiTest(private val tempFolder: TemporaryFolde
         }
 
         @Test
-        fun `submission with library file`() {
+        fun `submission with library file TSV`() {
             val submission = tsv {
                 line("Submission", "S-TEST1")
                 line("Title", "Test Submission")
@@ -111,6 +114,104 @@ internal class MultipartSubmissionApiTest(private val tempFolder: TemporaryFolde
             assertThat(Paths.get("$submissionFolderPath/S-TEST1.SECT-001.files.tsv")).exists()
             assertThat(Paths.get("$submissionFolderPath/S-TEST1.SECT-001.files.xml")).exists()
             assertThat(Paths.get("$submissionFolderPath/S-TEST1.SECT-001.files.json")).exists()
+        }
+
+        @Test
+        fun `submission with library file JSON`() {
+            val submission = jsonObj {
+                "accNo" to "S-TEST2"
+                "attributes" to jsonArray({
+                    "name" to "Title"
+                    "value" to "Test Submission"
+                })
+                "section" to {
+                    "accNo" to "SECT-001"
+                    "type" to "Study"
+                    "attributes" to jsonArray({
+                        "name" to "Title"
+                        "value" to "Root Section"
+                    }, {
+                        "name" to "LibraryFile"
+                        "value" to "LibraryFile.json"
+                    })
+                }
+            }
+
+            val libraryFile = tempFolder.createFile("LibraryFile.json").apply {
+                writeBytes(jsonArray({
+                    "path" to "File2.txt"
+                    "attributes" to jsonArray({
+                        "name" to "GEN"
+                        "value" to "ABC"
+                    })
+                }).toString().toByteArray())
+            }
+
+            val response = webClient.submitSingle(
+                submission.toString(), SubmissionFormat.JSON, listOf(libraryFile, tempFolder.createFile("File2.txt")))
+            assertSuccessfulResponse(response)
+
+            val createdSubmission = submissionRepository.getExtendedByAccNo("S-TEST2")
+            val submissionFolderPath = "$basePath/submission/${createdSubmission.relPath}"
+
+            assertThat(Paths.get("$submissionFolderPath/Files/File2.txt")).exists()
+            assertThat(Paths.get("$submissionFolderPath/S-TEST2.SECT-001.files.tsv")).exists()
+            assertThat(Paths.get("$submissionFolderPath/S-TEST2.SECT-001.files.xml")).exists()
+            assertThat(Paths.get("$submissionFolderPath/S-TEST2.SECT-001.files.json")).exists()
+        }
+
+        @Test
+        fun `submission with library file XML`() {
+            val submission = xml("submission") {
+                attribute("accNo", "S-TEST3")
+                "attributes" {
+                    "attribute" {
+                        "name" { -"Title" }
+                        "value" { -"Test Submission" }
+                    }
+                }
+
+                "section" {
+                    attribute("accNo", "SECT-001")
+                    attribute("type", "Study")
+                    "attributes" {
+                        "attribute" {
+                            "name" { -"Title" }
+                            "value" { -"Root Section" }
+                        }
+                        "attribute" {
+                            "name" { -"LibraryFile" }
+                            "value" { -"LibraryFile.xml" }
+                        }
+                    }
+                }
+            }
+
+            val libraryFile = tempFolder.createFile("LibraryFile.xml").apply {
+                writeBytes(xml("table") {
+                    "file" {
+                        "path" { -"File3.txt" }
+                        "attributes" {
+                            "attribute" {
+                                "name" { -"GEN" }
+                                "value" { -"ABC" }
+                            }
+                        }
+                    }
+                }.toString().toByteArray())
+            }
+
+            val response = webClient.submitSingle(
+                submission.toString(), SubmissionFormat.XML, listOf(libraryFile, tempFolder.createFile("File3.txt")))
+            assertSuccessfulResponse(response)
+
+            val createdSubmission = submissionRepository.getExtendedByAccNo("S-TEST3")
+            val submissionFolderPath = "$basePath/submission/${createdSubmission.relPath}"
+
+            assertThat(Paths.get("$submissionFolderPath/Files/File3.txt")).exists()
+            assertThat(Paths.get("$submissionFolderPath/S-TEST3.SECT-001.files.tsv")).exists()
+            assertThat(Paths.get("$submissionFolderPath/S-TEST3.SECT-001.files.xml")).exists()
+            assertThat(Paths.get("$submissionFolderPath/S-TEST3.SECT-001.files.json")).exists()
         }
 
         private fun <T> assertSuccessfulResponse(response: ResponseEntity<T>) {

--- a/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/MultipartSubmissionApiTest.kt
+++ b/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/MultipartSubmissionApiTest.kt
@@ -20,6 +20,7 @@ import ebi.ac.uk.dsl.section
 import ebi.ac.uk.dsl.submission
 import ebi.ac.uk.dsl.tsv
 import ebi.ac.uk.model.File
+import ebi.ac.uk.model.extensions.libraryFile
 import io.github.glytching.junit.extension.folder.TemporaryFolder
 import io.github.glytching.junit.extension.folder.TemporaryFolderExtension
 import org.assertj.core.api.Assertions.assertThat
@@ -105,15 +106,9 @@ internal class MultipartSubmissionApiTest(private val tempFolder: TemporaryFolde
 
             val response = webClient.submitSingle(
                 submission.toString(), SubmissionFormat.TSV, listOf(libraryFile, tempFolder.createFile("File1.txt")))
+
             assertSuccessfulResponse(response)
-
-            val createdSubmission = submissionRepository.getExtendedByAccNo("S-TEST1")
-            val submissionFolderPath = "$basePath/submission/${createdSubmission.relPath}"
-
-            assertThat(Paths.get("$submissionFolderPath/Files/File1.txt")).exists()
-            assertThat(Paths.get("$submissionFolderPath/S-TEST1.SECT-001.files.tsv")).exists()
-            assertThat(Paths.get("$submissionFolderPath/S-TEST1.SECT-001.files.xml")).exists()
-            assertThat(Paths.get("$submissionFolderPath/S-TEST1.SECT-001.files.json")).exists()
+            assertSubmissionFiles("S-TEST1", "File1.txt")
         }
 
         @Test
@@ -149,15 +144,9 @@ internal class MultipartSubmissionApiTest(private val tempFolder: TemporaryFolde
 
             val response = webClient.submitSingle(
                 submission.toString(), SubmissionFormat.JSON, listOf(libraryFile, tempFolder.createFile("File2.txt")))
+
             assertSuccessfulResponse(response)
-
-            val createdSubmission = submissionRepository.getExtendedByAccNo("S-TEST2")
-            val submissionFolderPath = "$basePath/submission/${createdSubmission.relPath}"
-
-            assertThat(Paths.get("$submissionFolderPath/Files/File2.txt")).exists()
-            assertThat(Paths.get("$submissionFolderPath/S-TEST2.SECT-001.files.tsv")).exists()
-            assertThat(Paths.get("$submissionFolderPath/S-TEST2.SECT-001.files.xml")).exists()
-            assertThat(Paths.get("$submissionFolderPath/S-TEST2.SECT-001.files.json")).exists()
+            assertSubmissionFiles("S-TEST2", "File2.txt")
         }
 
         @Test
@@ -203,21 +192,28 @@ internal class MultipartSubmissionApiTest(private val tempFolder: TemporaryFolde
 
             val response = webClient.submitSingle(
                 submission.toString(), SubmissionFormat.XML, listOf(libraryFile, tempFolder.createFile("File3.txt")))
+
             assertSuccessfulResponse(response)
-
-            val createdSubmission = submissionRepository.getExtendedByAccNo("S-TEST3")
-            val submissionFolderPath = "$basePath/submission/${createdSubmission.relPath}"
-
-            assertThat(Paths.get("$submissionFolderPath/Files/File3.txt")).exists()
-            assertThat(Paths.get("$submissionFolderPath/S-TEST3.SECT-001.files.tsv")).exists()
-            assertThat(Paths.get("$submissionFolderPath/S-TEST3.SECT-001.files.xml")).exists()
-            assertThat(Paths.get("$submissionFolderPath/S-TEST3.SECT-001.files.json")).exists()
+            assertSubmissionFiles("S-TEST3", "File3.txt")
         }
 
         private fun <T> assertSuccessfulResponse(response: ResponseEntity<T>) {
             assertThat(response).isNotNull
             assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
             assertThat(response.body).isNotNull
+        }
+
+        private fun assertSubmissionFiles(accNo: String, testFile: String) {
+            val createdSubmission = submissionRepository.getExtendedByAccNo(accNo)
+            val submissionFolderPath = "$basePath/submission/${createdSubmission.relPath}"
+
+            assertThat(createdSubmission.section.libraryFile).isEqualTo("$accNo.SECT-001.files")
+
+            assertThat(Paths.get("$submissionFolderPath/Files/$testFile")).exists()
+
+            assertThat(Paths.get("$submissionFolderPath/$accNo.SECT-001.files.tsv")).exists()
+            assertThat(Paths.get("$submissionFolderPath/$accNo.SECT-001.files.xml")).exists()
+            assertThat(Paths.get("$submissionFolderPath/$accNo.SECT-001.files.json")).exists()
         }
     }
 }

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/service/SubmissionService.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/service/SubmissionService.kt
@@ -40,6 +40,7 @@ class SubmissionService(
     fun submit(
         submission: Submission,
         user: User,
-        files: List<ResourceFile> = emptyList()
-    ) = submitter.submit(ExtendedSubmission(submission, user), files, persistenceContext)
+        files: List<ResourceFile> = emptyList(),
+        format: SubFormat
+    ) = submitter.submit(ExtendedSubmission(submission, user), files, persistenceContext, format)
 }

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/web/MultipartSubmissionResource.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/web/MultipartSubmissionResource.kt
@@ -38,7 +38,8 @@ class MultipartSubmissionResource(
         @AuthenticationPrincipal user: User,
         @RequestParam(FILES) files: Array<MultipartFile>,
         @RequestParam(SUBMISSION) submission: String
-    ) = submissionService.submit(serializationService.deserializeSubmission(submission, JSON), user, getFiles(files))
+    ) = submissionService.submit(
+        serializationService.deserializeSubmission(submission, JSON), user, getFiles(files), JSON)
 
     @PostMapping(headers = ["$CONTENT_TYPE=$MULTIPART_FORM_DATA", "$SUBMISSION_TYPE=$TEXT_XML"])
     @ResponseBody
@@ -46,7 +47,8 @@ class MultipartSubmissionResource(
         @AuthenticationPrincipal user: User,
         @RequestParam(FILES) files: Array<MultipartFile>,
         @RequestParam(SUBMISSION) submission: String
-    ) = submissionService.submit(serializationService.deserializeSubmission(submission, XML), user, getFiles(files))
+    ) = submissionService.submit(
+        serializationService.deserializeSubmission(submission, XML), user, getFiles(files), XML)
 
     @PostMapping(headers = ["$CONTENT_TYPE=$MULTIPART_FORM_DATA", "$SUBMISSION_TYPE=$TEXT_PLAIN"])
     @ResponseBody
@@ -54,7 +56,8 @@ class MultipartSubmissionResource(
         @AuthenticationPrincipal user: User,
         @RequestParam(FILES) files: Array<MultipartFile>,
         @RequestParam(SUBMISSION) submission: String
-    ) = submissionService.submit(serializationService.deserializeSubmission(submission, TSV), user, getFiles(files))
+    ) = submissionService.submit(
+        serializationService.deserializeSubmission(submission, TSV), user, getFiles(files), TSV)
 
     private fun getFiles(files: Array<MultipartFile>) =
             files.map { ResourceFile(it.originalFilename!!, it.inputStream, it.size) }

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/web/SubmissionResource.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/web/SubmissionResource.kt
@@ -1,5 +1,6 @@
 package ac.uk.ebi.biostd.submission.web
 
+import ac.uk.ebi.biostd.SubFormat
 import ac.uk.ebi.biostd.submission.service.SubmissionService
 import ebi.ac.uk.model.Submission
 import ebi.ac.uk.model.User
@@ -38,10 +39,20 @@ class SubmissionResource(
     @GetMapping("/{accNo}.tsv", produces = [TEXT_PLAIN])
     fun asTsv(@PathVariable accNo: String) = submissionService.getSubmissionAsTsv(accNo)
 
-    @PostMapping
+    @PostMapping(headers = ["$SUBMISSION_TYPE=$APPLICATION_JSON"])
     @ResponseBody
-    fun submit(@AuthenticationPrincipal user: User, @RequestBody submission: Submission) =
-        submissionService.submit(submission, user)
+    fun submitJson(@AuthenticationPrincipal user: User, @RequestBody submission: Submission) =
+        submissionService.submit(submission, user, format = SubFormat.JSON)
+
+    @PostMapping(headers = ["$SUBMISSION_TYPE=$TEXT_XML"])
+    @ResponseBody
+    fun submitXml(@AuthenticationPrincipal user: User, @RequestBody submission: Submission) =
+        submissionService.submit(submission, user, format = SubFormat.XML)
+
+    @PostMapping(headers = ["$SUBMISSION_TYPE=$TEXT_PLAIN"])
+    @ResponseBody
+    fun submitTsv(@AuthenticationPrincipal user: User, @RequestBody submission: Submission) =
+        submissionService.submit(submission, user, format = SubFormat.TSV)
 
     @DeleteMapping("/{accNo}")
     fun deleteSubmission(@AuthenticationPrincipal user: User, @PathVariable accNo: String) =

--- a/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/SubmissionSubmitter.kt
+++ b/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/SubmissionSubmitter.kt
@@ -1,5 +1,6 @@
 package ac.uk.ebi.biostd.submission
 
+import ac.uk.ebi.biostd.SubFormat
 import ac.uk.ebi.biostd.submission.handlers.FilesHandler
 import ac.uk.ebi.biostd.submission.model.ResourceFile
 import ac.uk.ebi.biostd.submission.processors.SubmissionProcessor
@@ -16,11 +17,12 @@ class SubmissionSubmitter(
     fun submit(
         submission: ExtendedSubmission,
         files: List<ResourceFile> = emptyList(),
-        context: PersistenceContext
+        context: PersistenceContext,
+        format: SubFormat
     ): Submission {
         validators.forEach { validator -> validator.validate(submission, context) }
         processors.forEach { processor -> processor.process(submission, context) }
-        filesHandler.processFiles(submission, files)
+        filesHandler.processFiles(submission, files, format)
         context.saveSubmission(submission)
         return submission
     }

--- a/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/handlers/FilesHandler.kt
+++ b/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/handlers/FilesHandler.kt
@@ -1,5 +1,6 @@
 package ac.uk.ebi.biostd.submission.handlers
 
+import ac.uk.ebi.biostd.SubFormat
 import ac.uk.ebi.biostd.submission.model.ListFilesSource
 import ac.uk.ebi.biostd.submission.model.PathFilesSource
 import ac.uk.ebi.biostd.submission.model.ResourceFile
@@ -19,12 +20,12 @@ class FilesHandler(
      * In charge of generate submission json/tsv/xml representation files and validate all submission specified files
      * are provided or exists in  user repository or in the list of provided files.
      */
-    fun processFiles(submission: ExtendedSubmission, files: List<ResourceFile>) {
+    fun processFiles(submission: ExtendedSubmission, files: List<ResourceFile>, format: SubFormat) {
         val userFolder = folderResolver.getUserMagicFolderPath(submission.user.id, submission.user.secretKey)
         val fileSource = if (files.isEmpty()) PathFilesSource(userFolder) else ListFilesSource(files)
 
         filesValidator.validate(submission, fileSource)
-        libraryFilesHandler.processLibraryFiles(submission, fileSource)
+        libraryFilesHandler.processLibraryFiles(submission, fileSource, format)
         filesCopier.copy(submission, fileSource)
         outputFilesGenerator.generate(submission)
     }

--- a/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/handlers/LibraryFilesHandler.kt
+++ b/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/handlers/LibraryFilesHandler.kt
@@ -8,12 +8,10 @@ import ebi.ac.uk.model.FilesTable
 import ebi.ac.uk.model.extensions.allLibraryFileSections
 
 class LibraryFilesHandler(private val serializationService: SerializationService) {
-    fun processLibraryFiles(submission: ExtendedSubmission, filesSource: FilesSource) {
+    fun processLibraryFiles(submission: ExtendedSubmission, filesSource: FilesSource, format: SubFormat) {
         submission.allLibraryFileSections().forEach { section ->
             val libFileContent = filesSource.readText(section.libraryFile!!.name)
-
-            // TODO support for all formats
-            val filesTable = serializationService.deserializeElement<FilesTable>(libFileContent, SubFormat.TSV)
+            val filesTable = serializationService.deserializeElement<FilesTable>(libFileContent, format)
 
             filesTable.elements.forEach { section.addReferencedFile(it) }
         }

--- a/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/handlers/OutputFilesGenerator.kt
+++ b/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/handlers/OutputFilesGenerator.kt
@@ -5,6 +5,7 @@ import ac.uk.ebi.biostd.SubFormat
 import ebi.ac.uk.model.ExtendedSubmission
 import ebi.ac.uk.model.FilesTable
 import ebi.ac.uk.model.extensions.allLibraryFileSections
+import ebi.ac.uk.model.extensions.libraryFileAttr
 import ebi.ac.uk.paths.FolderResolver
 import org.apache.commons.io.FileUtils
 
@@ -13,8 +14,8 @@ class OutputFilesGenerator(
     private val serializationService: SerializationService
 ) {
     fun generate(submission: ExtendedSubmission) {
-        generateSubmissionFiles(submission)
         generateLibraryFiles(submission)
+        generateSubmissionFiles(submission)
     }
 
     private fun generateSubmissionFiles(submission: ExtendedSubmission) =
@@ -25,7 +26,8 @@ class OutputFilesGenerator(
             val libFileName = "${submission.accNo}.${it.accNo}.files"
             val filesTable = FilesTable(it.libraryFile!!.referencedFiles.toList())
 
-            it.libraryFile!!.name = "$libFileName.tsv"
+            it.libraryFileAttr = libFileName
+            it.libraryFile!!.name = libFileName
             generateOutputFiles(filesTable, submission, libFileName)
         }
 

--- a/submission/submitter/src/test/kotlin/ac/uk/ebi/biostd/submission/handlers/FilesHandlerTest.kt
+++ b/submission/submitter/src/test/kotlin/ac/uk/ebi/biostd/submission/handlers/FilesHandlerTest.kt
@@ -1,5 +1,6 @@
 package ac.uk.ebi.biostd.submission.handlers
 
+import ac.uk.ebi.biostd.SubFormat.JSON
 import ac.uk.ebi.biostd.submission.model.PathFilesSource
 import ac.uk.ebi.biostd.submission.test.ACC_NO
 import ac.uk.ebi.biostd.submission.test.USER_ID
@@ -54,19 +55,23 @@ class FilesHandlerTest(
     // TODO add unit tests for the individual processors
     @Test
     fun `process submission files`() {
-        testInstance.processFiles(submission, emptyList())
+        testInstance.processFiles(submission, emptyList(), JSON)
 
         verify(exactly = 1) { mockFilesCopier.copy(submission, any<PathFilesSource>()) }
         verify(exactly = 1) { mockFilesValidator.validate(submission, any<PathFilesSource>()) }
         verify(exactly = 1) { mockOutputFilesGenerator.generate(submission) }
-        verify(exactly = 1) { mockLibraryFilesHandler.processLibraryFiles(submission, any<PathFilesSource>()) }
+        verify(exactly = 1) { mockLibraryFilesHandler.processLibraryFiles(submission, any<PathFilesSource>(), JSON) }
     }
 
     private fun initMocks() {
         every { mockFilesCopier.copy(submission, any<PathFilesSource>()) } answers { nothing }
         every { mockFilesValidator.validate(submission, any<PathFilesSource>()) } answers { nothing }
         every { mockOutputFilesGenerator.generate(submission) } answers { nothing }
-        every { mockLibraryFilesHandler.processLibraryFiles(submission, any<PathFilesSource>()) } answers { nothing }
+
+        every {
+            mockLibraryFilesHandler.processLibraryFiles(submission, any<PathFilesSource>(), JSON)
+        } answers { nothing }
+
         every {
             mockFolderResolver.getUserMagicFolderPath(USER_ID, USER_SECRET_KEY)
         } returns Paths.get("${temporaryFolder.root.absolutePath}/$USER_SECRET_KEY")


### PR DESCRIPTION
- Add support for library file in all formats
- Use the extended section instead of the regular section for persistence
- Remove hardcoded library file in TSV format
- Fix library file name in the submission generated files