### PR TITLE
Pivotal ID # 173361277: Excel File List Empty Attributes

### DIFF
--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/common/Functions.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/common/Functions.kt
@@ -8,7 +8,6 @@ import ac.uk.ebi.biostd.validation.MISPLACED_ATTR_NAME
 import ac.uk.ebi.biostd.validation.MISPLACED_ATTR_VAL
 import ac.uk.ebi.biostd.validation.REQUIRED_ATTR_VALUE
 import ac.uk.ebi.biostd.validation.REQUIRED_TABLE_ROWS
-import ebi.ac.uk.base.applyIfNotBlank
 import ebi.ac.uk.model.Attribute
 import ebi.ac.uk.model.AttributeDetail
 
@@ -43,7 +42,7 @@ internal fun <T> asTable(chunk: TsvChunk, initializer: (String, MutableList<Attr
         validate(rowAttrsSize <= headerAttrsSize) { throw InvalidElementException(INVALID_TABLE_ROW) }
 
         it.rawValues.forEachIndexed { index, attr ->
-            attr.applyIfNotBlank { parseTableAttribute(chunk.header[index + 1], attr, attrs) }
+            parseTableAttribute(chunk.header[index + 1], attr, attrs)
         }
 
         rows.add(initializer(it.name(), attrs))

--- a/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/tsv/TsvSingleElementDeserializationTest.kt
+++ b/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/tsv/TsvSingleElementDeserializationTest.kt
@@ -79,7 +79,7 @@ class TsvSingleElementDeserializationTest {
     }
 
     @Test
-    fun `table containing a row with less attributes`() {
+    fun `table containing an empty attribute`() {
         val tsv = tsv {
             line("Links", "Attr1", "Attr2")
             line("AF069307", "Value 1", "Value 2")
@@ -96,6 +96,7 @@ class TsvSingleElementDeserializationTest {
                 }
 
                 link("AF069308") {
+                    attribute("Attr1", "")
                     attribute("Attr2", "Value 2")
                 }
 

--- a/commons/commons-util/src/main/kotlin/ebi/ac/uk/util/file/PoiExt.kt
+++ b/commons/commons-util/src/main/kotlin/ebi/ac/uk/util/file/PoiExt.kt
@@ -21,7 +21,14 @@ fun Sheet.asTsvList(): List<String> {
     return elements
 }
 
-private fun Row.asString(): String = asIterable().joinToString("\t") { it.valueAsString }
+private fun Row.asString(): String {
+    val cells = mutableListOf<String>()
+    for (idx in 0 until lastCellNum) {
+        cells.add(getCell(idx)?.valueAsString ?: EMPTY)
+    }
+
+    return cells.joinToString("\t")
+}
 
 private val Cell.valueAsString: String
     get() = when (cellType) {

--- a/commons/commons-util/src/test/kotlin/ebi/ac/uk/util/file/ExcelReaderTest.kt
+++ b/commons/commons-util/src/test/kotlin/ebi/ac/uk/util/file/ExcelReaderTest.kt
@@ -39,6 +39,24 @@ class ExcelReaderTest(private val temporaryFolder: TemporaryFolder) {
                     cell("Numeric Attr")
                     cell("123")
                 }
+
+                emptyRow()
+
+                row {
+                    cell("Files")
+                    cell("Attr 1")
+                    cell("Attr 2")
+                }
+                row {
+                    cell("file1.txt")
+                    cell("")
+                    cell("a2")
+                }
+                row {
+                    cell("file2.txt")
+                    cell("b1")
+                    cell("b2")
+                }
             }
         }
 
@@ -50,6 +68,11 @@ class ExcelReaderTest(private val temporaryFolder: TemporaryFolder) {
             line("Study", "SECT-001")
             line("An Attr", "A Value")
             line("Numeric Attr", "123")
+            line()
+
+            line("Files", "Attr 1", "Attr 2")
+            line("file1.txt", "", "a2")
+            line("file2.txt", "b1", "b2")
         }
 
         assertThat(testInstance.readContentAsTsv(testFile)).isEqualTo(expectedTsv.toString())


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/173361277

- Process empty excel cells
- Allow empty values in table attributes