### PR TITLE
Pivotal-168424987: Add-support-for-multiline-values-in-tsv-formating

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -6,6 +6,7 @@ import TestVersions.JunitVersion
 import TestVersions.MockKVersion
 import TestVersions.XmlUnitVersion
 import Versions.CliKtVersion
+import Versions.CommonsCsvVersion
 import Versions.CommonsIOVersion
 import Versions.CommonsLang3Version
 import Versions.GuavaVersion
@@ -57,6 +58,7 @@ object Versions {
 
     const val CommonsLang3Version = "3.8.1"
     const val CommonsIOVersion = "2.6"
+    const val CommonsCsvVersion = "1.7"
     const val MySqlVersion = "6.0.6"
     const val XmlBuilderVersion = "1.4.2"
     const val WoodstoxVersion = "5.1.0"
@@ -139,6 +141,7 @@ object Dependencies {
     const val ArrowData = "io.arrow-kt:arrow-data:$KotlinArrowVersion"
 
     // Apache
+    const val CommonsCsv = "org.apache.commons:commons-csv:$CommonsCsvVersion"
     const val CommonsLang3 = "org.apache.commons:commons-lang3:$CommonsLang3Version"
     const val CommonsIO = "commons-io:commons-io:$CommonsIOVersion"
     const val Poi = "org.apache.poi:poi:$PoiVersion"

--- a/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/File.kt
+++ b/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/File.kt
@@ -1,6 +1,7 @@
 package ebi.ac.uk.model
 
-import java.util.Objects
+import java.util.Objects.equals
+import java.util.Objects.hash
 
 class File(
     var path: String,
@@ -11,10 +12,10 @@ class File(
         if (other !is File) return false
         if (this === other) return true
 
-        return Objects.equals(this.path, other.path)
-            .and(Objects.equals(this.size, other.size))
-            .and(Objects.equals(this.attributes, other.attributes))
+        return equals(this.path, other.path)
+            .and(equals(this.size, other.size))
+            .and(equals(this.attributes, other.attributes))
     }
 
-    override fun hashCode(): Int = Objects.hash(this.path, this.size, this.attributes)
+    override fun hashCode(): Int = hash(this.path, this.size, this.attributes)
 }

--- a/commons/commons-serialization/build.gradle
+++ b/commons/commons-serialization/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     compile(Woodstox)
     compile(Guava)
     compile(Arrow)
+    compile(CommonsCsv)
 
     testCompile(BaseTestCompileDependencies)
     testRuntime(BaseTestRuntimeDependencies)

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/Constants.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/Constants.kt
@@ -1,6 +1,5 @@
 package ac.uk.ebi.biostd.tsv
 
-internal const val TSV_SEPARATOR = "\t"
-internal val TSV_CHUNK_BREAK = "\r\n|\n".toRegex()
-internal const val TSV_COMMENT = "#"
+internal const val TAB = '\t'
+internal const val TSV_COMMENT = '#'
 internal const val SECTION_TABLE_OP = "["

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/TsvDeserializer.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/TsvDeserializer.kt
@@ -1,71 +1,35 @@
 package ac.uk.ebi.biostd.tsv.deserialization
 
-import ac.uk.ebi.biostd.tsv.TSV_CHUNK_BREAK
-import ac.uk.ebi.biostd.tsv.TSV_COMMENT
-import ac.uk.ebi.biostd.tsv.deserialization.model.FileChunk
-import ac.uk.ebi.biostd.tsv.deserialization.model.FileTableChunk
-import ac.uk.ebi.biostd.tsv.deserialization.model.LinkChunk
-import ac.uk.ebi.biostd.tsv.deserialization.model.LinksTableChunk
-import ac.uk.ebi.biostd.tsv.deserialization.model.RootSectionTableChunk
-import ac.uk.ebi.biostd.tsv.deserialization.model.RootSubSectionChunk
-import ac.uk.ebi.biostd.tsv.deserialization.model.SubSectionChunk
-import ac.uk.ebi.biostd.tsv.deserialization.model.SubSectionTableChunk
-import ac.uk.ebi.biostd.tsv.deserialization.model.TsvChunk
-import ac.uk.ebi.biostd.tsv.deserialization.model.TsvChunkLine
+import ac.uk.ebi.biostd.tsv.deserialization.chunks.ChunkProcessor
+import ac.uk.ebi.biostd.tsv.deserialization.chunks.TsvChunkGenerator
 import ac.uk.ebi.biostd.validation.InvalidChunkSizeException
-import ebi.ac.uk.base.like
 import ebi.ac.uk.model.Submission
-import ebi.ac.uk.model.constants.FileFields
-import ebi.ac.uk.model.constants.LinkFields
-import ebi.ac.uk.model.constants.SectionFields
-import ebi.ac.uk.model.constants.TABLE_REGEX
-import ebi.ac.uk.util.collections.findThird
 import ebi.ac.uk.util.collections.ifNotEmpty
-import ebi.ac.uk.util.collections.removeFirst
-import ebi.ac.uk.util.collections.split
-import ebi.ac.uk.util.regex.findGroup
 
-internal class TsvDeserializer(private val chunkProcessor: ChunkProcessor = ChunkProcessor()) {
+internal class TsvDeserializer(
+    private val chunkProcessor: ChunkProcessor = ChunkProcessor(),
+    private val chunkGenerator: TsvChunkGenerator = TsvChunkGenerator()) {
+
     fun deserialize(pageTab: String): Submission {
-        val chunks: MutableList<TsvChunk> = chunkerize(pageTab)
+        val chunks = chunkGenerator.chunks(pageTab)
         val context = TsvSerializationContext()
 
-        context.addSubmission(chunks.removeFirst()) { chunk -> chunkProcessor.getSubmission(chunk) }
+        context.addSubmission(chunks.poll()) { chunk -> chunkProcessor.getSubmission(chunk) }
         chunks.ifNotEmpty {
-            context.addRootSection(chunks.removeFirst()) { chunk -> chunkProcessor.getRootSection(chunk) }
+            context.addRootSection(chunks.poll()) { chunk -> chunkProcessor.getRootSection(chunk) }
             chunks.forEach { chunk -> chunkProcessor.processChunk(chunk, context) }
         }
 
         return context.getSubmission()
     }
 
-    fun <T> deserializeElement(pageTab: String, type: Class<out T>): T {
-        val chunks: MutableList<TsvChunk> = chunkerize(pageTab)
-        require(chunks.size == 1) { throw InvalidChunkSizeException() }
-
-        return type.cast(chunkProcessor.processIsolatedChunk(chunks.first()))
+    inline fun <reified T> deserializeElement(pageTab: String): T {
+        return deserializeElement(pageTab, T::class.java)
     }
 
-    private fun chunkerize(pagetab: String) =
-        pagetab.split(TSV_CHUNK_BREAK)
-            .filterNot { it.startsWith(TSV_COMMENT) }
-            .mapIndexed { index, line -> TsvChunkLine(index, line) }
-            .split { it.isEmpty() }
-            .mapTo(mutableListOf()) { createChunk(it) }
-
-    private fun createChunk(body: List<TsvChunkLine>): TsvChunk {
-        val header = body.first()
-        val type = header.first()
-
-        return when {
-            type like LinkFields.LINK -> LinkChunk(body)
-            type like FileFields.FILE -> FileChunk(body)
-            type like SectionFields.LINKS -> LinksTableChunk(body)
-            type like SectionFields.FILES -> FileTableChunk(body)
-            type.matches(TABLE_REGEX) -> TABLE_REGEX.findGroup(type, 1).fold(
-                { RootSectionTableChunk(body) },
-                { SubSectionTableChunk(body, it) })
-            else -> header.findThird().fold({ RootSubSectionChunk(body) }, { SubSectionChunk(body, it) })
-        }
+    fun <T> deserializeElement(pageTab: String, type: Class<out T>): T {
+        val chunks = chunkGenerator.chunks(pageTab)
+        require(chunks.size == 1) { throw InvalidChunkSizeException() }
+        return type.cast(chunkProcessor.processIsolatedChunk(chunks.poll()))
     }
 }

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/TsvDeserializer.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/TsvDeserializer.kt
@@ -8,8 +8,8 @@ import ebi.ac.uk.util.collections.ifNotEmpty
 
 internal class TsvDeserializer(
     private val chunkProcessor: ChunkProcessor = ChunkProcessor(),
-    private val chunkGenerator: TsvChunkGenerator = TsvChunkGenerator()) {
-
+    private val chunkGenerator: TsvChunkGenerator = TsvChunkGenerator()
+) {
     fun deserialize(pageTab: String): Submission {
         val chunks = chunkGenerator.chunks(pageTab)
         val context = TsvSerializationContext()

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/chunks/ChunkProcessor.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/chunks/ChunkProcessor.kt
@@ -1,5 +1,6 @@
-package ac.uk.ebi.biostd.tsv.deserialization
+package ac.uk.ebi.biostd.tsv.deserialization.chunks
 
+import ac.uk.ebi.biostd.tsv.deserialization.TsvSerializationContext
 import ac.uk.ebi.biostd.tsv.deserialization.common.findId
 import ac.uk.ebi.biostd.tsv.deserialization.common.getType
 import ac.uk.ebi.biostd.tsv.deserialization.common.getTypeOrElse

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/chunks/TsvChunkGenerator.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/chunks/TsvChunkGenerator.kt
@@ -26,7 +26,7 @@ import org.apache.commons.csv.CSVRecord
 import java.io.StringReader
 import java.util.Queue
 
-internal class TsvChunkGenerator {
+internal class TsvChunkGenerator(private val parser: CSVFormat = createParser()) {
     fun chunks(pagetab: String): Queue<TsvChunk> {
         return chunksLines(pagetab).split { it.isEmpty() }.mapTo(Lists.newLinkedList()) { createChunk(it) }
     }
@@ -46,15 +46,18 @@ internal class TsvChunkGenerator {
         }
     }
 
-    private fun chunksLines(pageTab: String): List<TsvChunkLine> {
-        val pp = CSVFormat.DEFAULT
-            .withDelimiter(TAB)
-            .withIgnoreSurroundingSpaces()
-            .withIgnoreEmptyLines(false)
-            .withCommentMarker(TSV_COMMENT)
-
-        return pp.parse(StringReader(pageTab)).mapIndexed { i, csvRecord -> TsvChunkLine(i, csvRecord.asList()) }
-    }
+    private fun chunksLines(pageTab: String): List<TsvChunkLine> =
+        parser.parse(StringReader(pageTab)).mapIndexed { i, csvRecord -> TsvChunkLine(i, csvRecord.asList()) }
 
     private fun CSVRecord.asList(): List<String> = map { it }
+
+    companion object {
+        private fun createParser(): CSVFormat {
+            return CSVFormat.DEFAULT
+                .withDelimiter(TAB)
+                .withIgnoreSurroundingSpaces()
+                .withIgnoreEmptyLines(false)
+                .withCommentMarker(TSV_COMMENT)
+        }
+    }
 }

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/chunks/TsvChunkGenerator.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/chunks/TsvChunkGenerator.kt
@@ -1,0 +1,60 @@
+package ac.uk.ebi.biostd.tsv.deserialization.chunks
+
+import ac.uk.ebi.biostd.tsv.TAB
+import ac.uk.ebi.biostd.tsv.TSV_COMMENT
+import ac.uk.ebi.biostd.tsv.deserialization.model.FileChunk
+import ac.uk.ebi.biostd.tsv.deserialization.model.FileTableChunk
+import ac.uk.ebi.biostd.tsv.deserialization.model.LinkChunk
+import ac.uk.ebi.biostd.tsv.deserialization.model.LinksTableChunk
+import ac.uk.ebi.biostd.tsv.deserialization.model.RootSectionTableChunk
+import ac.uk.ebi.biostd.tsv.deserialization.model.RootSubSectionChunk
+import ac.uk.ebi.biostd.tsv.deserialization.model.SubSectionChunk
+import ac.uk.ebi.biostd.tsv.deserialization.model.SubSectionTableChunk
+import ac.uk.ebi.biostd.tsv.deserialization.model.TsvChunk
+import ac.uk.ebi.biostd.tsv.deserialization.model.TsvChunkLine
+import com.google.common.collect.Lists
+import ebi.ac.uk.base.like
+import ebi.ac.uk.model.constants.FileFields
+import ebi.ac.uk.model.constants.LinkFields
+import ebi.ac.uk.model.constants.SectionFields
+import ebi.ac.uk.model.constants.TABLE_REGEX
+import ebi.ac.uk.util.collections.findThird
+import ebi.ac.uk.util.collections.split
+import ebi.ac.uk.util.regex.findGroup
+import org.apache.commons.csv.CSVFormat
+import org.apache.commons.csv.CSVRecord
+import java.io.StringReader
+import java.util.Queue
+
+internal class TsvChunkGenerator {
+    fun chunks(pagetab: String): Queue<TsvChunk> {
+        return chunksLines(pagetab).split { it.isEmpty() }.mapTo(Lists.newLinkedList()) { createChunk(it) }
+    }
+
+    private fun createChunk(body: List<TsvChunkLine>): TsvChunk {
+        val header = body.first()
+        val type = header.first()
+
+        return when {
+            type like LinkFields.LINK -> LinkChunk(body)
+            type like FileFields.FILE -> FileChunk(body)
+            type like SectionFields.LINKS -> LinksTableChunk(body)
+            type like SectionFields.FILES -> FileTableChunk(body)
+            type.matches(TABLE_REGEX) -> TABLE_REGEX.findGroup(type, 1)
+                .fold({ RootSectionTableChunk(body) }, { SubSectionTableChunk(body, it) })
+            else -> header.findThird().fold({ RootSubSectionChunk(body) }, { SubSectionChunk(body, it) })
+        }
+    }
+
+    private fun chunksLines(pageTab: String): List<TsvChunkLine> {
+        val pp = CSVFormat.DEFAULT
+            .withDelimiter(TAB)
+            .withIgnoreSurroundingSpaces()
+            .withIgnoreEmptyLines(false)
+            .withCommentMarker(TSV_COMMENT)
+
+        return pp.parse(StringReader(pageTab)).mapIndexed { i, csvRecord -> TsvChunkLine(i, csvRecord.asList()) }
+    }
+
+    private fun CSVRecord.asList(): List<String> = map { it }
+}

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/model/TsvChunkLine.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/model/TsvChunkLine.kt
@@ -1,14 +1,12 @@
 package ac.uk.ebi.biostd.tsv.deserialization.model
 
-import ac.uk.ebi.biostd.tsv.TSV_SEPARATOR
 import ebi.ac.uk.base.EMPTY
 import ebi.ac.uk.util.collections.findSecond
 
 class TsvChunkLine(
     val index: Int,
-    val body: String,
-    private val rawLines: List<String> = body.split(TSV_SEPARATOR),
-    private val lines: List<String> = body.split(TSV_SEPARATOR).filter(String::isNotBlank)
+    val rawLines: List<String>,
+    private val lines: List<String> = rawLines.filter(String::isNotBlank)
 ) : List<String> by lines {
 
     val value: String

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/stream/FileListTsvStreamDeserializer.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/stream/FileListTsvStreamDeserializer.kt
@@ -9,7 +9,7 @@ internal class FileListTsvStreamDeserializer {
         val reader = file.inputStream().bufferedReader()
         val deserializer = FilesTableTsvStreamDeserializer(reader.readLine().split(TAB))
         val filesList = reader.useLines {
-            it.mapIndexed { i, line -> deserializer.deserializeRow(i, line.split(TAB)) }.toList()
+            it.mapIndexed { idx, line -> deserializer.deserializeRow(idx, line.split(TAB)) }.toList()
         }
         return FileList(file.name, filesList)
     }

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/stream/FileListTsvStreamDeserializer.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/stream/FileListTsvStreamDeserializer.kt
@@ -1,19 +1,16 @@
 package ac.uk.ebi.biostd.tsv.deserialization.stream
 
+import ac.uk.ebi.biostd.tsv.TAB
 import ebi.ac.uk.model.FileList
 import java.io.File
 
 internal class FileListTsvStreamDeserializer {
     fun deserialize(file: File): FileList {
         val reader = file.inputStream().bufferedReader()
-        val deserializer = FilesTableTsvStreamDeserializer(reader.readLine())
-
+        val deserializer = FilesTableTsvStreamDeserializer(reader.readLine().split(TAB))
         val filesList = reader.useLines {
-            return@useLines it.mapIndexed { idx, line -> deserializer.deserializeRow(line, idx) }.toList()
+            it.mapIndexed { i, line -> deserializer.deserializeRow(i, line.split(TAB)) }.toList()
         }
-
-        reader.close()
-
         return FileList(file.name, filesList)
     }
 }

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/stream/FilesTableTsvStreamDeserializer.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/stream/FilesTableTsvStreamDeserializer.kt
@@ -5,10 +5,10 @@ import ac.uk.ebi.biostd.validation.InvalidElementException
 import ebi.ac.uk.model.Attribute
 import ebi.ac.uk.model.File
 
-internal class FilesTableTsvStreamDeserializer(pageTabHeader: String) {
+internal class FilesTableTsvStreamDeserializer(pageTabHeader: List<String>) {
     var header = TsvChunkLine(0, pageTabHeader)
 
-    fun deserializeRow(row: String, index: Int = 0): File {
+    fun deserializeRow(index: Int, row: List<String>): File {
         val fields = TsvChunkLine(index, row)
         return File(fields.name, attributes = buildAttributes(fields))
     }

--- a/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/test/TsvTestFactory.kt
+++ b/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/test/TsvTestFactory.kt
@@ -11,6 +11,11 @@ fun basicSubmission() = tsv {
     line()
 }
 
+fun basicSubmissionWithMultiline() = tsv {
+    line("Submission", "S-EPMC123")
+    line("Title", "\"This is a really long title \n with a break line\"")
+}
+
 fun basicSubmissionWithComments() = tsv {
     line("# This is a test submission")
     line("Submission", "S-EPMC123")
@@ -57,6 +62,19 @@ fun submissionWithRootSection() = tsv {
     line("Submission", "S-EPMC125")
     line("Title", "Test Submission")
     line()
+
+    line("Study")
+    line("Title", "Test Root Section")
+    line("Abstract", "Test abstract")
+    line()
+}
+
+fun submissionWithMultipleLineBreaks() = tsv {
+    line("Submission", "S-EPMC125")
+    line("Title", "Test Submission")
+    line()
+    line()
+    line("", "")
 
     line("Study")
     line("Title", "Test Root Section")

--- a/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/tsv/TsvDeserializerTest.kt
+++ b/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/tsv/TsvDeserializerTest.kt
@@ -178,7 +178,10 @@ class TsvDeserializerTest {
                         Attribute("Grant Id", "No. 2015BAD27B01")),
                     sections = mutableListOf(
                         Either.left(Section(
-                            accNo = "E-001", type = "Expense", attributes = listOf(Attribute("Description", "Travel"))))
+                            type = "Expense",
+                            accNo = "E-001",
+                            parentAccNo = "F-001",
+                            attributes = listOf(Attribute("Description", "Travel"))))
                     )))
             }
 
@@ -365,6 +368,13 @@ class TsvDeserializerTest {
 
         @Nested
         inner class NegativeTestCases {
+            @Test
+            fun `subsection with invalid parent`() {
+                assertThrows<SerializationException> {
+                    deserializer.deserialize(submissionWithInvalidInnerSubsection().toString())
+                }
+            }
+
             @Test
             fun `invalid single element`() {
                 val tsv = tsv {

--- a/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/tsv/TsvDeserializerTest.kt
+++ b/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/tsv/TsvDeserializerTest.kt
@@ -3,6 +3,7 @@ package ac.uk.ebi.biostd.tsv
 import ac.uk.ebi.biostd.common.assertAttributes
 import ac.uk.ebi.biostd.test.basicSubmission
 import ac.uk.ebi.biostd.test.basicSubmissionWithComments
+import ac.uk.ebi.biostd.test.basicSubmissionWithMultiline
 import ac.uk.ebi.biostd.test.submissionWithDetailedAttributes
 import ac.uk.ebi.biostd.test.submissionWithFiles
 import ac.uk.ebi.biostd.test.submissionWithFilesTable
@@ -13,13 +14,13 @@ import ac.uk.ebi.biostd.test.submissionWithInvalidNameAttributeDetail
 import ac.uk.ebi.biostd.test.submissionWithInvalidValueAttributeDetail
 import ac.uk.ebi.biostd.test.submissionWithLinks
 import ac.uk.ebi.biostd.test.submissionWithLinksTable
+import ac.uk.ebi.biostd.test.submissionWithMultipleLineBreaks
 import ac.uk.ebi.biostd.test.submissionWithRootSection
 import ac.uk.ebi.biostd.test.submissionWithSectionsTable
 import ac.uk.ebi.biostd.test.submissionWithSubsection
 import ac.uk.ebi.biostd.test.submissionWithTableWithMoreAttributes
 import ac.uk.ebi.biostd.test.submissionWithTableWithNoRows
 import ac.uk.ebi.biostd.tsv.deserialization.TsvDeserializer
-import ac.uk.ebi.biostd.validation.INVALID_TABLE_ROW
 import ac.uk.ebi.biostd.validation.InvalidChunkSizeException
 import ac.uk.ebi.biostd.validation.InvalidElementException
 import ac.uk.ebi.biostd.validation.MISPLACED_ATTR_NAME
@@ -31,6 +32,7 @@ import arrow.core.Either
 import ebi.ac.uk.asserts.assertSingleElement
 import ebi.ac.uk.asserts.assertSubmission
 import ebi.ac.uk.asserts.assertTable
+import ebi.ac.uk.dsl.Tsv
 import ebi.ac.uk.dsl.line
 import ebi.ac.uk.dsl.tsv
 import ebi.ac.uk.model.Attribute
@@ -46,368 +48,393 @@ import ebi.ac.uk.util.collections.ifLeft
 import ebi.ac.uk.util.collections.ifRight
 import ebi.ac.uk.util.collections.second
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
-// TODO: refactor this to use group or organize somehow!
 class TsvDeserializerTest {
     private val deserializer = TsvDeserializer()
 
-    @Test
-    fun `basic submission`() {
-        val submission: Submission = deserializer.deserialize(basicSubmission().toString())
+    @Nested
+    inner class SubmissionTestCases {
+        @Test
+        fun `basic submission`() {
+            val submission: Submission = deserializer.deserialize(basicSubmission().toString())
 
-        assertSubmission(
-            submission,
-            "S-EPMC123",
-            Attribute("Title", "Basic Submission"),
-            Attribute("DataSource", "EuropePMC"),
-            Attribute("AttachTo", "EuropePMC"))
-    }
-
-    @Test
-    fun `basic submission with comments`() {
-        val submission: Submission = deserializer.deserialize(basicSubmissionWithComments().toString())
-
-        assertSubmission(
-            submission,
-            "S-EPMC123",
-            Attribute("Title", "Basic Submission"),
-            Attribute("DataSource", "EuropePMC"),
-            Attribute("AttachTo", "EuropePMC"))
-    }
-
-    @Test
-    fun `detailed attributes`() {
-        val submission: Submission = deserializer.deserialize(submissionWithDetailedAttributes().toString())
-        val detailedAttribute = Attribute(
-            "Submission Type",
-            "RNA-seq of non coding RNA",
-            false,
-            mutableListOf(AttributeDetail("Seq Type", "RNA")),
-            mutableListOf(AttributeDetail("Ontology", "EFO")))
-
-        assertSubmission(
-            submission,
-            "S-EPMC124",
-            Attribute("Title", "Submission With Detailed Attributes"),
-            detailedAttribute,
-            Attribute("affiliation", "EuropePMC", true))
-    }
-
-    @Test
-    fun `submission with root section`() {
-        val submission: Submission = deserializer.deserialize(submissionWithRootSection().toString())
-
-        assertSubmission(submission, "S-EPMC125", Attribute("Title", "Test Submission"))
-        assertThat(submission.section).isEqualTo(Section(
-            type = "Study",
-            attributes = listOf(Attribute("Title", "Test Root Section"), Attribute("Abstract", "Test abstract"))
-        ))
-    }
-
-    @Test
-    fun `submission with sections table`() {
-        val submission: Submission = deserializer.deserialize(submissionWithSectionsTable().toString())
-
-        assertThat(submission.section.sections).hasSize(1)
-        assertTable(
-            submission.section.sections.first(),
-            Section(
-                accNo = "DT-1",
-                type = "Data",
-                attributes = listOf(Attribute("Title", "Data 1"), Attribute("Desc", "Group 1"))),
-            Section(
-                accNo = "DT-2",
-                type = "Data",
-                attributes = listOf(Attribute("Title", "Data 2"), Attribute("Desc", "Group 2"))))
-    }
-
-    @Test
-    fun subsection() {
-        val submission: Submission = deserializer.deserialize(submissionWithSubsection().toString())
-
-        assertThat(submission.section.sections).hasSize(1)
-        assertSingleElement(
-            submission.section.sections.first(),
-            Section(
-                accNo = "F-001",
-                type = "Funding",
-                attributes = listOf(
-                    Attribute("Agency", "National Support Program of China"),
-                    Attribute("Grant Id", "No. 2015BAD27B01"))))
-    }
-
-    @Test
-    fun `inner subsections`() {
-        val submission: Submission = deserializer.deserialize(submissionWithInnerSubsections().toString())
-
-        assertThat(submission.section.sections).hasSize(2)
-        submission.section.sections.first().ifLeft { section ->
-            assertThat(section.sections).hasSize(1)
-            assertThat(section).isEqualTo(Section(
-                accNo = "F-001",
-                type = "Funding",
-                attributes = listOf(
-                    Attribute("Agency", "National Support Program of China"),
-                    Attribute("Grant Id", "No. 2015BAD27B01")),
-                sections = mutableListOf(
-                    Either.left(Section(
-                        accNo = "E-001", type = "Expense", attributes = listOf(Attribute("Description", "Travel"))))
-                )))
+            assertSubmission(
+                submission,
+                "S-EPMC123",
+                Attribute("Title", "Basic Submission"),
+                Attribute("DataSource", "EuropePMC"),
+                Attribute("AttachTo", "EuropePMC"))
         }
 
-        submission.section.sections.second().ifLeft { section ->
-            assertThat(section.sections).isEmpty()
-            assertThat(section).isEqualTo(Section(
-                accNo = "F-002",
-                type = "Funding",
-                attributes = listOf(
-                    Attribute("Agency", "National Support Program of Japan"),
-                    Attribute("Grant Id", "No. 2015BAD27A03"))))
-        }
-    }
+        @Test
+        fun `basic submission with comments`() {
+            val submission: Submission = deserializer.deserialize(basicSubmissionWithComments().toString())
 
-    @Test
-    fun `inner subsections table`() {
-        val submission: Submission = deserializer.deserialize(submissionWithInnerSubsectionsTable().toString())
-        assertThat(submission.section.sections).hasSize(2)
-
-        submission.section.sections.first().ifLeft { section ->
-            assertThat(section.sections).isEmpty()
-            assertThat(section).isEqualTo(Section(
-                accNo = "F-001",
-                type = "Funding",
-                attributes = listOf(
-                    Attribute("Agency", "National Support Program of China"),
-                    Attribute("Grant Id", "No. 2015BAD27B01"))))
+            assertSubmission(
+                submission,
+                "S-EPMC123",
+                Attribute("Title", "Basic Submission"),
+                Attribute("DataSource", "EuropePMC"),
+                Attribute("AttachTo", "EuropePMC"))
         }
 
-        submission.section.sections.second().ifLeft { section ->
-            assertThat(section.sections).hasSize(1)
+        @Test
+        fun `submission with multiline attribute value`() {
+            val submission: Submission = deserializer.deserialize(basicSubmissionWithMultiline().toString())
 
-            assertThat(section).isEqualTo(
+            assertSubmission(
+                submission,
+                "S-EPMC123",
+                Attribute("Title", "This is a really long title \n with a break line"))
+        }
+
+        @Test
+        fun `detailed attributes`() {
+            val submission: Submission = deserializer.deserialize(submissionWithDetailedAttributes().toString())
+            val detailedAttribute = Attribute(
+                "Submission Type",
+                "RNA-seq of non coding RNA",
+                false,
+                mutableListOf(AttributeDetail("Seq Type", "RNA")),
+                mutableListOf(AttributeDetail("Ontology", "EFO")))
+
+            assertSubmission(
+                submission,
+                "S-EPMC124",
+                Attribute("Title", "Submission With Detailed Attributes"),
+                detailedAttribute,
+                Attribute("affiliation", "EuropePMC", true))
+        }
+
+        @Test
+        fun `submission with root section`() {
+            val submission: Submission = deserializer.deserialize(submissionWithRootSection().toString())
+
+            assertSubmission(submission, "S-EPMC125", Attribute("Title", "Test Submission"))
+            assertThat(submission.section).isEqualTo(Section(
+                type = "Study",
+                attributes = listOf(Attribute("Title", "Test Root Section"), Attribute("Abstract", "Test abstract"))
+            ))
+        }
+
+        @Test
+        fun `submission with multiple line breaks`() {
+            val submission: Submission = deserializer.deserialize(submissionWithMultipleLineBreaks().toString())
+
+            assertSubmission(submission, "S-EPMC125", Attribute("Title", "Test Submission"))
+            assertThat(submission.section).isEqualTo(Section(
+                type = "Study",
+                attributes = listOf(Attribute("Title", "Test Root Section"), Attribute("Abstract", "Test abstract"))
+            ))
+        }
+
+        @Test
+        fun `submission with sections table`() {
+            val submission: Submission = deserializer.deserialize(submissionWithSectionsTable().toString())
+
+            assertThat(submission.section.sections).hasSize(1)
+            assertTable(
+                submission.section.sections.first(),
                 Section(
-                    accNo = "S-001",
-                    type = "Study",
-                    attributes = listOf(Attribute("Type", "Imaging")),
+                    accNo = "DT-1",
+                    type = "Data",
+                    attributes = listOf(Attribute("Title", "Data 1"), Attribute("Desc", "Group 1"))),
+                Section(
+                    accNo = "DT-2",
+                    type = "Data",
+                    attributes = listOf(Attribute("Title", "Data 2"), Attribute("Desc", "Group 2"))))
+        }
+
+        @Test
+        fun subsection() {
+            val submission: Submission = deserializer.deserialize(submissionWithSubsection().toString())
+
+            assertThat(submission.section.sections).hasSize(1)
+            assertSingleElement(
+                submission.section.sections.first(),
+                Section(
+                    accNo = "F-001",
+                    type = "Funding",
+                    attributes = listOf(
+                        Attribute("Agency", "National Support Program of China"),
+                        Attribute("Grant Id", "No. 2015BAD27B01"))))
+        }
+
+        @Test
+        fun `inner subsections`() {
+            val submission: Submission = deserializer.deserialize(submissionWithInnerSubsections().toString())
+
+            assertThat(submission.section.sections).hasSize(2)
+            submission.section.sections.first().ifLeft { section ->
+                assertThat(section.sections).hasSize(1)
+                assertThat(section).isEqualTo(Section(
+                    accNo = "F-001",
+                    type = "Funding",
+                    attributes = listOf(
+                        Attribute("Agency", "National Support Program of China"),
+                        Attribute("Grant Id", "No. 2015BAD27B01")),
                     sections = mutableListOf(
-                        Either.right(SectionsTable(listOf(
-                            Section(
-                                accNo = "SMP-1",
-                                type = "Sample",
-                                parentAccNo = "S-001",
-                                attributes = listOf(Attribute("Title", "Sample1"), Attribute("Desc", "Measure 1"))),
-                            Section(
-                                accNo = "SMP-2",
-                                type = "Sample",
-                                parentAccNo = "S-001",
-                                attributes = listOf(Attribute("Title", "Sample2"), Attribute("Desc", "Measure 2")))
-                        )))
+                        Either.left(Section(
+                            accNo = "E-001", type = "Expense", attributes = listOf(Attribute("Description", "Travel"))))
                     )))
+            }
+
+            submission.section.sections.second().ifLeft { section ->
+                assertThat(section.sections).isEmpty()
+                assertThat(section).isEqualTo(Section(
+                    accNo = "F-002",
+                    type = "Funding",
+                    attributes = listOf(
+                        Attribute("Agency", "National Support Program of Japan"),
+                        Attribute("Grant Id", "No. 2015BAD27A03"))))
+            }
+        }
+
+        @Test
+        fun `inner subsections table`() {
+            val submission: Submission = deserializer.deserialize(submissionWithInnerSubsectionsTable().toString())
+            assertThat(submission.section.sections).hasSize(2)
+
+            submission.section.sections.first().ifLeft { section ->
+                assertThat(section.sections).isEmpty()
+                assertThat(section).isEqualTo(Section(
+                    accNo = "F-001",
+                    type = "Funding",
+                    attributes = listOf(
+                        Attribute("Agency", "National Support Program of China"),
+                        Attribute("Grant Id", "No. 2015BAD27B01"))))
+            }
+
+            submission.section.sections.second().ifLeft { section ->
+                assertThat(section.sections).hasSize(1)
+
+                assertThat(section).isEqualTo(
+                    Section(
+                        accNo = "S-001",
+                        type = "Study",
+                        attributes = listOf(Attribute("Type", "Imaging")),
+                        sections = mutableListOf(
+                            Either.right(SectionsTable(listOf(
+                                Section(
+                                    accNo = "SMP-1",
+                                    type = "Sample",
+                                    parentAccNo = "S-001",
+                                    attributes = listOf(Attribute("Title", "Sample1"), Attribute("Desc", "Measure 1"))),
+                                Section(
+                                    accNo = "SMP-2",
+                                    type = "Sample",
+                                    parentAccNo = "S-001",
+                                    attributes = listOf(Attribute("Title", "Sample2"), Attribute("Desc", "Measure 2")))
+                            )))
+                        )))
+            }
+        }
+
+        @Test
+        fun links() {
+            val submission: Submission = deserializer.deserialize(submissionWithLinks().toString())
+
+            assertThat(submission.section.links).hasSize(2)
+            assertSingleElement(submission.section.links.first(), Link("http://arandomsite.org"))
+            assertSingleElement(submission.section.links.second(), Link("http://completelyunrelatedsite.org"))
+        }
+
+        @Test
+        fun `links table`() {
+            val submission: Submission = deserializer.deserialize(submissionWithLinksTable().toString())
+
+            assertThat(submission.section.links).hasSize(1)
+            assertTable(
+                submission.section.links.first(),
+                Link("AF069309", listOf(Attribute("Type", "gen"))),
+                Link("AF069123", listOf(Attribute("Type", "gen"))))
+        }
+
+        @Test
+        fun files() {
+            val submission: Submission = deserializer.deserialize(submissionWithFiles().toString())
+
+            assertThat(submission.section.files).hasSize(2)
+            submission.section.files.first().ifLeft { file -> assertFile(file, "12870_2017_1225_MOESM10_ESM.docx") }
+            submission.section.files.second().ifLeft { file -> assertFile(file, "12870_2017_1225_MOESM1_ESM.docx") }
+        }
+
+        @Test
+        fun `files table`() {
+            val submission: Submission = deserializer.deserialize(submissionWithFilesTable().toString())
+            assertThat(submission.section.files).hasSize(1)
+
+            submission.section.files.first().ifRight { filesTable ->
+                assertThat(filesTable.elements).hasSize(2)
+                assertFile(
+                    filesTable.elements.first(),
+                    "Abstract.pdf",
+                    Attribute("Description", "An abstract file"),
+                    Attribute("Usage", "Testing"))
+                assertFile(
+                    filesTable.elements.second(),
+                    "SuperImportantFile1.docx",
+                    Attribute("Description", "A super important file"),
+                    Attribute("Usage", "Important stuff"))
+            }
+        }
+
+        private fun assertFile(file: File, expectedName: String, vararg expectedAttributes: Attribute) {
+            assertThat(file.path).isEqualTo(expectedName)
+            assertAttributes(file.attributes, expectedAttributes)
         }
     }
 
-    @Test
-    fun links() {
-        val submission: Submission = deserializer.deserialize(submissionWithLinks().toString())
+    /**
+     * Contains single element deserialization test.
+     *
+     */
+    @Nested
+    inner class ElementDeserialization {
+        @Test
+        fun `single file`() {
+            val tsv = tsv {
+                line("File", "File1.txt")
+                line("Attr", "Value")
+                line()
+            }.toString()
 
-        assertThat(submission.section.links).hasSize(2)
-        assertSingleElement(submission.section.links.first(), Link("http://arandomsite.org"))
-        assertSingleElement(submission.section.links.second(), Link("http://completelyunrelatedsite.org"))
-    }
-
-    @Test
-    fun `links table`() {
-        val submission: Submission = deserializer.deserialize(submissionWithLinksTable().toString())
-
-        assertThat(submission.section.links).hasSize(1)
-        assertTable(
-            submission.section.links.first(),
-            Link("AF069309", listOf(Attribute("Type", "gen"))),
-            Link("AF069123", listOf(Attribute("Type", "gen"))))
-    }
-
-    @Test
-    fun files() {
-        val submission: Submission = deserializer.deserialize(submissionWithFiles().toString())
-
-        assertThat(submission.section.files).hasSize(2)
-        submission.section.files.first().ifLeft { file -> assertFile(file, "12870_2017_1225_MOESM10_ESM.docx") }
-        submission.section.files.second().ifLeft { file -> assertFile(file, "12870_2017_1225_MOESM1_ESM.docx") }
-    }
-
-    @Test
-    fun `files table`() {
-        val submission: Submission = deserializer.deserialize(submissionWithFilesTable().toString())
-        assertThat(submission.section.files).hasSize(1)
-
-        submission.section.files.first().ifRight { filesTable ->
-            assertThat(filesTable.elements).hasSize(2)
-            assertFile(
-                filesTable.elements.first(),
-                "Abstract.pdf",
-                Attribute("Description", "An abstract file"),
-                Attribute("Usage", "Testing"))
-            assertFile(
-                filesTable.elements.second(),
-                "SuperImportantFile1.docx",
-                Attribute("Description", "A super important file"),
-                Attribute("Usage", "Important stuff"))
+            val file = deserializer.deserializeElement(tsv, File::class.java)
+            assertThat(file).isEqualTo(File("File1.txt", attributes = listOf(Attribute("Attr", "Value"))))
         }
-    }
 
-    @Test
-    fun `single file`() {
-        val tsv = tsv {
-            line("File", "File1.txt")
-            line("Attr", "Value")
-            line()
-        }.toString()
+        @Test
+        fun `single files table`() {
+            val tsv = tsv {
+                line("Files", "Attr")
+                line("File1.txt", "Value")
+                line()
+            }.toString()
 
-        val file = deserializer.deserializeElement(tsv, File::class.java)
+            val filesTable = deserializer.deserializeElement<FilesTable>(tsv)
+            assertThat(filesTable).isEqualTo(
+                FilesTable(listOf(File("File1.txt", attributes = listOf(Attribute("Attr", "Value"))))))
+        }
 
-        assertThat(file).isEqualTo(File("File1.txt", attributes = listOf(Attribute("Attr", "Value"))))
-    }
+        @Test
+        fun `single link`() {
+            val tsv = tsv {
+                line("Link", "http://alink.org")
+                line("Attr", "Value")
+                line()
+            }.toString()
 
-    @Test
-    fun `single files table`() {
-        val tsv = tsv {
-            line("Files", "Attr")
-            line("File1.txt", "Value")
-            line()
-        }.toString()
+            val link = deserializer.deserializeElement<Link>(tsv)
+            assertThat(link).isEqualTo(Link("http://alink.org", attributes = listOf(Attribute("Attr", "Value"))))
+        }
 
-        val filesTable = deserializer.deserializeElement(tsv, FilesTable::class.java)
+        @Test
+        fun `single links table`() {
+            val tsv = tsv {
+                line("Links", "Attr")
+                line("http://alink.org", "Value")
+                line()
+            }.toString()
 
-        assertThat(filesTable).isEqualTo(
-            FilesTable(listOf(File("File1.txt", attributes = listOf(Attribute("Attr", "Value"))))))
-    }
+            val linksTable = deserializer.deserializeElement<LinksTable>(tsv)
+            assertThat(linksTable).isEqualTo(
+                LinksTable(listOf(Link("http://alink.org", attributes = listOf(Attribute("Attr", "Value"))))))
+        }
 
-    @Test
-    fun `single link`() {
-        val tsv = tsv {
-            line("Link", "http://alink.org")
-            line("Attr", "Value")
-            line()
-        }.toString()
+        @Test
+        fun `table containing a row with less attributes`() {
+            val tsv = tsv {
+                line("Links", "Attr1", "Attr2")
+                line("AF069307", "Value 1", "Value 2")
+                line("AF069308", "", "Value 2")
+                line("AF069309", "Value 1")
+                line()
+            }.toString()
 
-        val link = deserializer.deserializeElement(tsv, Link::class.java)
+            val linksTable = deserializer.deserializeElement<LinksTable>(tsv)
 
-        assertThat(link).isEqualTo(Link("http://alink.org", attributes = listOf(Attribute("Attr", "Value"))))
-    }
+            assertThat(linksTable).isEqualTo(
+                LinksTable(listOf(
+                    Link("AF069307", attributes = listOf(Attribute("Attr1", "Value 1"), Attribute("Attr2", "Value 2"))),
+                    Link("AF069308", attributes = listOf(Attribute("Attr2", "Value 2"))),
+                    Link("AF069309", attributes = listOf(Attribute("Attr1", "Value 1"))))))
+        }
 
-    @Test
-    fun `single links table`() {
-        val tsv = tsv {
-            line("Links", "Attr")
-            line("http://alink.org", "Value")
-            line()
-        }.toString()
+        @Nested
+        inner class NegativeTestCases {
+            @Test
+            fun `invalid single element`() {
+                val tsv = tsv {
+                    line("Submission", "S-BIAD2")
+                    line("Title", "A Title")
+                    line()
+                }.toString()
 
-        val linksTable = deserializer.deserializeElement(tsv, LinksTable::class.java)
+                assertThrows<NotImplementedError> { deserializer.deserializeElement<Submission>(tsv) }
+            }
 
-        assertThat(linksTable).isEqualTo(
-            LinksTable(listOf(Link("http://alink.org", attributes = listOf(Attribute("Attr", "Value"))))))
-    }
+            @Test
+            fun `invalid processing class`() {
+                val tsv = tsv {
+                    line("Links", "Attr")
+                    line("http://alink.org", "Value")
+                    line()
+                }.toString()
 
-    @Test
-    fun `table containing a row with less attributes`() {
-        val tsv = tsv {
-            line("Links", "Attr1", "Attr2")
-            line("AF069307", "Value 1", "Value 2")
-            line("AF069308", "", "Value 2")
-            line("AF069309", "Value 1")
-            line()
-        }.toString()
+                assertThrows<ClassCastException> { deserializer.deserializeElement<File>(tsv) }
+            }
 
-        val linksTable = deserializer.deserializeElement(tsv, LinksTable::class.java)
+            @Test
+            fun `empty single element`() {
+                assertThrows<InvalidChunkSizeException> { deserializer.deserializeElement<File>("") }
+            }
 
-        assertThat(linksTable).isEqualTo(
-            LinksTable(listOf(
-                Link("AF069307", attributes = listOf(Attribute("Attr1", "Value 1"), Attribute("Attr2", "Value 2"))),
-                Link("AF069308", attributes = listOf(Attribute("Attr2", "Value 2"))),
-                Link("AF069309", attributes = listOf(Attribute("Attr1", "Value 1"))))))
-    }
+            @Test
+            fun `invalid chunk size`() {
+                val tsv = tsv {
+                    line("Links", "Attr")
+                    line("http://alink.org", "Value")
+                    line()
 
-    @Test
-    fun `invalid single element`() {
-        val tsv = tsv {
-            line("Submission", "S-BIAD2")
-            line("Title", "A Title")
-            line()
-        }.toString()
+                    line("Links", "Attr")
+                    line("http://otherlink.org", "Value")
+                    line()
+                }.toString()
 
-        assertThrows<NotImplementedError> { deserializer.deserializeElement(tsv, Submission::class.java) }
-    }
+                assertThrows<InvalidChunkSizeException> { deserializer.deserializeElement<Link>(tsv) }
+            }
 
-    @Test
-    fun `invalid processing class`() {
-        val tsv = tsv {
-            line("Links", "Attr")
-            line("http://alink.org", "Value")
-            line()
-        }.toString()
+            @Test
+            fun `invalid attribute`() =
+                testInvalidElement(submissionWithInvalidAttribute(), REQUIRED_ATTR_VALUE)
 
-        assertThrows<ClassCastException> { deserializer.deserializeElement(tsv, File::class.java) }
-    }
+            @Test
+            fun `invalid name attribute detail`(): Unit =
+                testInvalidElement(submissionWithInvalidNameAttributeDetail(), MISPLACED_ATTR_NAME)
 
-    @Test
-    fun `empty single element`() {
-        assertThrows<InvalidChunkSizeException> { deserializer.deserializeElement("", File::class.java) }
-    }
+            @Test
+            fun `invalid value attribute detail`(): Unit =
+                testInvalidElement(submissionWithInvalidValueAttributeDetail(), MISPLACED_ATTR_VAL)
 
-    @Test
-    fun `invalid chunk size`() {
-        val tsv = tsv {
-            line("Links", "Attr")
-            line("http://alink.org", "Value")
-            line()
+            @Test
+            fun `table with no rows`(): Unit =
+                testInvalidElement(submissionWithTableWithNoRows(), REQUIRED_TABLE_ROWS)
 
-            line("Links", "Attr")
-            line("http://otherlink.org", "Value")
-            line()
-        }.toString()
+            @Test
+            fun `table with more attributes than expected`(): Unit = testInvalidElement(
+                submissionWithTableWithMoreAttributes(), "A row table can't have more attributes than the table header")
 
-        assertThrows<InvalidChunkSizeException> { deserializer.deserializeElement(tsv, Link::class.java) }
-    }
+            private fun testInvalidElement(submissionTsv: Tsv, expectedMessage: String) {
+                val exception = assertThrows<SerializationException> { deserializer.deserialize(submissionTsv.toString()) }
+                assertThat(exception.errors.values()).hasSize(1)
 
-    @Test
-    fun `invalid attribute`() =
-        assertInvalidElementException(
-            assertThrows { deserializer.deserialize(submissionWithInvalidAttribute().toString()) }, REQUIRED_ATTR_VALUE)
-
-    @Test
-    fun `invalid name attribute detail`() =
-        assertInvalidElementException(assertThrows {
-            deserializer.deserialize(submissionWithInvalidNameAttributeDetail().toString()) }, MISPLACED_ATTR_NAME)
-
-    @Test
-    fun `invalid value attribute detail`() =
-        assertInvalidElementException(assertThrows {
-            deserializer.deserialize(submissionWithInvalidValueAttributeDetail().toString()) }, MISPLACED_ATTR_VAL)
-
-    @Test
-    fun `table with no rows`() =
-        assertInvalidElementException(assertThrows {
-            deserializer.deserialize(submissionWithTableWithNoRows().toString()) }, REQUIRED_TABLE_ROWS)
-
-    @Test
-    fun `table with more attributes than expected`() =
-        assertInvalidElementException(
-            assertThrows { deserializer.deserialize(submissionWithTableWithMoreAttributes().toString()) },
-            String.format(INVALID_TABLE_ROW, 1, 2))
-
-    private fun assertInvalidElementException(exception: SerializationException, expectedMessage: String) {
-        assertThat(exception.errors.values()).hasSize(1)
-
-        val cause = exception.errors.values().first().cause
-        assertThat(cause).isInstanceOf(InvalidElementException::class.java)
-        assertThat(cause).hasMessage("$expectedMessage. Element was not created.")
-    }
-
-    private fun assertFile(file: File, expectedName: String, vararg expectedAttributes: Attribute) {
-        assertThat(file.path).isEqualTo(expectedName)
-        assertAttributes(file.attributes, expectedAttributes)
+                val cause = exception.errors.values().first().cause
+                assertThat(cause).isInstanceOf(InvalidElementException::class.java)
+                assertThat(cause).hasMessage("$expectedMessage. Element was not created.")
+            }
+        }
     }
 }

--- a/submission/submission-webapp/src/test/kotlin/ac/uk/ebi/biostd/submission/exception/SerializationExceptionHandlerTest.kt
+++ b/submission/submission-webapp/src/test/kotlin/ac/uk/ebi/biostd/submission/exception/SerializationExceptionHandlerTest.kt
@@ -21,7 +21,7 @@ class SerializationExceptionHandlerTest {
     fun handle() {
         val testSubmission = submission("ABC-123") {}
         val testErrors = HashMultimap.create<Any, SerializationError>()
-        val testChunk = FileChunk(listOf(TsvChunkLine(1, ""), TsvChunkLine(2, ""), TsvChunkLine(3, "")))
+        val testChunk = FileChunk(listOf(TsvChunkLine(1, emptyList()), TsvChunkLine(2, emptyList()), TsvChunkLine(3, emptyList())))
         testErrors.put(testChunk, SerializationError(testChunk, Exception("An exception")))
 
         val validation = testInstance.handle(SerializationException(testSubmission, testErrors))


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/168424987
- added multiple line support
- added specialized TsvChunkGenerator for chunks generation from pagetav content