### PR TITLE
Fix: Pivotal ID # 168286132 - TSV Parent Acc No

### DIFF
--- a/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/ExtendedSection.kt
+++ b/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/ExtendedSection.kt
@@ -8,6 +8,7 @@ class ExtendedSection(type: String) : Section(type) {
 
     constructor(section: Section) : this(section.type) {
         accNo = section.accNo
+        parentAccNo = section.parentAccNo
         files = section.files
         links = section.links
         fileList = section.fileList
@@ -17,7 +18,7 @@ class ExtendedSection(type: String) : Section(type) {
             section.sections.mapTo(mutableListOf()) { subSection -> subSection.bimap({ ExtendedSection(it) }, { it }) }
     }
 
-    fun asSection() = Section(type, accNo, fileList, toSections(), files, links, attributes)
+    fun asSection() = Section(type, accNo, fileList, toSections(), files, links, attributes, parentAccNo)
 
     private fun toSections(): MutableList<Either<Section, SectionsTable>> =
         extendedSections.mapTo(mutableListOf()) { extSect -> extSect.bimap({ it.asSection() }, { it }) }
@@ -27,6 +28,7 @@ class ExtendedSection(type: String) : Section(type) {
         other === this -> true
         else -> Objects.equals(type, other.type)
             .and(Objects.equals(accNo, other.accNo))
+            .and(Objects.equals(parentAccNo, other.parentAccNo))
             .and(Objects.equals(files, other.files))
             .and(Objects.equals(links, other.links))
             .and(Objects.equals(sections, other.sections))
@@ -36,5 +38,5 @@ class ExtendedSection(type: String) : Section(type) {
     }
 
     override fun hashCode() =
-        Objects.hash(type, accNo, files, links, sections, attributes, fileList, extendedSections)
+        Objects.hash(type, accNo, parentAccNo, files, links, sections, attributes, fileList, extendedSections)
 }

--- a/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/Section.kt
+++ b/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/Section.kt
@@ -13,6 +13,8 @@ open class Section(
     var files: MutableList<Either<File, FilesTable>> = mutableListOf(),
     var links: MutableList<Either<Link, LinksTable>> = mutableListOf(),
     override var attributes: List<Attribute> = listOf(),
+
+    // TODO Pivotal ID #168381570: Remove Parent AccNo From Section Model
     var parentAccNo: String? = null
 ) : Attributable {
     fun addFile(file: File) = files.addLeft(file)

--- a/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/Section.kt
+++ b/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/Section.kt
@@ -15,10 +15,10 @@ open class Section(
     override var attributes: List<Attribute> = listOf(),
     var parentAccNo: String? = null
 ) : Attributable {
-
     fun addFile(file: File) = files.addLeft(file)
     fun addLink(link: Link) = links.addLeft(link)
-    fun addSection(section: Section) = sections.addLeft(section)
+    fun addSection(section: Section) = sections.addLeft(section.apply { parentAccNo = this@Section.accNo })
+
     fun addFilesTable(table: FilesTable) = files.addRight(table)
     fun addLinksTable(table: LinksTable) = links.addRight(table)
     fun addSectionTable(table: SectionsTable) = sections.addRight(table)

--- a/commons/commons-bio/src/test/kotlin/ebi/ac/uk/dsl/SubDslTest.kt
+++ b/commons/commons-bio/src/test/kotlin/ebi/ac/uk/dsl/SubDslTest.kt
@@ -60,7 +60,23 @@ class SubDslTest {
         }
 
         assertThat(section).isEqualTo(Section(
-            "Study", "SECT-001", sections = mutableListOf(Either.Right(SectionsTable(listOf(Section("Data", "DT-1")))))))
+            "Study",
+            "SECT-001",
+            sections = mutableListOf(Either.Right(SectionsTable(listOf(Section("Data", "DT-1")))))))
+    }
+
+    @Test
+    fun `section with inner subsections`() {
+        val section = section("Study") {
+            accNo = "SECT-001"
+            section("Data") { accNo = "DT-1" }
+        }
+        val expectedSection = Section(
+            "Study",
+            "SECT-001",
+            sections = mutableListOf(Either.Left(Section("Data", "DT-1", parentAccNo = "SECT-001"))))
+
+        assertThat(section).isEqualTo(expectedSection)
     }
 
     @Test

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/serialization/BuilderSecExtensions.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/serialization/BuilderSecExtensions.kt
@@ -7,9 +7,10 @@ import ebi.ac.uk.model.Link
 internal const val LINK_KEY = "Link"
 internal const val FILE_KEY = "File"
 
-internal fun TsvBuilder.addSecDescriptor(type: String, accNo: String?) {
+internal fun TsvBuilder.addSecDescriptor(type: String, accNo: String?, parentAccNo: String?) {
     append(type)
     accNo?.let { append("\t$accNo") }
+    parentAccNo?.let { append("\t$parentAccNo") }
     append("\n")
 }
 

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/serialization/TsvToStringSerializer.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/serialization/TsvToStringSerializer.kt
@@ -7,7 +7,6 @@ import ebi.ac.uk.model.Submission
 import ebi.ac.uk.model.Table
 
 class TsvToStringSerializer {
-
     fun <T> serialize(element: T): String {
         val builder = TsvBuilder()
 
@@ -30,7 +29,7 @@ class TsvToStringSerializer {
 
     private fun serializeSection(builder: TsvBuilder, section: Section) {
         builder.addSeparator()
-        builder.addSecDescriptor(section.type, section.accNo)
+        builder.addSecDescriptor(section.type, section.accNo, section.parentAccNo)
         section.attributes.forEach(builder::addAttr)
 
         section.links.forEach { either -> either.fold({ addLink(builder, it) }, { addTable(builder, it) }) }

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/serialization/TsvToStringSerializer.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/serialization/TsvToStringSerializer.kt
@@ -12,7 +12,10 @@ class TsvToStringSerializer {
 
         when (element) {
             is Submission -> serializeSubmission(builder, element as Submission)
-            is Section -> serializeSection(builder, element as Section)
+            is Section -> {
+                val section = element as Section
+                serializeSection(builder, section, section.parentAccNo)
+            }
             is File -> addFile(builder, element as File)
             is Link -> addLink(builder, element as Link)
             is Table<*> -> addTable(builder, element as Table<*>)
@@ -27,14 +30,16 @@ class TsvToStringSerializer {
         serializeSection(builder, submission.section)
     }
 
-    private fun serializeSection(builder: TsvBuilder, section: Section) {
+    private fun serializeSection(builder: TsvBuilder, section: Section, parentAccNo: String? = null) {
         builder.addSeparator()
-        builder.addSecDescriptor(section.type, section.accNo, section.parentAccNo)
+        builder.addSecDescriptor(section.type, section.accNo, parentAccNo)
         section.attributes.forEach(builder::addAttr)
 
         section.links.forEach { either -> either.fold({ addLink(builder, it) }, { addTable(builder, it) }) }
         section.files.forEach { either -> either.fold({ addFile(builder, it) }, { addTable(builder, it) }) }
-        section.sections.forEach { either -> either.fold({ serializeSection(builder, it) }) { addTable(builder, it) } }
+        section.sections.forEach {
+            either -> either.fold({ serializeSection(builder, it, section.accNo) }) { addTable(builder, it) }
+        }
     }
 
     private fun addFile(builder: TsvBuilder, file: File) {

--- a/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/test/SubTestFactory.kt
+++ b/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/test/SubTestFactory.kt
@@ -49,6 +49,7 @@ fun createVenousBloodMonocyte() = submission("S-IHECRE00000919.1") {
         }
 
         section("Stranded Total RNA-Seq") {
+            accNo = "SUB-SECT-001"
             filesTable {
                 file("Results.xls") {
                     attribute("Type", "Results File")

--- a/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/test/TsvTestFactory.kt
+++ b/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/test/TsvTestFactory.kt
@@ -89,6 +89,12 @@ fun submissionWithInnerSubsections() = submissionWithSubsection().apply {
     line()
 }
 
+fun submissionWithInvalidInnerSubsection() = submissionWithSubsection().apply {
+    line("Expense", "E-001", "F-002")
+    line("Description", "Travel")
+    line()
+}
+
 fun submissionWithInnerSubsectionsTable() = submissionWithSubsection().apply {
     line("Study", "S-001")
     line("Type", "Imaging")

--- a/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/tsv/SimpleSubmissionTsvParserTest.kt
+++ b/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/tsv/SimpleSubmissionTsvParserTest.kt
@@ -55,7 +55,7 @@ class SimpleSubmissionTsvParserTest {
             line("Type", "data")
             line()
 
-            line("Stranded Total RNA-Seq")
+            line("Stranded Total RNA-Seq", "SUB-SECT-001", "SECT-001")
             line()
 
             line("Links", "Type", "Assay type", "Experiment type", "Primary id")

--- a/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/tsv/TsvDeserializerTest.kt
+++ b/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/tsv/TsvDeserializerTest.kt
@@ -9,6 +9,7 @@ import ac.uk.ebi.biostd.test.submissionWithFilesTable
 import ac.uk.ebi.biostd.test.submissionWithInnerSubsections
 import ac.uk.ebi.biostd.test.submissionWithInnerSubsectionsTable
 import ac.uk.ebi.biostd.test.submissionWithInvalidAttribute
+import ac.uk.ebi.biostd.test.submissionWithInvalidInnerSubsection
 import ac.uk.ebi.biostd.test.submissionWithInvalidNameAttributeDetail
 import ac.uk.ebi.biostd.test.submissionWithInvalidValueAttributeDetail
 import ac.uk.ebi.biostd.test.submissionWithLinks
@@ -168,6 +169,13 @@ class TsvDeserializerTest {
                 attributes = listOf(
                     Attribute("Agency", "National Support Program of Japan"),
                     Attribute("Grant Id", "No. 2015BAD27A03"))))
+        }
+    }
+
+    @Test
+    fun `subsection with invalid parent`() {
+        assertThrows<SerializationException> {
+            deserializer.deserialize(submissionWithInvalidInnerSubsection().toString())
         }
     }
 

--- a/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/tsv/TsvDeserializerTest.kt
+++ b/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/tsv/TsvDeserializerTest.kt
@@ -153,7 +153,10 @@ class TsvDeserializerTest {
                     Attribute("Grant Id", "No. 2015BAD27B01")),
                 sections = mutableListOf(
                     Either.left(Section(
-                        accNo = "E-001", type = "Expense", attributes = listOf(Attribute("Description", "Travel"))))
+                        type = "Expense",
+                        accNo = "E-001",
+                        parentAccNo = "F-001",
+                        attributes = listOf(Attribute("Description", "Travel"))))
                 )))
         }
 

--- a/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/tsv/TsvToStringSerializerTest.kt
+++ b/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/tsv/TsvToStringSerializerTest.kt
@@ -73,6 +73,30 @@ class TsvToStringSerializerTest {
     }
 
     @Test
+    fun `serialize subsection`() {
+        val section = section("Study") {
+            accNo = "SECT-001"
+            attribute("Project", "Test Project")
+            section("Data") {
+                accNo = "DT-1"
+                attribute("Type", "data")
+            }
+        }
+
+        val expectedTsv = tsv {
+            line("Study", "SECT-001")
+            line("Project", "Test Project")
+            line()
+
+            line("Data", "DT-1", "SECT-001")
+            line("Type", "data")
+            line()
+        }.toString()
+
+        assertThat(testInstance.serialize(section)).isEqualToIgnoringNewLines(expectedTsv)
+    }
+
+    @Test
     fun `serialize subsections table`() {
         val section = section("Study") {
             accNo = "SECT-001"

--- a/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/mapping/SubmissionDbMapper.kt
+++ b/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/mapping/SubmissionDbMapper.kt
@@ -76,23 +76,21 @@ class SubmissionDbMapper {
 }
 
 private class DbSectionMapper {
-    internal fun toSection(sectionDb: SectionDb, parentAccNo: String? = null): Section =
+    internal fun toSection(sectionDb: SectionDb): Section =
         Section(accNo = sectionDb.accNo,
-            parentAccNo = parentAccNo,
             type = sectionDb.type,
             links = toLinks(sectionDb.links.toList()),
             fileList = sectionDb.fileList?.let { toFileList(it) },
             files = toFiles(sectionDb.files.toList()),
-            sections = toSections(sectionDb.sections.toList(), sectionDb.accNo),
+            sections = toSections(sectionDb.sections.toList()),
             attributes = toAttributes(sectionDb.attributes))
 
-    internal fun toExtendedSection(sectionDb: SectionDb, parentAccNo: String? = null) =
+    internal fun toExtendedSection(sectionDb: SectionDb) =
         ExtendedSection(sectionDb.type).apply {
             accNo = sectionDb.accNo
-            this.parentAccNo = parentAccNo
             links = toLinks(sectionDb.links.toList())
             files = toFiles(sectionDb.files.toList())
-            sections = toSections(sectionDb.sections.toList(), sectionDb.accNo)
+            sections = toSections(sectionDb.sections.toList())
             attributes = toAttributes(sectionDb.attributes)
             extendedSections = toExtendedSections(sectionDb.sections.toList())
             sectionDb.fileList?.let { fileList = toFileList(it) }
@@ -103,17 +101,11 @@ private object DbEitherMapper {
     internal fun toLinks(links: List<LinkDb>) = toEitherList(links, DbEntityMapper::toLink, ::LinksTable)
     internal fun toFiles(files: List<FileDb>) = toEitherList(files, DbEntityMapper::toFile, ::FilesTable)
 
-    internal fun toSections(
-        sections: List<SectionDb>,
-        parentAccNo: String? = null
-    ): MutableList<Either<Section, SectionsTable>> =
-        toEitherList(sections, { DbSectionMapper().toSection(it, parentAccNo) }, ::SectionsTable)
+    internal fun toSections(sections: List<SectionDb>): MutableList<Either<Section, SectionsTable>> =
+        toEitherList(sections, DbSectionMapper()::toSection, ::SectionsTable)
 
-    internal fun toExtendedSections(
-        sections: List<SectionDb>,
-        parentAccNo: String? = null
-    ): MutableList<Either<ExtendedSection, SectionsTable>> =
-        toEitherList(sections, { DbSectionMapper().toExtendedSection(it, parentAccNo) }, ::SectionsTable)
+    internal fun toExtendedSections(sections: List<SectionDb>): MutableList<Either<ExtendedSection, SectionsTable>> =
+        toEitherList(sections, DbSectionMapper()::toExtendedSection, ::SectionsTable)
 
     /**
      * Convert the given list of elements into an instance of @See [Either] using transform function for simple element

--- a/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/service/SubmissionRepository.kt
+++ b/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/service/SubmissionRepository.kt
@@ -10,8 +10,8 @@ class SubmissionRepository(
     fun getByAccNo(accNo: String) =
         submissionDbMapper.toSubmission(submissionRepository.getByAccNoAndVersionGreaterThan(accNo))
 
-    fun getExtendedByAccNo(accNo: String, loadRefFiles: Boolean = false) =
-        submissionDbMapper.toExtSubmission(submissionRepository.getByAccNoAndVersionGreaterThan(accNo), loadRefFiles)
+    fun getExtendedByAccNo(accNo: String) =
+        submissionDbMapper.toExtSubmission(submissionRepository.getByAccNoAndVersionGreaterThan(accNo))
 
     fun getExtendedLastVersionByAccNo(accNo: String) =
         submissionDbMapper.toExtSubmission(submissionRepository.getFirstByAccNoOrderByVersionDesc(accNo))

--- a/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/MultipartSubmissionApiTest.kt
+++ b/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/MultipartSubmissionApiTest.kt
@@ -253,7 +253,7 @@ internal class MultipartSubmissionApiTest(private val tempFolder: TemporaryFolde
 
         private fun assertSubmissionFiles(accNo: String, testFile: String) {
             val fileListName = "FileList"
-            val createdSubmission = submissionRepository.getExtendedByAccNo(accNo, loadRefFiles = true)
+            val createdSubmission = submissionRepository.getExtendedByAccNo(accNo)
             val submissionFolderPath = "$basePath/submission/${createdSubmission.relPath}"
 
             assertThat(createdSubmission.section.fileListName).isEqualTo(fileListName)

--- a/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/factory/TsvSubmissionFactory.kt
+++ b/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/factory/TsvSubmissionFactory.kt
@@ -115,7 +115,7 @@ fun assertAllInOneSubmissionTsv(tsv: String, accNo: String) {
 
     // TODO add parent acc no validation and subsections table validation after fixing Pivotal ID #168286132
     val expectedSubsection = tsv {
-        line("Stranded Total RNA-Seq", "SUBSECT-001")
+        line("Stranded Total RNA-Seq", "SUBSECT-001", "SECT-001")
         line()
     }
     assertTsvBlock(lines, 23, 24, expectedSubsection)


### PR DESCRIPTION
- Add parent accession number when adding a subsection
- Add parent accession to the TSV serialization
- Remove unnecessary "loadRefFiles" flag
- Improve unit tests