### PR TITLE
Pivotal ID # 173569202: Empty Section Parent Cell

### DIFF
--- a/commons/commons-util/src/main/kotlin/ebi/ac/uk/dsl/excel/ExcelSheet.kt
+++ b/commons/commons-util/src/main/kotlin/ebi/ac/uk/dsl/excel/ExcelSheet.kt
@@ -1,5 +1,6 @@
 package ebi.ac.uk.dsl.excel
 
+import ebi.ac.uk.base.EMPTY
 import org.apache.poi.xssf.streaming.SXSSFSheet
 
 class ExcelSheet(private val sheet: SXSSFSheet) {
@@ -7,7 +8,10 @@ class ExcelSheet(private val sheet: SXSSFSheet) {
 
     fun row(cellsBuilder: ExcelRow.() -> Unit) = ExcelRow(newRow()).apply { cellsBuilder() }
 
-    fun emptyRow() = row { }
+    fun emptyRow() = row {
+        cell(EMPTY)
+        cell(EMPTY)
+    }
 
     private fun newRow() = sheet.createRow(rowIterator.next())
 }

--- a/commons/commons-util/src/main/kotlin/ebi/ac/uk/util/file/PoiExt.kt
+++ b/commons/commons-util/src/main/kotlin/ebi/ac/uk/util/file/PoiExt.kt
@@ -5,20 +5,19 @@ import org.apache.poi.ss.usermodel.Cell
 import org.apache.poi.ss.usermodel.CellType.NUMERIC
 import org.apache.poi.ss.usermodel.Row
 import org.apache.poi.ss.usermodel.Sheet
-import java.util.LinkedList
 
 /**
  * Retrieves the sheet representation as a list of tsv separated string List. Note that as stream reader ignored empty
  * rows they are completed with emtpy values.
  */
 fun Sheet.asTsvList(): List<String> {
-    val elements = LinkedList<String>()
+    val elements = mutableListOf<String>()
     for (row in this) {
         while (elements.size < row.rowNum) elements.add(EMPTY)
         elements.add(row.asString())
     }
 
-    return elements
+    return elements.trim()
 }
 
 private fun Row.asString(): String {
@@ -27,7 +26,21 @@ private fun Row.asString(): String {
         cells.add(getCell(idx)?.valueAsString ?: EMPTY)
     }
 
-    return cells.joinToString("\t")
+    return when {
+        cells.all { it == EMPTY } -> EMPTY
+        else -> cells.trim().joinToString("\t")
+    }
+}
+
+private fun MutableList<String>.trim(): MutableList<String> {
+    if (last().isBlank()) {
+        for (idx in indices.reversed()) {
+            if (elementAt(idx).isNotBlank()) break
+            removeAt(idx)
+        }
+    }
+
+    return this
 }
 
 private val Cell.valueAsString: String

--- a/commons/commons-util/src/main/kotlin/ebi/ac/uk/util/file/PoiExt.kt
+++ b/commons/commons-util/src/main/kotlin/ebi/ac/uk/util/file/PoiExt.kt
@@ -5,13 +5,14 @@ import org.apache.poi.ss.usermodel.Cell
 import org.apache.poi.ss.usermodel.CellType.NUMERIC
 import org.apache.poi.ss.usermodel.Row
 import org.apache.poi.ss.usermodel.Sheet
+import java.util.LinkedList
 
 /**
  * Retrieves the sheet representation as a list of tsv separated string List. Note that as stream reader ignored empty
  * rows they are completed with emtpy values.
  */
 fun Sheet.asTsvList(): List<String> {
-    val elements = mutableListOf<String>()
+    val elements = LinkedList<String>()
     for (row in this) {
         while (elements.size < row.rowNum) elements.add(EMPTY)
         elements.add(row.asString())
@@ -32,15 +33,9 @@ private fun Row.asString(): String {
     }
 }
 
-private fun MutableList<String>.trim(): MutableList<String> {
-    if (last().isBlank()) {
-        for (idx in indices.reversed()) {
-            if (elementAt(idx).isNotBlank()) break
-            removeAt(idx)
-        }
-    }
-
-    return this
+private fun MutableList<String>.trim(): List<String> = when {
+    last().isBlank() -> dropLastWhile { it.isBlank() }
+    else -> this
 }
 
 private val Cell.valueAsString: String

--- a/commons/commons-util/src/test/kotlin/ebi/ac/uk/util/file/ExcelReaderTest.kt
+++ b/commons/commons-util/src/test/kotlin/ebi/ac/uk/util/file/ExcelReaderTest.kt
@@ -60,12 +60,6 @@ class ExcelReaderTest(private val temporaryFolder: TemporaryFolder) {
                     cell("b1")
                     cell("b2")
                 }
-
-                emptyRow()
-                emptyRow()
-                emptyRow()
-                emptyRow()
-                emptyRow()
             }
         }
 
@@ -82,6 +76,51 @@ class ExcelReaderTest(private val temporaryFolder: TemporaryFolder) {
             line("Files", "Attr 1", "Attr 2")
             line("file1.txt", "", "a2")
             line("file2.txt", "b1", "b2")
+        }
+
+        assertThat(testInstance.readContentAsTsv(testFile)).isEqualTo(expectedTsv.toString())
+    }
+
+    @Test
+    fun `file containing empty rows and cells`() {
+        val testFile = excel("${temporaryFolder.root.absolutePath}/ExcelSubmissionWithEmptyCells.xlsx") {
+            sheet("weird sheet") {
+                row {
+                    cell("Submission")
+                }
+                row {
+                    cell("Title")
+                    cell("Excel Submission With Empty Cells")
+                }
+
+                emptyRow()
+
+                row {
+                    cell("Study")
+                    cell("SECT-001")
+                    cell("")
+                    cell("")
+                }
+                row {
+                    cell("An Attr")
+                    cell("A Value")
+                }
+
+                emptyRow()
+                emptyRow()
+                emptyRow()
+                emptyRow()
+                emptyRow()
+            }
+        }
+
+        val expectedTsv = tsv {
+            line("Submission")
+            line("Title", "Excel Submission With Empty Cells")
+            line()
+
+            line("Study", "SECT-001")
+            line("An Attr", "A Value")
         }
 
         assertThat(testInstance.readContentAsTsv(testFile)).isEqualTo(expectedTsv.toString())

--- a/commons/commons-util/src/test/kotlin/ebi/ac/uk/util/file/ExcelReaderTest.kt
+++ b/commons/commons-util/src/test/kotlin/ebi/ac/uk/util/file/ExcelReaderTest.kt
@@ -30,6 +30,8 @@ class ExcelReaderTest(private val temporaryFolder: TemporaryFolder) {
                 row {
                     cell("Study")
                     cell("SECT-001")
+                    cell("")
+                    cell("")
                 }
                 row {
                     cell("An Attr")
@@ -46,6 +48,7 @@ class ExcelReaderTest(private val temporaryFolder: TemporaryFolder) {
                     cell("Files")
                     cell("Attr 1")
                     cell("Attr 2")
+                    cell("")
                 }
                 row {
                     cell("file1.txt")
@@ -57,6 +60,12 @@ class ExcelReaderTest(private val temporaryFolder: TemporaryFolder) {
                     cell("b1")
                     cell("b2")
                 }
+
+                emptyRow()
+                emptyRow()
+                emptyRow()
+                emptyRow()
+                emptyRow()
             }
         }
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/173569202

Improve excel reader:
- When all the cells in a row are empty, this will be interpreted as an empty line
- Remove empty elements from the end of a row
- Remove all empty rows starting at the last populated
- Add unit tests for these edge cases

Fixes # 173569202