### PR TITLE
Pivotal # 175163839: Submission Operations Refactor

### DIFF
--- a/submission/persistence-common-api/src/main/kotlin/ac/uk/ebi/biostd/persistence/common/model/BasicProject.kt
+++ b/submission/persistence-common-api/src/main/kotlin/ac/uk/ebi/biostd/persistence/common/model/BasicProject.kt
@@ -1,0 +1,9 @@
+package ac.uk.ebi.biostd.persistence.common.model
+
+import java.time.OffsetDateTime
+
+data class BasicProject(
+    val accNo: String,
+    val accNoPattern: String,
+    val releaseTime: OffsetDateTime?
+)

--- a/submission/persistence-common-api/src/main/kotlin/ac/uk/ebi/biostd/persistence/common/model/BasicSubmission.kt
+++ b/submission/persistence-common-api/src/main/kotlin/ac/uk/ebi/biostd/persistence/common/model/BasicSubmission.kt
@@ -5,9 +5,9 @@ import ebi.ac.uk.model.constants.ProcessingStatus
 import java.time.OffsetDateTime
 
 /**
- * Submission simple projection. Contains only submission attributes (no related entities).
+ * Submission basic projection. Contains only submission attributes (no related entities).
  */
-data class SimpleSubmission(
+data class BasicSubmission(
     val accNo: String,
     val relPath: String,
     val released: Boolean,

--- a/submission/persistence-common-api/src/main/kotlin/ac/uk/ebi/biostd/persistence/common/model/SimpleSubmission.kt
+++ b/submission/persistence-common-api/src/main/kotlin/ac/uk/ebi/biostd/persistence/common/model/SimpleSubmission.kt
@@ -18,5 +18,8 @@ data class SimpleSubmission(
     val modificationTime: OffsetDateTime,
     val creationTime: OffsetDateTime,
     val method: SubmissionMethod?,
-    var status: ProcessingStatus
-)
+    var status: ProcessingStatus,
+    val owner: String
+) {
+    val isActive = version > 0
+}

--- a/submission/persistence-common-api/src/main/kotlin/ac/uk/ebi/biostd/persistence/common/service/ProjectDataService.kt
+++ b/submission/persistence-common-api/src/main/kotlin/ac/uk/ebi/biostd/persistence/common/service/ProjectDataService.kt
@@ -1,7 +1,7 @@
 package ac.uk.ebi.biostd.persistence.common.service
 
-import ac.uk.ebi.biostd.persistence.common.model.SimpleSubmission
+import ac.uk.ebi.biostd.persistence.common.model.BasicSubmission
 
 interface ProjectDataService {
-    fun findProjectsByAccessTags(tags: List<String>): List<SimpleSubmission>
+    fun findProjectsByAccessTags(tags: List<String>): List<BasicSubmission>
 }

--- a/submission/persistence-common-api/src/main/kotlin/ac/uk/ebi/biostd/persistence/common/service/SubmissionOperations.kt
+++ b/submission/persistence-common-api/src/main/kotlin/ac/uk/ebi/biostd/persistence/common/service/SubmissionOperations.kt
@@ -1,44 +1,49 @@
 package ac.uk.ebi.biostd.persistence.common.service
 
+import ac.uk.ebi.biostd.persistence.common.model.BasicProject
 import ac.uk.ebi.biostd.persistence.common.model.SimpleSubmission
 import ac.uk.ebi.biostd.persistence.common.request.SaveSubmissionRequest
 import ac.uk.ebi.biostd.persistence.common.request.SubmissionFilter
 import ebi.ac.uk.extended.model.ExtSubmission
 import ebi.ac.uk.extended.model.FileMode
 import org.springframework.data.domain.Page
-import java.io.File
-import java.time.OffsetDateTime
 
 interface SubmissionRequestService {
     fun saveAndProcessSubmissionRequest(saveRequest: SaveSubmissionRequest): ExtSubmission
+
     fun saveSubmissionRequest(saveRequest: SaveSubmissionRequest): ExtSubmission
+
     fun processSubmission(saveRequest: SaveSubmissionRequest): ExtSubmission
+
     fun refreshSubmission(submission: ExtSubmission)
 }
 
 interface SubmissionPersistenceService {
     fun saveSubmissionRequest(submission: ExtSubmission): ExtSubmission
+
     fun processSubmission(submission: ExtSubmission, mode: FileMode): ExtSubmission
 }
 
 interface SubmissionQueryService {
     fun existByAccNo(accNo: String): Boolean
+
     fun getExtByAccNo(accNo: String): ExtSubmission
+
     fun getExtByAccNoAndVersion(accNo: String, version: Int): ExtSubmission
+
     fun expireSubmission(accNo: String)
+
     fun getExtendedSubmissions(filter: SubmissionFilter, offset: Long, limit: Int): Page<ExtSubmission>
+
     fun getSubmissionsByUser(userId: Long, filter: SubmissionFilter): List<SimpleSubmission>
 }
 
 interface SubmissionMetaQueryService {
-    fun getParentAccPattern(accNo: String): String?
-    fun isNew(accNo: String): Boolean
-    fun getSecret(accNo: String): String?
+    fun getBasicProject(accNo: String): BasicProject
+
+    fun findLatestBasicByAccNo(accNo: String): SimpleSubmission?
+
     fun getAccessTags(accNo: String): List<String>
-    fun getReleaseTime(accNo: String): OffsetDateTime?
+
     fun existByAccNo(accNo: String): Boolean
-    fun findCreationTime(accNo: String): OffsetDateTime?
-    fun getCurrentFolder(accNo: String): File?
-    fun getOwner(accNo: String): String?
-    fun isProcessing(accNo: String): Boolean
 }

--- a/submission/persistence-common-api/src/main/kotlin/ac/uk/ebi/biostd/persistence/common/service/SubmissionOperations.kt
+++ b/submission/persistence-common-api/src/main/kotlin/ac/uk/ebi/biostd/persistence/common/service/SubmissionOperations.kt
@@ -1,7 +1,7 @@
 package ac.uk.ebi.biostd.persistence.common.service
 
 import ac.uk.ebi.biostd.persistence.common.model.BasicProject
-import ac.uk.ebi.biostd.persistence.common.model.SimpleSubmission
+import ac.uk.ebi.biostd.persistence.common.model.BasicSubmission
 import ac.uk.ebi.biostd.persistence.common.request.SaveSubmissionRequest
 import ac.uk.ebi.biostd.persistence.common.request.SubmissionFilter
 import ebi.ac.uk.extended.model.ExtSubmission
@@ -35,13 +35,13 @@ interface SubmissionQueryService {
 
     fun getExtendedSubmissions(filter: SubmissionFilter, offset: Long, limit: Int): Page<ExtSubmission>
 
-    fun getSubmissionsByUser(userId: Long, filter: SubmissionFilter): List<SimpleSubmission>
+    fun getSubmissionsByUser(userId: Long, filter: SubmissionFilter): List<BasicSubmission>
 }
 
 interface SubmissionMetaQueryService {
     fun getBasicProject(accNo: String): BasicProject
 
-    fun findLatestBasicByAccNo(accNo: String): SimpleSubmission?
+    fun findLatestBasicByAccNo(accNo: String): BasicSubmission?
 
     fun getAccessTags(accNo: String): List<String>
 

--- a/submission/persistence-sql/src/main/kotlin/ac/uk/ebi/biostd/persistence/exception/ProjectNotFoundException.kt
+++ b/submission/persistence-sql/src/main/kotlin/ac/uk/ebi/biostd/persistence/exception/ProjectNotFoundException.kt
@@ -1,3 +1,7 @@
 package ac.uk.ebi.biostd.persistence.exception
 
-class ProjectNotFoundException(project: String) : RuntimeException("The project '$project' doesn't exist")
+class ProjectNotFoundException(project: String) : RuntimeException("The project '$project' was not found")
+
+class ProjectWithoutPatternException(
+    project: String
+) : RuntimeException("The project '$project' does not have a valid accession pattern")

--- a/submission/persistence-sql/src/main/kotlin/ac/uk/ebi/biostd/persistence/integration/config/SqlPersistenceConfig.kt
+++ b/submission/persistence-sql/src/main/kotlin/ac/uk/ebi/biostd/persistence/integration/config/SqlPersistenceConfig.kt
@@ -25,7 +25,6 @@ import ac.uk.ebi.biostd.persistence.repositories.UserDataDataRepository
 import ac.uk.ebi.biostd.persistence.repositories.UserDataRepository
 import ac.uk.ebi.biostd.persistence.repositories.data.ProjectSqlDataService
 import ac.uk.ebi.biostd.persistence.repositories.data.SubmissionRepository
-import ebi.ac.uk.paths.SubmissionFolderResolver
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -36,10 +35,7 @@ import java.nio.file.Paths
 @Suppress("LongParameterList")
 @Configuration
 @Import(JpaRepositoryConfig::class)
-open class SqlPersistenceConfig(
-    private val folderResolver: SubmissionFolderResolver,
-    private val applicationProperties: ApplicationProperties
-) {
+open class SqlPersistenceConfig(private val applicationProperties: ApplicationProperties) {
     @Bean
     @ConditionalOnMissingBean(LockExecutor::class)
     internal open fun lockExecutor(
@@ -47,8 +43,8 @@ open class SqlPersistenceConfig(
     ): LockExecutor = JdbcLockExecutor(namedParameterJdbcTemplate)
 
     @Bean
-    internal open fun toExtSubmissionMapper():
-        ToExtSubmissionMapper = ToExtSubmissionMapper(Paths.get(applicationProperties.submissionPath))
+    internal open fun toExtSubmissionMapper(): ToExtSubmissionMapper =
+        ToExtSubmissionMapper(Paths.get(applicationProperties.submissionPath))
 
     @Bean
     internal open fun submissionRepository(
@@ -56,20 +52,17 @@ open class SqlPersistenceConfig(
         submissionDataRepository: SubmissionDataRepository,
         sectionRepository: SectionDataRepository,
         statsRepository: SubmissionStatsDataRepository
-    ) =
-        SubmissionRepository(
-            submissionDataRepository,
-            sectionRepository,
-            statsRepository,
-            toExtSubmissionMapper()
-        )
+    ) = SubmissionRepository(
+        submissionDataRepository,
+        sectionRepository,
+        statsRepository,
+        toExtSubmissionMapper())
 
     @Bean
     internal open fun submissionQueryService(
         submissionDataRepository: SubmissionDataRepository,
         accessTagDataRepo: AccessTagDataRepo
-    ): SubmissionMetaQueryService =
-        SubmissionSqlQueryService(submissionDataRepository, accessTagDataRepo, folderResolver)
+    ): SubmissionMetaQueryService = SubmissionSqlQueryService(submissionDataRepository, accessTagDataRepo)
 
     @Bean
     internal open fun persistenceService(
@@ -87,8 +80,7 @@ open class SqlPersistenceConfig(
             sequenceRepository,
             tagsDataRepository,
             submissionQueryService,
-            lockExecutor
-        )
+            lockExecutor)
 
     @Bean
     internal open fun submissionPersistenceService(

--- a/submission/persistence-sql/src/main/kotlin/ac/uk/ebi/biostd/persistence/integration/services/SubmissionSqlQueryService.kt
+++ b/submission/persistence-sql/src/main/kotlin/ac/uk/ebi/biostd/persistence/integration/services/SubmissionSqlQueryService.kt
@@ -1,13 +1,13 @@
 package ac.uk.ebi.biostd.persistence.integration.services
 
 import ac.uk.ebi.biostd.persistence.common.model.BasicProject
-import ac.uk.ebi.biostd.persistence.common.model.SimpleSubmission
+import ac.uk.ebi.biostd.persistence.common.model.BasicSubmission
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionMetaQueryService
 import ac.uk.ebi.biostd.persistence.exception.ProjectNotFoundException
 import ac.uk.ebi.biostd.persistence.exception.ProjectWithoutPatternException
 import ac.uk.ebi.biostd.persistence.repositories.AccessTagDataRepo
 import ac.uk.ebi.biostd.persistence.repositories.SubmissionDataRepository
-import ac.uk.ebi.biostd.persistence.repositories.data.ProjectSqlDataService.Companion.asSimpleSubmission
+import ac.uk.ebi.biostd.persistence.repositories.data.ProjectSqlDataService.Companion.asBasicSubmission
 import ebi.ac.uk.model.constants.SubFields
 
 @Suppress("TooManyFunctions")
@@ -26,8 +26,8 @@ internal class SubmissionSqlQueryService(
         return BasicProject(projectDb.accNo, projectPattern, projectDb.releaseTime)
     }
 
-    override fun findLatestBasicByAccNo(accNo: String): SimpleSubmission? =
-        subRepository.getLastVersion(accNo)?.asSimpleSubmission()
+    override fun findLatestBasicByAccNo(accNo: String): BasicSubmission? =
+        subRepository.getLastVersion(accNo)?.asBasicSubmission()
 
     override fun getAccessTags(accNo: String) = accessTagDataRepo.findBySubmissionsAccNo(accNo).map { it.name }
 

--- a/submission/persistence-sql/src/main/kotlin/ac/uk/ebi/biostd/persistence/repositories/Repositories.kt
+++ b/submission/persistence-sql/src/main/kotlin/ac/uk/ebi/biostd/persistence/repositories/Repositories.kt
@@ -42,9 +42,6 @@ interface SubmissionDataRepository :
     EntityGraphJpaRepository<DbSubmission, Long>, EntityGraphJpaSpecificationExecutor<DbSubmission> {
     fun findByAccNoAndVersionGreaterThan(id: String, version: Int = 0): DbSubmission?
 
-    @Query("select s from DbSubmission s inner join s.owner where s.accNo = :accNo and s.version > 0")
-    fun getBasic(@Param("accNo") accNo: String): DbSubmission
-
     @Query("select s from DbSubmission s inner join s.owner where s.accNo = :accNo order by s.id desc")
     fun getBasicAllVersions(@Param("accNo") accNo: String, pageable: Pageable): List<DbSubmission>
 
@@ -56,10 +53,7 @@ interface SubmissionDataRepository :
         from DbSubmission s inner join s.owner inner join s.attributes
         where s.accNo = :accNo and s.version > 0
     """)
-    fun getBasicWithAttributes(@Param("accNo") accNo: String): DbSubmission
-
-    @Query("select s from DbSubmission s inner join s.owner where s.accNo = :accNo and s.version > 0")
-    fun findBasic(@Param("accNo") accNo: String): DbSubmission?
+    fun findBasicWithAttributes(@Param("accNo") accNo: String): DbSubmission?
 
     @EntityGraph(value = SUBMISSION_FULL_GRAPH, type = LOAD)
     fun getByAccNoAndVersionGreaterThan(accNo: String, version: Int = 0): DbSubmission?
@@ -89,12 +83,6 @@ interface SubmissionDataRepository :
 
     @Query("select s.accNo as accNo, s.version as version from DbSubmission s where s.version > 0 ")
     fun getIds(pageRequest: Pageable): Page<SubmissionId>
-
-    @Query("""
-        select count(s.id) from DbSubmission s
-        where s.accNo = :accNo and s.version > 0 and s.status <> 'PROCESSED'
-    """)
-    fun getProcessingCount(accNo: String): Int
 }
 
 interface SectionDataRepository : JpaRepository<DbSection, Long> {

--- a/submission/persistence-sql/src/main/kotlin/ac/uk/ebi/biostd/persistence/repositories/data/ProjectSqlDataService.kt
+++ b/submission/persistence-sql/src/main/kotlin/ac/uk/ebi/biostd/persistence/repositories/data/ProjectSqlDataService.kt
@@ -9,8 +9,9 @@ import ac.uk.ebi.biostd.persistence.model.ext.title
 import ac.uk.ebi.biostd.persistence.repositories.SubmissionDataRepository
 import com.cosium.spring.data.jpa.entity.graph.domain.EntityGraphs.named
 
-internal class ProjectSqlDataService(private val submissionRepository: SubmissionDataRepository) : ProjectDataService {
-
+internal class ProjectSqlDataService(
+    private val submissionRepository: SubmissionDataRepository
+) : ProjectDataService {
     override fun findProjectsByAccessTags(tags: List<String>): List<SimpleSubmission> =
         if (tags.isEmpty()) emptyList() else getProjectsByAccessTags(tags)
 
@@ -35,6 +36,7 @@ internal class ProjectSqlDataService(private val submissionRepository: Submissio
                 modificationTime = modificationTime,
                 releaseTime = releaseTime,
                 status = status,
-                method = method)
+                method = method,
+                owner = owner.email)
     }
 }

--- a/submission/persistence-sql/src/main/kotlin/ac/uk/ebi/biostd/persistence/repositories/data/ProjectSqlDataService.kt
+++ b/submission/persistence-sql/src/main/kotlin/ac/uk/ebi/biostd/persistence/repositories/data/ProjectSqlDataService.kt
@@ -1,7 +1,7 @@
 package ac.uk.ebi.biostd.persistence.repositories.data
 
 import ac.uk.ebi.biostd.persistence.common.SubmissionTypes.Project
-import ac.uk.ebi.biostd.persistence.common.model.SimpleSubmission
+import ac.uk.ebi.biostd.persistence.common.model.BasicSubmission
 import ac.uk.ebi.biostd.persistence.common.service.ProjectDataService
 import ac.uk.ebi.biostd.persistence.model.DbSubmission
 import ac.uk.ebi.biostd.persistence.model.SIMPLE_QUERY_GRAPH
@@ -12,20 +12,20 @@ import com.cosium.spring.data.jpa.entity.graph.domain.EntityGraphs.named
 internal class ProjectSqlDataService(
     private val submissionRepository: SubmissionDataRepository
 ) : ProjectDataService {
-    override fun findProjectsByAccessTags(tags: List<String>): List<SimpleSubmission> =
+    override fun findProjectsByAccessTags(tags: List<String>): List<BasicSubmission> =
         if (tags.isEmpty()) emptyList() else getProjectsByAccessTags(tags)
 
-    private fun getProjectsByAccessTags(tags: List<String>): List<SimpleSubmission> =
+    private fun getProjectsByAccessTags(tags: List<String>): List<BasicSubmission> =
         submissionRepository
             .findByRootSectionTypeAndAccNoInAndVersionGreaterThan(
                 Project.value, tags, named(SIMPLE_GRAPH))
-            .map { it.asSimpleSubmission() }
+            .map { it.asBasicSubmission() }
 
     companion object {
         const val SIMPLE_GRAPH: String = SIMPLE_QUERY_GRAPH
 
-        fun DbSubmission.asSimpleSubmission(): SimpleSubmission =
-            SimpleSubmission(
+        fun DbSubmission.asBasicSubmission(): BasicSubmission =
+            BasicSubmission(
                 accNo = accNo,
                 version = version,
                 secretKey = secretKey,

--- a/submission/persistence-sql/src/main/kotlin/ac/uk/ebi/biostd/persistence/repositories/data/SubmissionRepository.kt
+++ b/submission/persistence-sql/src/main/kotlin/ac/uk/ebi/biostd/persistence/repositories/data/SubmissionRepository.kt
@@ -1,6 +1,6 @@
 package ac.uk.ebi.biostd.persistence.repositories.data
 
-import ac.uk.ebi.biostd.persistence.common.model.SimpleSubmission
+import ac.uk.ebi.biostd.persistence.common.model.BasicSubmission
 import ac.uk.ebi.biostd.persistence.common.request.SubmissionFilter
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionQueryService
 import ac.uk.ebi.biostd.persistence.exception.SubmissionNotFoundException
@@ -14,7 +14,7 @@ import ac.uk.ebi.biostd.persistence.repositories.SectionDataRepository
 import ac.uk.ebi.biostd.persistence.repositories.SubmissionDataRepository
 import ac.uk.ebi.biostd.persistence.repositories.SubmissionStatsDataRepository
 import ac.uk.ebi.biostd.persistence.repositories.data.ProjectSqlDataService.Companion.SIMPLE_GRAPH
-import ac.uk.ebi.biostd.persistence.repositories.data.ProjectSqlDataService.Companion.asSimpleSubmission
+import ac.uk.ebi.biostd.persistence.repositories.data.ProjectSqlDataService.Companion.asBasicSubmission
 import com.cosium.spring.data.jpa.entity.graph.domain.EntityGraphs
 import ebi.ac.uk.extended.model.ExtSubmission
 import mu.KotlinLogging
@@ -62,14 +62,14 @@ internal open class SubmissionRepository(
             .map { getExtByAccNoAndVersion(it.accNo, it.version) }
     }
 
-    override fun getSubmissionsByUser(userId: Long, filter: SubmissionFilter): List<SimpleSubmission> {
+    override fun getSubmissionsByUser(userId: Long, filter: SubmissionFilter): List<BasicSubmission> {
         val filterSpecs = SubmissionFilterSpecification(filter, userId)
         val pageable = PageRequest.of(filter.pageNumber, filter.limit, Sort.by(SUB_RELEASE_TIME).descending())
 
         return submissionRepository
             .findAll(filterSpecs.specification, pageable, EntityGraphs.named(SIMPLE_GRAPH))
             .content
-            .map { it.asSimpleSubmission() }
+            .map { it.asBasicSubmission() }
     }
 
     private fun loadSubmissionAndStatus(accNo: String, version: Int? = null): DbToExtRequest =

--- a/submission/submission-security/src/main/kotlin/ebi/ac/uk/security/service/UserPrivilegesService.kt
+++ b/submission/submission-security/src/main/kotlin/ebi/ac/uk/security/service/UserPrivilegesService.kt
@@ -39,12 +39,12 @@ internal class UserPrivilegesService(
 
     override fun canResubmit(submitter: String, accNo: String) =
         isSuperUser(submitter)
-            .or(isAuthor(submissionQueryService.getOwner(accNo), submitter))
+            .or(isAuthor(getOwner(accNo), submitter))
             .or(hasPermissions(submitter, submissionQueryService.getAccessTags(accNo), UPDATE))
 
     override fun canDelete(submitter: String, accNo: String) =
         isSuperUser(submitter)
-            .or(isAuthor(submissionQueryService.getOwner(accNo), submitter))
+            .or(isAuthor(getOwner(accNo), submitter))
             .or(hasPermissions(submitter, submissionQueryService.getAccessTags(accNo), DELETE))
 
     private fun hasPermissions(user: String, accessTags: List<String>, accessType: AccessType): Boolean {
@@ -59,4 +59,6 @@ internal class UserPrivilegesService(
 
     private fun getUser(email: String) =
         userRepository.findByEmail(email).orElseThrow { UserNotFoundByEmailException(email) }
+
+    private fun getOwner(accNo: String) = submissionQueryService.findLatestBasicByAccNo(accNo)?.owner
 }

--- a/submission/submission-security/src/test/kotlin/ebi/ac/uk/security/service/UserPrivilegesServiceTest.kt
+++ b/submission/submission-security/src/test/kotlin/ebi/ac/uk/security/service/UserPrivilegesServiceTest.kt
@@ -1,6 +1,7 @@
 package ebi.ac.uk.security.service
 
 import ac.uk.ebi.biostd.persistence.common.model.AccessType
+import ac.uk.ebi.biostd.persistence.common.model.SimpleSubmission
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionMetaQueryService
 import ac.uk.ebi.biostd.persistence.common.service.UserPermissionsService
 import ac.uk.ebi.biostd.persistence.repositories.AccessTagDataRepo
@@ -24,6 +25,7 @@ class UserPrivilegesServiceTest(
     @MockK private val author: UserDB,
     @MockK private val otherAuthor: UserDB,
     @MockK private val superuser: UserDB,
+    @MockK private val simpleSubmission: SimpleSubmission,
     @MockK private val userRepository: UserDataRepository,
     @MockK private val queryService: SubmissionMetaQueryService,
     @MockK private val tagsDataRepository: AccessTagDataRepo,
@@ -65,8 +67,11 @@ class UserPrivilegesServiceTest(
     }
 
     @Test
-    fun `author user with tag resubmits a submission that is in a project`() {
-        every { queryService.getOwner("accNo") } returns "author@mail.com"
+    fun `author user with tag resubmits a submission that is in a project`(
+        @MockK simpleSubmission: SimpleSubmission
+    ) {
+        every { simpleSubmission.owner } returns "author@mail.com"
+        every { queryService.findLatestBasicByAccNo("accNo") } returns simpleSubmission
 
         assertThat(testInstance.canResubmit("author@mail.com", "accNo")).isTrue()
     }
@@ -77,8 +82,10 @@ class UserPrivilegesServiceTest(
     }
 
     @Test
-    fun `author user deletes own submission`() {
-        every { queryService.getOwner("accNo") } returns "author@mail.com"
+    fun `author user deletes own submission`(@MockK simpleSubmission: SimpleSubmission) {
+        every { simpleSubmission.owner } returns "author@mail.com"
+        every { queryService.findLatestBasicByAccNo("accNo") } returns simpleSubmission
+
         assertThat(testInstance.canDelete("author@mail.com", "accNo")).isTrue()
     }
 
@@ -124,7 +131,8 @@ class UserPrivilegesServiceTest(
     }
 
     private fun initSubmissionQueries() {
+        every { simpleSubmission.owner } returns "nottheauthor@mail.com"
         every { queryService.getAccessTags("accNo") } returns emptyList()
-        every { queryService.getOwner("accNo") } returns "nottheauthor@mail.com"
+        every { queryService.findLatestBasicByAccNo("accNo") } returns simpleSubmission
     }
 }

--- a/submission/submission-security/src/test/kotlin/ebi/ac/uk/security/service/UserPrivilegesServiceTest.kt
+++ b/submission/submission-security/src/test/kotlin/ebi/ac/uk/security/service/UserPrivilegesServiceTest.kt
@@ -1,7 +1,7 @@
 package ebi.ac.uk.security.service
 
 import ac.uk.ebi.biostd.persistence.common.model.AccessType
-import ac.uk.ebi.biostd.persistence.common.model.SimpleSubmission
+import ac.uk.ebi.biostd.persistence.common.model.BasicSubmission
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionMetaQueryService
 import ac.uk.ebi.biostd.persistence.common.service.UserPermissionsService
 import ac.uk.ebi.biostd.persistence.repositories.AccessTagDataRepo
@@ -25,7 +25,7 @@ class UserPrivilegesServiceTest(
     @MockK private val author: UserDB,
     @MockK private val otherAuthor: UserDB,
     @MockK private val superuser: UserDB,
-    @MockK private val simpleSubmission: SimpleSubmission,
+    @MockK private val basicSubmission: BasicSubmission,
     @MockK private val userRepository: UserDataRepository,
     @MockK private val queryService: SubmissionMetaQueryService,
     @MockK private val tagsDataRepository: AccessTagDataRepo,
@@ -68,10 +68,10 @@ class UserPrivilegesServiceTest(
 
     @Test
     fun `author user with tag resubmits a submission that is in a project`(
-        @MockK simpleSubmission: SimpleSubmission
+        @MockK basicSubmission: BasicSubmission
     ) {
-        every { simpleSubmission.owner } returns "author@mail.com"
-        every { queryService.findLatestBasicByAccNo("accNo") } returns simpleSubmission
+        every { basicSubmission.owner } returns "author@mail.com"
+        every { queryService.findLatestBasicByAccNo("accNo") } returns basicSubmission
 
         assertThat(testInstance.canResubmit("author@mail.com", "accNo")).isTrue()
     }
@@ -82,9 +82,9 @@ class UserPrivilegesServiceTest(
     }
 
     @Test
-    fun `author user deletes own submission`(@MockK simpleSubmission: SimpleSubmission) {
-        every { simpleSubmission.owner } returns "author@mail.com"
-        every { queryService.findLatestBasicByAccNo("accNo") } returns simpleSubmission
+    fun `author user deletes own submission`(@MockK basicSubmission: BasicSubmission) {
+        every { basicSubmission.owner } returns "author@mail.com"
+        every { queryService.findLatestBasicByAccNo("accNo") } returns basicSubmission
 
         assertThat(testInstance.canDelete("author@mail.com", "accNo")).isTrue()
     }
@@ -131,8 +131,8 @@ class UserPrivilegesServiceTest(
     }
 
     private fun initSubmissionQueries() {
-        every { simpleSubmission.owner } returns "nottheauthor@mail.com"
+        every { basicSubmission.owner } returns "nottheauthor@mail.com"
         every { queryService.getAccessTags("accNo") } returns emptyList()
-        every { queryService.findLatestBasicByAccNo("accNo") } returns simpleSubmission
+        every { queryService.findLatestBasicByAccNo("accNo") } returns basicSubmission
     }
 }

--- a/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/test/submission/refresh/SubmissionRefreshApiTest.kt
+++ b/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/test/submission/refresh/SubmissionRefreshApiTest.kt
@@ -163,6 +163,6 @@ internal class SubmissionRefreshApiTest(private val tempFolder: TemporaryFolder)
 
         private fun getExtSubmission(): ExtSubmission = submissionRepository.getExtByAccNo(ACC_NO)
 
-        private fun getSubmissionDb(): DbSubmission = submissionDataRepository.getBasicWithAttributes(ACC_NO)
+        private fun getSubmissionDb(): DbSubmission = submissionDataRepository.findBasicWithAttributes(ACC_NO)!!
     }
 }

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/common/config/SubmissionConfig.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/common/config/SubmissionConfig.kt
@@ -15,6 +15,7 @@ import ac.uk.ebi.biostd.submission.submitter.SubmissionSubmitter
 import ac.uk.ebi.biostd.submission.web.handlers.SubmissionsWebHandler
 import ac.uk.ebi.biostd.submission.web.handlers.SubmitWebHandler
 import ac.uk.ebi.biostd.submission.web.resources.ext.ExtendedPageMapper
+import ebi.ac.uk.paths.SubmissionFolderResolver
 import ebi.ac.uk.security.integration.components.ISecurityService
 import ebi.ac.uk.security.integration.components.IUserPrivilegesService
 import org.springframework.amqp.rabbit.core.RabbitTemplate
@@ -28,6 +29,7 @@ import java.net.URI
 @Import(value = [PersistenceConfig::class, SecurityBeansConfig::class])
 class SubmissionConfig(
     private val sourceGenerator: SourceGenerator,
+    private val folderResolver: SubmissionFolderResolver,
     private val serializationService: SerializationService
 ) {
     @Bean
@@ -73,8 +75,8 @@ class SubmissionConfig(
             sourceGenerator,
             serializationService,
             userFilesService,
-            securityService
-        )
+            securityService,
+            folderResolver)
 
     @Bean
     fun submissionHandler(submissionService: SubmissionService): SubmissionsWebHandler =

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/common/config/SubmitterConfig.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/common/config/SubmitterConfig.kt
@@ -71,15 +71,15 @@ class SubmitterConfig {
         fun accNoPatternUtil() = AccNoPatternUtil()
 
         @Bean
-        fun accNoService() = AccNoService(service, queryService, accNoPatternUtil(), userPrivilegesService)
+        fun accNoService() = AccNoService(service, accNoPatternUtil(), userPrivilegesService)
 
         @Bean
         fun parentInfoService() = ParentInfoService(queryService)
 
         @Bean
-        fun projectInfoService() = ProjectInfoService(service, queryService, accNoPatternUtil(), userPrivilegesService)
+        fun projectInfoService() = ProjectInfoService(service, accNoPatternUtil(), userPrivilegesService)
 
         @Bean
-        fun timesService() = TimesService(queryService)
+        fun timesService() = TimesService()
     }
 }

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/domain/service/SubmissionService.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/domain/service/SubmissionService.kt
@@ -5,7 +5,7 @@ import ac.uk.ebi.biostd.integration.SerializationService
 import ac.uk.ebi.biostd.integration.SubFormat.JsonFormat.JsonPretty
 import ac.uk.ebi.biostd.integration.SubFormat.TsvFormat.Tsv
 import ac.uk.ebi.biostd.integration.SubFormat.XmlFormat
-import ac.uk.ebi.biostd.persistence.common.model.SimpleSubmission
+import ac.uk.ebi.biostd.persistence.common.model.BasicSubmission
 import ac.uk.ebi.biostd.persistence.common.request.SaveSubmissionRequest
 import ac.uk.ebi.biostd.persistence.common.request.SubmissionFilter
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionMetaQueryService
@@ -77,7 +77,7 @@ class SubmissionService(
         return serializationService.serializeSubmission(submission, Tsv)
     }
 
-    fun getSubmissions(user: SecurityUser, filter: SubmissionFilter): List<SimpleSubmission> =
+    fun getSubmissions(user: SecurityUser, filter: SubmissionFilter): List<BasicSubmission> =
         subRepository.getSubmissionsByUser(user.id, filter)
 
     fun deleteSubmission(accNo: String, user: SecurityUser) {
@@ -87,5 +87,5 @@ class SubmissionService(
 
     fun getSubmission(accNo: String): ExtSubmission = subRepository.getExtByAccNo(accNo)
 
-    fun findPreviousVersion(accNo: String): SimpleSubmission? = queryService.findLatestBasicByAccNo(accNo)
+    fun findPreviousVersion(accNo: String): BasicSubmission? = queryService.findLatestBasicByAccNo(accNo)
 }

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/domain/service/SubmissionService.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/domain/service/SubmissionService.kt
@@ -10,13 +10,11 @@ import ac.uk.ebi.biostd.persistence.common.request.SaveSubmissionRequest
 import ac.uk.ebi.biostd.persistence.common.request.SubmissionFilter
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionMetaQueryService
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionQueryService
-import ac.uk.ebi.biostd.submission.exceptions.ConcurrentProcessingSubmissionException
 import ac.uk.ebi.biostd.submission.ext.getSimpleByAccNo
 import ac.uk.ebi.biostd.submission.model.SubmissionRequest
 import ac.uk.ebi.biostd.submission.submitter.SubmissionSubmitter
 import ebi.ac.uk.extended.events.SubmissionRequestMessage
 import ebi.ac.uk.extended.model.ExtSubmission
-import ebi.ac.uk.paths.FILES_PATH
 import ebi.ac.uk.security.integration.components.IUserPrivilegesService
 import ebi.ac.uk.security.integration.model.api.SecurityUser
 import mu.KotlinLogging
@@ -28,7 +26,6 @@ import uk.ac.ebi.events.service.EventsPublisherService
 
 private val logger = KotlinLogging.logger {}
 
-@Suppress("TooManyFunctions")
 class SubmissionService(
     private val subRepository: SubmissionQueryService,
     private val serializationService: SerializationService,
@@ -88,10 +85,7 @@ class SubmissionService(
         subRepository.expireSubmission(accNo)
     }
 
-    fun submissionFolder(accNo: String): java.io.File? = queryService.getCurrentFolder(accNo)?.resolve(FILES_PATH)
-
     fun getSubmission(accNo: String): ExtSubmission = subRepository.getExtByAccNo(accNo)
 
-    fun requireNotProcessing(accNo: String) =
-        require(queryService.isProcessing(accNo).not()) { throw ConcurrentProcessingSubmissionException(accNo) }
+    fun findPreviousVersion(accNo: String): SimpleSubmission? = queryService.findLatestBasicByAccNo(accNo)
 }

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/web/handlers/SubmitWebHandler.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/web/handlers/SubmitWebHandler.kt
@@ -3,7 +3,7 @@ package ac.uk.ebi.biostd.submission.web.handlers
 import ac.uk.ebi.biostd.files.service.UserFilesService
 import ac.uk.ebi.biostd.integration.SerializationService
 import ac.uk.ebi.biostd.integration.SubFormat
-import ac.uk.ebi.biostd.persistence.common.model.SimpleSubmission
+import ac.uk.ebi.biostd.persistence.common.model.BasicSubmission
 import ac.uk.ebi.biostd.submission.domain.helpers.RequestSources
 import ac.uk.ebi.biostd.submission.domain.helpers.SourceGenerator
 import ac.uk.ebi.biostd.submission.domain.service.SubmissionService
@@ -122,13 +122,13 @@ class SubmitWebHandler(
     private fun submission(subFile: File, source: FilesSource) =
         serializationService.deserializeSubmission(subFile, source)
 
-    private fun subFolder(submission: SimpleSubmission?): File? =
+    private fun subFolder(submission: BasicSubmission?): File? =
         submission?.let { folderResolver.getSubFolder(submission.relPath).toFile().resolve(FILES_PATH) }
 
-    private fun requireNotProcessing(simpleSubmission: SimpleSubmission?) =
-        simpleSubmission?.let {
+    private fun requireNotProcessing(basicSubmission: BasicSubmission?) =
+        basicSubmission?.let {
             if (it.isActive) require(it.status == PROCESSED) {
-                throw ConcurrentProcessingSubmissionException(simpleSubmission.accNo)
+                throw ConcurrentProcessingSubmissionException(basicSubmission.accNo)
             }
         }
 }

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/web/resources/SubmissionResource.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/web/resources/SubmissionResource.kt
@@ -1,6 +1,6 @@
 package ac.uk.ebi.biostd.submission.web.resources
 
-import ac.uk.ebi.biostd.persistence.common.model.SimpleSubmission
+import ac.uk.ebi.biostd.persistence.common.model.BasicSubmission
 import ac.uk.ebi.biostd.persistence.common.request.SubmissionFilter
 import ac.uk.ebi.biostd.submission.converters.BioUser
 import ac.uk.ebi.biostd.submission.web.handlers.SubmissionsWebHandler
@@ -61,7 +61,7 @@ class SubmissionResource(
         @PathVariable accNo: String
     ): Unit = submissionsWebHandler.deleteSubmission(accNo, user)
 
-    private fun SimpleSubmission.asDto() =
+    private fun BasicSubmission.asDto() =
         SubmissionDto(
             accNo,
             title.orEmpty(),

--- a/submission/submission-webapp/src/test/kotlin/ac/uk/ebi/biostd/submission/domain/service/SubmissionServiceTest.kt
+++ b/submission/submission-webapp/src/test/kotlin/ac/uk/ebi/biostd/submission/domain/service/SubmissionServiceTest.kt
@@ -3,7 +3,6 @@ package ac.uk.ebi.biostd.submission.domain.service
 import ac.uk.ebi.biostd.integration.SerializationService
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionMetaQueryService
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionQueryService
-import ac.uk.ebi.biostd.submission.exceptions.ConcurrentProcessingSubmissionException
 import ac.uk.ebi.biostd.submission.model.SubmissionRequest
 import ac.uk.ebi.biostd.submission.submitter.SubmissionSubmitter
 import ebi.ac.uk.extended.model.ExtSubmission
@@ -14,8 +13,6 @@ import io.mockk.junit5.MockKExtension
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.amqp.rabbit.core.RabbitTemplate
 import uk.ac.ebi.events.service.EventsPublisherService
@@ -51,23 +48,5 @@ class SubmissionServiceTest(
         val submission = testInstance.submit(submissionRequest)
         assertThat(submission).isEqualTo(extSubmission)
         verify(exactly = 1) { eventsPublisherService.submissionSubmitted(extSubmission) }
-    }
-
-    @Test
-    fun `require not processing when concurrent`() {
-        every { queryService.isProcessing("S-TEST123") } returns true
-
-        val exception = assertThrows<ConcurrentProcessingSubmissionException> {
-            testInstance.requireNotProcessing("S-TEST123")
-        }
-
-        assertThat(exception.message).isEqualTo(
-            "Submission request can't be accepted. Another version for 'S-TEST123' is currently being processed.")
-    }
-
-    @Test
-    fun `require not processing when not concurrent`() {
-        every { queryService.isProcessing("S-TEST123") } returns false
-        assertDoesNotThrow { testInstance.requireNotProcessing("S-TEST123") }
     }
 }

--- a/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/service/AccNoService.kt
+++ b/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/service/AccNoService.kt
@@ -1,7 +1,6 @@
 package ac.uk.ebi.biostd.submission.service
 
 import ac.uk.ebi.biostd.persistence.common.service.PersistenceService
-import ac.uk.ebi.biostd.persistence.common.service.SubmissionMetaQueryService
 import ac.uk.ebi.biostd.submission.exceptions.ProvideAccessNumber
 import ac.uk.ebi.biostd.submission.exceptions.UserCanNotSubmitToProjectException
 import ac.uk.ebi.biostd.submission.exceptions.UserCanNotUpdateSubmit
@@ -14,16 +13,15 @@ const val PATH_DIGITS = 3
 
 class AccNoService(
     private val service: PersistenceService,
-    private val queryService: SubmissionMetaQueryService,
     private val patternUtil: AccNoPatternUtil,
     private val privilegesService: IUserPrivilegesService
 ) {
     @Suppress("ThrowsCount")
     fun getAccNo(request: AccNoServiceRequest): AccNumber {
-        val (submitter, accNo, project, projectPattern) = request
+        val (submitter, accNo, isNew, project, projectPattern) = request
 
         when {
-            accNo == null || queryService.isNew(accNo) -> {
+            accNo == null || isNew -> {
                 if (accNo != null && privilegesService.canProvideAccNo(submitter).not())
                     throw ProvideAccessNumber(submitter)
                 if (project != null && privilegesService.canSubmitToProject(submitter, project).not())
@@ -61,6 +59,7 @@ class AccNoService(
 data class AccNoServiceRequest(
     val submitter: String,
     val accNo: String? = null,
+    val isNew: Boolean = true,
     val project: String? = null,
     val projectPattern: String? = null
 )

--- a/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/service/ParentInfoService.kt
+++ b/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/service/ParentInfoService.kt
@@ -1,7 +1,6 @@
 package ac.uk.ebi.biostd.submission.service
 
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionMetaQueryService
-import ac.uk.ebi.biostd.persistence.exception.ProjectNotFoundException
 import ac.uk.ebi.biostd.submission.exceptions.ProjectInvalidAccessTagException
 import ebi.ac.uk.model.constants.SubFields
 import java.time.OffsetDateTime
@@ -13,15 +12,15 @@ class ParentInfoService(private val queryService: SubmissionMetaQueryService) {
     }
 
     private fun parentInfo(parentAccNo: String): ParentInfo {
-        require(queryService.existByAccNo(parentAccNo)) { throw ProjectNotFoundException(parentAccNo) }
+        val project = queryService.getBasicProject(parentAccNo)
+        return ParentInfo(accessTags(parentAccNo), project.releaseTime, project.accNoPattern)
+    }
 
+    private fun accessTags(parentAccNo: String): List<String> {
         val accessTags = queryService.getAccessTags(parentAccNo).filterNot { it == SubFields.PUBLIC_ACCESS_TAG.value }
         require(accessTags.contains(parentAccNo)) { throw ProjectInvalidAccessTagException(parentAccNo) }
 
-        return ParentInfo(
-            accessTags,
-            queryService.getReleaseTime(parentAccNo),
-            queryService.getParentAccPattern(parentAccNo))
+        return accessTags
     }
 }
 

--- a/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/service/ProjectInfoService.kt
+++ b/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/service/ProjectInfoService.kt
@@ -1,7 +1,6 @@
 package ac.uk.ebi.biostd.submission.service
 
 import ac.uk.ebi.biostd.persistence.common.service.PersistenceService
-import ac.uk.ebi.biostd.persistence.common.service.SubmissionMetaQueryService
 import ac.uk.ebi.biostd.submission.exceptions.ProjectAccNoTemplateAlreadyExistsException
 import ac.uk.ebi.biostd.submission.exceptions.ProjectAlreadyExistingException
 import ac.uk.ebi.biostd.submission.exceptions.ProjectInvalidAccNoPatternException
@@ -14,16 +13,14 @@ internal const val ACC_NO_TEMPLATE_INVALID = "The given AccNoTemplate is invalid
 
 class ProjectInfoService(
     private val service: PersistenceService,
-    private val queryService: SubmissionMetaQueryService,
     private val accNoUtil: AccNoPatternUtil,
     private val privilegesService: IUserPrivilegesService
 ) {
     fun process(request: ProjectRequest): ProjectResponse? {
-        val (submitter, subType, template, accNo) = request
+        val (submitter, subType, template, accNo, isNew) = request
 
         if (subType != "Project") return null
 
-        val isNew = queryService.isNew(accNo)
         require(privilegesService.canSubmitProjects(submitter)) { throw UserCanNotSubmitProjectsException(submitter) }
         validatePattern(template)
 
@@ -53,5 +50,12 @@ class ProjectInfoService(
     }
 }
 
-data class ProjectRequest(val submitter: String, val subType: String, val accNoTemplate: String?, val accNo: String)
+data class ProjectRequest(
+    val submitter: String,
+    val subType: String,
+    val accNoTemplate: String?,
+    val accNo: String,
+    val isNew: Boolean = true
+)
+
 data class ProjectResponse(val accessTag: String)

--- a/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/service/TimesService.kt
+++ b/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/service/TimesService.kt
@@ -1,6 +1,5 @@
 package ac.uk.ebi.biostd.submission.service
 
-import ac.uk.ebi.biostd.persistence.common.service.SubmissionMetaQueryService
 import ac.uk.ebi.biostd.submission.exceptions.InvalidDateFormatException
 import java.time.Instant
 import java.time.LocalDate
@@ -11,10 +10,10 @@ import java.time.ZoneOffset
 /**
  * Calculates the submission release date based on current state of the submission in the system. Calculation rules.
  */
-class TimesService(private val queryService: SubmissionMetaQueryService) {
+class TimesService {
     internal fun getTimes(request: TimesRequest): Times {
         val now = OffsetDateTime.now()
-        val creationTime = queryService.findCreationTime(request.accNo) ?: now
+        val creationTime = request.creationTime ?: now
         val releaseTime = request.releaseDate?.let { parseDate(it) }
         return Times(creationTime, now, releaseTime)
     }
@@ -34,5 +33,6 @@ data class Times(
 data class TimesRequest(
     val accNo: String,
     val releaseDate: String? = null,
+    val creationTime: OffsetDateTime? = null,
     val parentReleaseTime: OffsetDateTime? = null
 )

--- a/submission/submitter/src/test/kotlin/ac/uk/ebi/biostd/submission/service/ParentInfoServiceTest.kt
+++ b/submission/submitter/src/test/kotlin/ac/uk/ebi/biostd/submission/service/ParentInfoServiceTest.kt
@@ -1,7 +1,7 @@
 package ac.uk.ebi.biostd.submission.service
 
+import ac.uk.ebi.biostd.persistence.common.model.BasicProject
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionMetaQueryService
-import ac.uk.ebi.biostd.persistence.exception.ProjectNotFoundException
 import ac.uk.ebi.biostd.submission.exceptions.ProjectInvalidAccessTagException
 import ebi.ac.uk.model.constants.SubFields.PUBLIC_ACCESS_TAG
 import io.mockk.every
@@ -15,7 +15,9 @@ import java.time.OffsetDateTime
 import java.time.ZoneOffset
 
 @ExtendWith(MockKExtension::class)
-class ParentInfoServiceTest(@MockK private val queryService: SubmissionMetaQueryService) {
+class ParentInfoServiceTest(
+    @MockK private val queryService: SubmissionMetaQueryService
+) {
     private val testInstance = ParentInfoService(queryService)
 
     @Test
@@ -31,10 +33,9 @@ class ParentInfoServiceTest(@MockK private val queryService: SubmissionMetaQuery
         val parentTemplate = "!{S-BIAD}"
         val parentAccNo = "BioImages-EMPIAR"
         val testTime = OffsetDateTime.of(2018, 10, 10, 0, 0, 0, 0, ZoneOffset.UTC)
+        val basicProject = BasicProject("BioImages-EMPIAR", "!{S-BIAD}", testTime)
 
-        every { queryService.existByAccNo(parentAccNo) } returns true
-        every { queryService.getReleaseTime(parentAccNo) } returns testTime
-        every { queryService.getParentAccPattern(parentAccNo) } returns parentTemplate
+        every { queryService.getBasicProject(parentAccNo) } returns basicProject
         every { queryService.getAccessTags(parentAccNo) } returns listOf(PUBLIC_ACCESS_TAG.value, parentAccNo)
 
         val parentInfo = testInstance.getParentInfo(parentAccNo)
@@ -47,17 +48,11 @@ class ParentInfoServiceTest(@MockK private val queryService: SubmissionMetaQuery
     @Test
     fun `project without access tag`() {
         val parentAccNo = "BioImages-EMPIAR"
-        every { queryService.existByAccNo(parentAccNo) } returns true
+        val basicProject = BasicProject(parentAccNo, "!{S-BIAD}", null)
+
+        every { queryService.getBasicProject(parentAccNo) } returns basicProject
         every { queryService.getAccessTags(parentAccNo) } returns listOf("Empiar")
 
         assertThrows<ProjectInvalidAccessTagException> { testInstance.getParentInfo(parentAccNo) }
-    }
-
-    @Test
-    fun `project not existing`() {
-        val parentAccNo = "BioImages-EMPIAR"
-        every { queryService.existByAccNo(parentAccNo) } returns false
-
-        assertThrows<ProjectNotFoundException> { testInstance.getParentInfo(parentAccNo) }
     }
 }

--- a/submission/submitter/src/test/kotlin/ac/uk/ebi/biostd/submission/service/ProjectInfoServiceTest.kt
+++ b/submission/submitter/src/test/kotlin/ac/uk/ebi/biostd/submission/service/ProjectInfoServiceTest.kt
@@ -1,7 +1,6 @@
 package ac.uk.ebi.biostd.submission.service
 
 import ac.uk.ebi.biostd.persistence.common.service.PersistenceService
-import ac.uk.ebi.biostd.persistence.common.service.SubmissionMetaQueryService
 import ac.uk.ebi.biostd.submission.exceptions.ProjectAccNoTemplateAlreadyExistsException
 import ac.uk.ebi.biostd.submission.exceptions.ProjectAlreadyExistingException
 import ac.uk.ebi.biostd.submission.exceptions.ProjectInvalidAccNoPatternException
@@ -25,11 +24,10 @@ import kotlin.test.assertNull
 @ExtendWith(MockKExtension::class)
 class ProjectInfoServiceTest(
     @MockK private val service: PersistenceService,
-    @MockK private val queryService: SubmissionMetaQueryService,
     @MockK private val accNoUtil: AccNoPatternUtil,
     @MockK private val privilegesService: IUserPrivilegesService
 ) {
-    private val testInstance = ProjectInfoService(service, queryService, accNoUtil, privilegesService)
+    private val testInstance = ProjectInfoService(service, accNoUtil, privilegesService)
 
     @AfterEach
     fun afterEach() = clearAllMocks()
@@ -38,7 +36,6 @@ class ProjectInfoServiceTest(
     fun beforeEach() {
         initContext()
         initAccNoUtil()
-        every { queryService.isNew("TheProject") } returns true
         every { privilegesService.canSubmitProjects("user@test.org") } returns true
     }
 

--- a/submission/submitter/src/test/kotlin/ac/uk/ebi/biostd/submission/service/TimesServiceTest.kt
+++ b/submission/submitter/src/test/kotlin/ac/uk/ebi/biostd/submission/service/TimesServiceTest.kt
@@ -1,9 +1,7 @@
 package ac.uk.ebi.biostd.submission.service
 
-import ac.uk.ebi.biostd.persistence.common.service.SubmissionMetaQueryService
 import ac.uk.ebi.biostd.submission.exceptions.InvalidDateFormatException
 import io.mockk.every
-import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockkStatic
 import org.assertj.core.api.Assertions.assertThat
@@ -18,8 +16,8 @@ import java.time.ZoneOffset
 private const val ACC_NO = "ABC456"
 
 @ExtendWith(MockKExtension::class)
-class TimesServiceTest(@MockK private val queryService: SubmissionMetaQueryService) {
-    private val testInstance = TimesService(queryService)
+class TimesServiceTest {
+    private val testInstance = TimesService()
     private val testTime = OffsetDateTime.of(2018, 10, 10, 0, 0, 0, 0, ZoneOffset.UTC)
     private val mockNow = OffsetDateTime.of(2018, 12, 31, 0, 0, 0, 0, ZoneOffset.UTC)
 
@@ -27,7 +25,6 @@ class TimesServiceTest(@MockK private val queryService: SubmissionMetaQueryServi
     fun beforeEach() {
         mockkStatic(OffsetDateTime::class)
         every { OffsetDateTime.now() } returns mockNow
-        every { queryService.findCreationTime(ACC_NO) } returns null
     }
 
     @Nested
@@ -43,9 +40,7 @@ class TimesServiceTest(@MockK private val queryService: SubmissionMetaQueryServi
     inner class CreationTime {
         @Test
         fun `when exists`() {
-            every { queryService.findCreationTime(ACC_NO) } returns testTime
-
-            val times = testInstance.getTimes(TimesRequest(ACC_NO))
+            val times = testInstance.getTimes(TimesRequest(accNo = ACC_NO, creationTime = testTime))
             assertThat(times.createTime).isEqualTo(testTime)
         }
 

--- a/submission/submitter/src/test/kotlin/ac/uk/ebi/biostd/submission/submitter/SubmissionSubmitterTest.kt
+++ b/submission/submitter/src/test/kotlin/ac/uk/ebi/biostd/submission/submitter/SubmissionSubmitterTest.kt
@@ -1,6 +1,6 @@
 package ac.uk.ebi.biostd.submission.submitter
 
-import ac.uk.ebi.biostd.persistence.common.model.SimpleSubmission
+import ac.uk.ebi.biostd.persistence.common.model.BasicSubmission
 import ac.uk.ebi.biostd.persistence.common.request.SaveSubmissionRequest
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionMetaQueryService
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionRequestService
@@ -63,7 +63,7 @@ class SubmissionSubmitterTest {
     private val queryService = mockk<SubmissionMetaQueryService>()
     private val projectInfoService = mockk<ProjectInfoService>()
     private val submissionRequestService = mockk<SubmissionRequestService>()
-    private val basicSubmission = mockk<SimpleSubmission>()
+    private val basicSubmission = mockk<BasicSubmission>()
 
     private val timesRequest = slot<TimesRequest>()
     private val saveRequest = slot<SaveSubmissionRequest>()

--- a/submission/submitter/src/test/kotlin/ac/uk/ebi/biostd/submission/submitter/SubmissionSubmitterTest.kt
+++ b/submission/submitter/src/test/kotlin/ac/uk/ebi/biostd/submission/submitter/SubmissionSubmitterTest.kt
@@ -1,5 +1,6 @@
 package ac.uk.ebi.biostd.submission.submitter
 
+import ac.uk.ebi.biostd.persistence.common.model.SimpleSubmission
 import ac.uk.ebi.biostd.persistence.common.request.SaveSubmissionRequest
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionMetaQueryService
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionRequestService
@@ -62,6 +63,7 @@ class SubmissionSubmitterTest {
     private val queryService = mockk<SubmissionMetaQueryService>()
     private val projectInfoService = mockk<ProjectInfoService>()
     private val submissionRequestService = mockk<SubmissionRequestService>()
+    private val basicSubmission = mockk<SimpleSubmission>()
 
     private val timesRequest = slot<TimesRequest>()
     private val saveRequest = slot<SaveSubmissionRequest>()
@@ -74,6 +76,7 @@ class SubmissionSubmitterTest {
     @BeforeEach
     fun beforeEach() {
         mockServices()
+        mockBasicSubmission()
         mockPersistenceContext()
         mockkStatic("ebi.ac.uk.extended.mapping.to.ToSubmissionKt")
         every { any<ExtSubmission>().toSimpleSubmission() } returns submission
@@ -176,7 +179,7 @@ class SubmissionSubmitterTest {
         accNoService.getRelPath(accNo)
         accNoService.getAccNo(accNoServiceRequest.captured)
 
-        queryService.getSecret("S-TEST123")
+        queryService.findLatestBasicByAccNo("S-TEST123")
 
         parentInfoService.getParentInfo("BioImages")
 
@@ -189,13 +192,16 @@ class SubmissionSubmitterTest {
         submissionRequestService.saveAndProcessSubmissionRequest(saveRequest.captured)
     }
 
+    private fun mockBasicSubmission() {
+        every { basicSubmission.creationTime } returns testTime
+        every { basicSubmission.secretKey } returns "a-secret-key"
+        every { basicSubmission.owner } returns "the-owner@mail.com"
+    }
+
     private fun mockServices() {
         every { accNoService.getRelPath(accNo) } returns "/a/rel/path"
         every { accNoService.getAccNo(capture(accNoServiceRequest)) } returns accNo
-        every { queryService.getOwner("S-TEST123") } returns null
-        every { queryService.isNew("S-TEST123") } returns false
-        every { queryService.isProcessing("S-TEST123") } returns false
-        every { queryService.getSecret("S-TEST123") } returns "a-secret-key"
+        every { queryService.findLatestBasicByAccNo("S-TEST123") } returns basicSubmission
         every { timesService.getTimes(capture(timesRequest)) } returns Times(testTime, testTime, null)
         every { projectInfoService.process(capture(projectRequest)) } returns ProjectResponse("BioImages")
         every { parentInfoService.getParentInfo("BioImages") } returns ParentInfo(emptyList(), null, "S-BIAD")


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/175163839

- Simplify SubmissionOperations interface and implementation
- Adjust services that used these queries in order to avoid multiple DB requests
- Adjust tests
- Rename SimpleSubmission to BasicSubmission in order to preserve the same terms all over the code