### PR TITLE
Send Content-Disposition and Content-Length headers while downloading files

### DIFF
--- a/infrastructure/build.gradle.kts
+++ b/infrastructure/build.gradle.kts
@@ -24,7 +24,16 @@ tasks.register("setUpTestDatabase") {
 tasks.register("setUpDatabase") {
     project.ext["linuxScript"] = "./SetUpDatabase.sh"
     project.ext["windowsScript"] = "SetUpDatabase.cmd"
-    project.ext["workingDir"] = "./src/main/resources/setup/database"
+    project.ext["workingDir"] = "./src/main/resources/setup/mysql"
+
+    finalizedBy("executeScript")
+}
+
+tasks.register("setUpMongoDatabase") {
+    project.ext["args"] = ""
+    project.ext["linuxScript"] = "./SetUpMongoDatabase.sh"
+    project.ext["windowsScript"] = ""
+    project.ext["workingDir"] = "./src/main/resources/setup/mongo"
 
     finalizedBy("executeScript")
 }

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/files/web/resources/UserFilesResource.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/files/web/resources/UserFilesResource.kt
@@ -6,8 +6,7 @@ import ac.uk.ebi.biostd.files.web.common.UserPath
 import ac.uk.ebi.biostd.submission.converters.BioUser
 import ebi.ac.uk.security.integration.model.api.SecurityUser
 import org.springframework.core.io.FileSystemResource
-import org.springframework.http.HttpStatus
-import org.springframework.http.MediaType
+import org.springframework.http.*
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -37,7 +36,13 @@ class UserFilesResource(
         @BioUser user: SecurityUser,
         @RequestParam(name = "fileName") fileName: String,
         pathDescriptor: UserPath
-    ): FileSystemResource = FileSystemResource(fileManager.getFile(user, pathDescriptor.path, fileName))
+    ): ResponseEntity<FileSystemResource> {
+        val fileSystemResource = FileSystemResource(fileManager.getFile(user, pathDescriptor.path, fileName))
+        val contentDisposition = ContentDisposition.builder("inline").filename(fileSystemResource.filename).build()
+        val headers = HttpHeaders().apply { setContentDisposition(contentDisposition) }
+
+        return ResponseEntity.ok().headers(headers).contentLength(fileSystemResource.contentLength()).body(fileSystemResource)
+    }
 
     @PostMapping("/files/user/**")
     @ResponseStatus(value = HttpStatus.OK)

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/files/web/resources/UserFilesResource.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/files/web/resources/UserFilesResource.kt
@@ -6,7 +6,11 @@ import ac.uk.ebi.biostd.files.web.common.UserPath
 import ac.uk.ebi.biostd.submission.converters.BioUser
 import ebi.ac.uk.security.integration.model.api.SecurityUser
 import org.springframework.core.io.FileSystemResource
-import org.springframework.http.*
+import org.springframework.http.ContentDisposition
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -37,11 +41,20 @@ class UserFilesResource(
         @RequestParam(name = "fileName") fileName: String,
         pathDescriptor: UserPath
     ): ResponseEntity<FileSystemResource> {
-        val fileSystemResource = FileSystemResource(fileManager.getFile(user, pathDescriptor.path, fileName))
-        val contentDisposition = ContentDisposition.builder("inline").filename(fileSystemResource.filename).build()
+        val fileSystemResource = FileSystemResource(
+            fileManager.getFile(user, pathDescriptor.path, fileName)
+        )
+        val contentDisposition = ContentDisposition
+            .builder("inline")
+            .filename(fileSystemResource.filename)
+            .build()
         val headers = HttpHeaders().apply { setContentDisposition(contentDisposition) }
 
-        return ResponseEntity.ok().headers(headers).contentLength(fileSystemResource.contentLength()).body(fileSystemResource)
+        return ResponseEntity
+            .ok()
+            .headers(headers)
+            .contentLength(fileSystemResource.contentLength())
+            .body(fileSystemResource)
     }
 
     @PostMapping("/files/user/**")

--- a/submission/submission-webapp/src/test/kotlin/ac/uk/ebi/biostd/files/web/UserFilesResourceTest.kt
+++ b/submission/submission-webapp/src/test/kotlin/ac/uk/ebi/biostd/files/web/UserFilesResourceTest.kt
@@ -1,0 +1,59 @@
+package ac.uk.ebi.biostd.files.web
+
+import ac.uk.ebi.biostd.factory.TestSuperUser
+import ac.uk.ebi.biostd.files.service.UserFilesService
+import ac.uk.ebi.biostd.files.web.common.FilesMapper
+import ac.uk.ebi.biostd.files.web.resources.UserFilesResource
+import ac.uk.ebi.biostd.resolvers.TEST_USER_PATH
+import ac.uk.ebi.biostd.resolvers.TestBioUserResolver
+import ac.uk.ebi.biostd.resolvers.TestUserPathResolver
+import ebi.ac.uk.security.integration.model.api.SecurityUser
+import ebi.ac.uk.test.createFile
+import io.github.glytching.junit.extension.folder.TemporaryFolder
+import io.github.glytching.junit.extension.folder.TemporaryFolderExtension
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.slot
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+
+@ExtendWith(MockKExtension::class, TemporaryFolderExtension::class)
+class UserFilesResourceTest(
+    private val tempFolder: TemporaryFolder,
+    @MockK private val filesMapper: FilesMapper,
+    @MockK private val fileManager: UserFilesService
+) {
+    private val bioUserResolver = TestBioUserResolver()
+    private val userPathResource = TestUserPathResolver()
+    private val testInstance = UserFilesResource(filesMapper, fileManager)
+    private val mvc = MockMvcBuilders
+        .standaloneSetup(testInstance)
+        .setCustomArgumentResolvers(bioUserResolver, userPathResource)
+        .build()
+
+    @AfterEach
+    fun afterEach() = clearAllMocks()
+
+    @Test
+    fun `download file`() {
+        val file = tempFolder.createFile("test.txt", "test content")
+        val user = slot<SecurityUser>()
+        bioUserResolver.securityUser = TestSuperUser.asSecurityUser()
+
+        every { fileManager.getFile(capture(user), TEST_USER_PATH, file.name) } returns file
+
+        mvc.get("/files/user/folder") {
+            accept = MediaType.APPLICATION_OCTET_STREAM
+            param("fileName", file.name)
+        }.andExpect {
+            status { isOk }
+            header { string("Content-Disposition", "inline; filename=\"test.txt\"") }
+        }
+    }
+}

--- a/submission/submission-webapp/src/test/kotlin/ac/uk/ebi/biostd/resolvers/TestUserPathResolver.kt
+++ b/submission/submission-webapp/src/test/kotlin/ac/uk/ebi/biostd/resolvers/TestUserPathResolver.kt
@@ -1,0 +1,21 @@
+package ac.uk.ebi.biostd.resolvers
+
+import ac.uk.ebi.biostd.files.web.common.UserPath
+import org.springframework.core.MethodParameter
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+
+internal const val TEST_USER_PATH = "/test/path"
+
+internal class TestUserPathResolver : HandlerMethodArgumentResolver {
+    override fun supportsParameter(parameter: MethodParameter) = parameter.parameterType == UserPath::class.java
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory
+    ) = UserPath(TEST_USER_PATH)
+}


### PR DESCRIPTION
Additionally:
- Fixes `setUpDatabase` task
- Adds `setUpMongoDatabase` task 