### PR TITLE
Pivotal ID # 171647484: TSV Serialization Inconsistency

### DIFF
--- a/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/Section.kt
+++ b/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/Section.kt
@@ -23,7 +23,16 @@ open class Section(
 
     fun addFilesTable(table: FilesTable) = files.addRight(table)
     fun addLinksTable(table: LinksTable) = links.addRight(table)
-    fun addSectionTable(table: SectionsTable) = sections.addRight(table)
+    fun addSectionTable(table: SectionsTable) = sections.addRight(table.apply { parentAccNo = this@Section.accNo })
+
+    fun addSections(sections: MutableList<Either<Section, SectionsTable>>) {
+        sections.forEach { it.fold(
+            { sec -> sec.parentAccNo = this@Section.accNo },
+            { secTable -> secTable.setParent(this@Section.accNo) }
+        ) }
+
+        this.sections.addAll(sections)
+    }
 
     override fun equals(other: Any?) = when {
         other !is Section -> false

--- a/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/TableModel.kt
+++ b/commons/commons-bio/src/main/kotlin/ebi/ac/uk/model/TableModel.kt
@@ -100,7 +100,7 @@ class FilesTable(files: List<File> = emptyList()) : Table<File>(files) {
 
 class SectionsTable(sections: List<Section> = emptyList()) : Table<Section>(sections) {
     private var sectionType = ""
-    private var parentAccNo: String? = null
+    var parentAccNo: String? = null
 
     override val header: String
         get() {
@@ -118,6 +118,8 @@ class SectionsTable(sections: List<Section> = emptyList()) : Table<Section>(sect
         override val id = t.accNo!!
         override val attributes = t.attributes
     }
+
+    fun setParent(parentAccNo: String?) = parentAccNo?.let { elements.forEach { it.parentAccNo = parentAccNo } }
 
     fun asSectionsTable() = SectionsTable(
         elements.map { if (it is ExtendedSection) it.asSection() else it })

--- a/commons/commons-model-extended/src/main/kotlin/ebi/ac/uk/extended/mapping/serialization/from/ToExtSection.kt
+++ b/commons/commons-model-extended/src/main/kotlin/ebi/ac/uk/extended/mapping/serialization/from/ToExtSection.kt
@@ -10,6 +10,7 @@ fun Section.toExtSection(source: FilesSource): ExtSection {
     return ExtSection(
         type = type,
         accNo = accNo,
+        parentAccNo = parentAccNo,
         fileList = fileList?.toExtFileList(source),
         attributes = attributes.map { it.toExtAttribute() },
         files = files.map { either -> either.bimap({ it.toExtFile(source) }, { it.toExtTable(source) }) },

--- a/commons/commons-model-extended/src/main/kotlin/ebi/ac/uk/extended/mapping/serialization/to/ToSection.kt
+++ b/commons/commons-model-extended/src/main/kotlin/ebi/ac/uk/extended/mapping/serialization/to/ToSection.kt
@@ -9,6 +9,7 @@ fun ExtSection.toSection(): Section {
     return Section(
         type = type,
         accNo = accNo,
+        parentAccNo = parentAccNo,
         fileList = fileList?.toFileList(),
         attributes = attributes.mapTo(mutableListOf()) { it.toAttribute() },
         files = files.mapTo(mutableListOf()) { either -> either.bimap({ it.toFile() }, { it.toTable() }) },

--- a/commons/commons-model-extended/src/main/kotlin/ebi/ac/uk/extended/model/ExtendedModel.kt
+++ b/commons/commons-model-extended/src/main/kotlin/ebi/ac/uk/extended/model/ExtendedModel.kt
@@ -31,6 +31,7 @@ data class ExtSection(
     val accNo: String? = null,
     val type: String,
     val fileList: ExtFileList? = null,
+    val parentAccNo: String? = null,
     val attributes: List<ExtAttribute> = listOf(),
     val sections: List<Either<ExtSection, ExtSectionTable>> = listOf(),
     val files: List<Either<ExtFile, ExtFileTable>> = listOf(),

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/json/deserialization/SectionJsonDeserializer.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/json/deserialization/SectionJsonDeserializer.kt
@@ -23,7 +23,6 @@ internal object LinksType : TypeReference<MutableList<Either<Link, LinksTable>>>
 internal object FileType : TypeReference<MutableList<Either<File, FilesTable>>>()
 
 internal class SectionJsonDeserializer : StdDeserializer<Section>(Section::class.java) {
-
     override fun deserialize(jp: JsonParser, ctxt: DeserializationContext): Section {
         val mapper = jp.codec as ObjectMapper
         val node: JsonNode = mapper.readTree(jp)
@@ -33,7 +32,8 @@ internal class SectionJsonDeserializer : StdDeserializer<Section>(Section::class
             type = node.findNode<TextNode>(SectionFields.TYPE.value)?.textValue().orEmpty(),
             attributes = mapper.convertList(node.findNode(SectionFields.ATTRIBUTES.value)),
             links = mapper.convertList(node.findNode(SectionFields.LINKS.value), LinksType),
-            files = mapper.convertList(node.findNode(SectionFields.FILES.value), FileType),
-            sections = mapper.convertList(node.findNode(SectionFields.SUBSECTIONS.value), SectionsType))
+            files = mapper.convertList(node.findNode(SectionFields.FILES.value), FileType)).apply {
+            addSections(mapper.convertList(node.findNode(SectionFields.SUBSECTIONS.value), SectionsType))
+        }
     }
 }

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/TsvSerializationContext.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/TsvSerializationContext.kt
@@ -7,6 +7,7 @@ import ac.uk.ebi.biostd.tsv.deserialization.model.LinksTableChunk
 import ac.uk.ebi.biostd.tsv.deserialization.model.SectionChunk
 import ac.uk.ebi.biostd.tsv.deserialization.model.SectionTableChunk
 import ac.uk.ebi.biostd.tsv.deserialization.model.TsvChunk
+import ac.uk.ebi.biostd.validation.DuplicatedSectionAccNoException
 import ac.uk.ebi.biostd.validation.InvalidSectionException
 import ac.uk.ebi.biostd.validation.SerializationError
 import ac.uk.ebi.biostd.validation.SerializationException
@@ -77,7 +78,10 @@ internal class TsvSerializationContext {
 internal class TsvSectionContext {
     private val sections: MutableMap<String, Section> = mutableMapOf()
 
-    fun addSection(accNo: String, section: Section) = sections.put(accNo, section)
+    fun addSection(accNo: String, section: Section) {
+        require(sections.containsKey(accNo).not()) { throw DuplicatedSectionAccNoException(accNo) }
+        sections[accNo] = section
+    }
 
     fun getSection(accNo: String) = sections.getOrElse(accNo, { throw InvalidSectionException(accNo) })
 }

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/validation/Errors.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/validation/Errors.kt
@@ -7,8 +7,16 @@ import ebi.ac.uk.model.Submission
 const val CHUNK_SIZE_ERROR_MSG = "Exactly one element must be provided"
 
 class InvalidElementException(message: String) : RuntimeException("$message. Element was not created.")
-class SerializationException(val submission: Submission, val errors: Multimap<Any, SerializationError>) :
-    RuntimeException()
+
 class SerializationError(val chunk: TsvChunk, val cause: Exception)
+
 class InvalidChunkSizeException : RuntimeException(CHUNK_SIZE_ERROR_MSG)
+
 class InvalidSectionException(accNo: String) : RuntimeException(String.format(SECTION_NOT_CREATED, accNo))
+
+class DuplicatedSectionAccNoException(accNo: String) : RuntimeException("A section with accNo $accNo already exists")
+
+class SerializationException(
+    val submission: Submission,
+    val errors: Multimap<Any, SerializationError>
+) : RuntimeException()

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/xml/deserializer/SectionXmlDeserializer.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/xml/deserializer/SectionXmlDeserializer.kt
@@ -21,14 +21,12 @@ class SectionXmlDeserializer(
     private val linkXmlDeserializer: LinkXmlDeserializer,
     private val fileXmlDeserializer: FileXmlDeserializer
 ) : BaseXmlDeserializer<Section>() {
-
-    override fun deserialize(node: Node): Section {
-        return Section(
+    override fun deserialize(node: Node): Section =
+        Section(
             accNo = node.findProperty(ACC_NO),
             type = node.getProperty(TYPE),
             attributes = attributeXmlDeserializer.deserializeList(node.findNode(ATTRIBUTES)),
             links = linkXmlDeserializer.deserializeTableList(node.findNode(LINKS), LinkFields.LINK.value, ::LinksTable),
-            files = fileXmlDeserializer.deserializeTableList(node.findNode(FILES), FileFields.FILE.value, ::FilesTable),
-            sections = deserializeTableList(node.findNode(SUBSECTIONS), SECTION.value, ::SectionsTable))
-    }
+            files = fileXmlDeserializer.deserializeTableList(node.findNode(FILES), FileFields.FILE.value, ::FilesTable))
+            .apply { addSections(deserializeTableList(node.findNode(SUBSECTIONS), SECTION.value, ::SectionsTable)) }
 }

--- a/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/test/SubTestFactory.kt
+++ b/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/test/SubTestFactory.kt
@@ -50,6 +50,8 @@ fun createVenousBloodMonocyte() = submission("S-IHECRE00000919.1") {
 
         section("Stranded Total RNA-Seq") {
             accNo = "SUB-SECT-001"
+            parentAccNo = "SECT-001"
+
             filesTable {
                 file("Results.xls") {
                     attribute("Type", "Results File")
@@ -67,7 +69,10 @@ fun createVenousBloodMonocyte() = submission("S-IHECRE00000919.1") {
         }
 
         sectionsTable {
-            section("Data") { accNo = "DT-1" }
+            section("Data") {
+                accNo = "DT-1"
+                parentAccNo = "SECT-001"
+            }
         }
     }
 }

--- a/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/tsv/SimpleSubmissionTsvParserTest.kt
+++ b/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/tsv/SimpleSubmissionTsvParserTest.kt
@@ -66,7 +66,7 @@ class SimpleSubmissionTsvParserTest {
             line("Results.xls", "Results File")
             line()
 
-            line("Data[]")
+            line("Data[SECT-001]")
             line("DT-1")
             line()
         }.toString()

--- a/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/mapping/extended/from/ToDbSection.kt
+++ b/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/mapping/extended/from/ToDbSection.kt
@@ -13,6 +13,7 @@ import java.util.SortedSet
 internal fun ExtSection.toDbSection(submission: Submission, index: Int): Section {
     val section = asSection(submission, index)
     section.tableIndex = NO_TABLE_INDEX
+    section.parentAccNo = parentAccNo
     section.sections = sections.toDbSections(submission)
     section.fileList = fileList?.toDbFileList()
     section.links = links.toDbLinks()
@@ -22,6 +23,7 @@ internal fun ExtSection.toDbSection(submission: Submission, index: Int): Section
 
 private fun ExtSection.toDbTableSection(submission: Submission, index: Int, tableIndex: Int): Section {
     val section = asSection(submission, index)
+    section.parentAccNo = parentAccNo
     section.tableIndex = tableIndex
     return section
 }

--- a/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/mapping/extended/to/ToExtSection.kt
+++ b/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/mapping/extended/to/ToExtSection.kt
@@ -8,6 +8,7 @@ internal fun Section.toExtSection(filesSource: FilesSource): ExtSection {
     return ExtSection(
         accNo = accNo,
         type = type,
+        parentAccNo = parentAccNo,
         fileList = fileList?.toExtFileList(filesSource),
         attributes = attributes.map { it.toExtAttribute() },
         sections = sections.toExtSections(filesSource),

--- a/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/model/Section.kt
+++ b/submission/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/model/Section.kt
@@ -40,6 +40,9 @@ class Section(
     @Convert(converter = NullableIntConverter::class)
     override var order: Int = 0
 
+    @Column
+    var parentAccNo: String? = null
+
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "submission_id")
     var submission: Submission? = null

--- a/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/factory/TsvSubmissionFactory.kt
+++ b/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/factory/TsvSubmissionFactory.kt
@@ -120,6 +120,13 @@ fun assertAllInOneSubmissionTsv(tsv: String, accNo: String) {
         line()
     }
     assertTsvBlock(lines, 25, 27, expectedSubsectionLinksTable)
+
+    val expectedSubsectionsTable = tsv {
+        line("Data[SECT-001]", "Title", "Description")
+        line("DT-1", "Group 1 Transcription Data", "The data for zygotic transcription in mammals group 1")
+        line()
+    }
+    assertTsvBlock(lines, 28, 30, expectedSubsectionsTable)
 }
 
 private fun assertTsvBlock(lines: List<String>, from: Int, to: Int, expected: Tsv) {


### PR DESCRIPTION
**Pivotal Link:** https://www.pivotaltracker.com/story/show/171647484

- Set parentAccNo property during deserialization
- Validate duplicated section AccNo
- Fix parent accNo serialization
- Add validation for TSV sections table with parent

Fixes #171647484