### PR TITLE
Pivotal ID # 179024679: Fix RabbitMQ version to 3.8

### DIFF
--- a/infrastructure/src/main/resources/setup/rabbitmq/SetUpRabbitMQ.cmd
+++ b/infrastructure/src/main/resources/setup/rabbitmq/SetUpRabbitMQ.cmd
@@ -4,4 +4,4 @@ docker run -d ^
   -e RABBITMQ_DEFAULT_USER=manager ^
   -e RABBITMQ_DEFAULT_PASS=manager-local ^
   -p 4369:4369 -p 5672:5672 -p 15672:15672 -p 25672:25672 ^
-  rabbitmq:3-management
+  rabbitmq:3.8-management

--- a/infrastructure/src/main/resources/setup/rabbitmq/SetUpRabbitMQ.sh
+++ b/infrastructure/src/main/resources/setup/rabbitmq/SetUpRabbitMQ.sh
@@ -5,4 +5,4 @@ docker run -d \
   -e RABBITMQ_DEFAULT_USER=manager \
   -e RABBITMQ_DEFAULT_PASS=manager-local \
   -p 4369:4369 -p 5672:5672 -p 15672:15672 -p 25672:25672 \
-  rabbitmq:3-management;
+  rabbitmq:3.8-management;


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/179024679

* Pin RabbitMQ container to 3.8-management (already used)
