### PR TITLE
Pivotal ID # 179389139: FIRE Directories Persistence

### DIFF
--- a/commons/commons-bio/src/main/kotlin/ebi/ac/uk/io/sources/FilesSource.kt
+++ b/commons/commons-bio/src/main/kotlin/ebi/ac/uk/io/sources/FilesSource.kt
@@ -3,6 +3,7 @@ package ebi.ac.uk.io.sources
 import ebi.ac.uk.io.ext.md5
 import ebi.ac.uk.io.ext.size
 import java.io.File
+import java.lang.UnsupportedOperationException
 
 interface FilesSource {
     fun exists(filePath: String): Boolean
@@ -31,4 +32,13 @@ class FireBioFile(
     override fun readContent(): String = readContent.value
     override fun md5(): String = md5
     override fun size(): Long = size
+}
+
+class FireDirectoryBioFile(
+    val md5: String,
+    val size: Long
+) : BioFile() {
+    override fun md5(): String = md5
+    override fun size(): Long = size
+    override fun readContent(): String = throw UnsupportedOperationException()
 }

--- a/commons/commons-model-extended-mapping/src/main/kotlin/ebi/ac/uk/extended/mapping/from/ToExtAttribute.kt
+++ b/commons/commons-model-extended-mapping/src/main/kotlin/ebi/ac/uk/extended/mapping/from/ToExtAttribute.kt
@@ -13,4 +13,6 @@ fun Attribute.toExtAttribute(): ExtAttribute {
     return ExtAttribute(name, attrValue, reference, toDetails(nameAttrs), toDetails(valueAttrs))
 }
 
+fun List<Attribute>.toExtAttributes(): List<ExtAttribute> = map { it.toExtAttribute() }
+
 private fun toDetails(details: List<AttributeDetail>) = details.map { ExtAttributeDetail(it.name, it.value) }

--- a/commons/commons-model-extended-mapping/src/main/kotlin/ebi/ac/uk/extended/mapping/from/ToExtFile.kt
+++ b/commons/commons-model-extended-mapping/src/main/kotlin/ebi/ac/uk/extended/mapping/from/ToExtFile.kt
@@ -1,10 +1,12 @@
 package ebi.ac.uk.extended.mapping.from
 
 import ebi.ac.uk.extended.model.ExtFile
+import ebi.ac.uk.extended.model.FireDirectory
 import ebi.ac.uk.extended.model.FireFile
 import ebi.ac.uk.extended.model.NfsFile
 import ebi.ac.uk.io.sources.FilesSource
 import ebi.ac.uk.io.sources.FireBioFile
+import ebi.ac.uk.io.sources.FireDirectoryBioFile
 import ebi.ac.uk.io.sources.NfsBioFile
 import ebi.ac.uk.model.File
 
@@ -12,7 +14,8 @@ internal const val TO_EXT_FILE_EXTENSIONS = "ebi.ac.uk.extended.mapping.from.ToE
 
 fun File.toExtFile(fileSource: FilesSource): ExtFile {
     return when (val file = fileSource.getFile(path)) {
-        is FireBioFile -> FireFile(path, file.fireId, file.md5, file.size(), attributes.map { it.toExtAttribute() })
-        is NfsBioFile -> NfsFile(path, file.file, attributes.map { it.toExtAttribute() })
+        is FireBioFile -> FireFile(path, file.fireId, file.md5, file.size(), attributes.toExtAttributes())
+        is FireDirectoryBioFile -> FireDirectory(path, file.md5, file.size, attributes.toExtAttributes())
+        is NfsBioFile -> NfsFile(path, file.file, attributes.toExtAttributes())
     }
 }

--- a/commons/commons-model-extended-mapping/src/main/kotlin/ebi/ac/uk/extended/mapping/to/ToFile.kt
+++ b/commons/commons-model-extended-mapping/src/main/kotlin/ebi/ac/uk/extended/mapping/to/ToFile.kt
@@ -1,6 +1,7 @@
 package ebi.ac.uk.extended.mapping.to
 
 import ebi.ac.uk.extended.model.ExtFile
+import ebi.ac.uk.extended.model.FireDirectory
 import ebi.ac.uk.extended.model.FireFile
 import ebi.ac.uk.extended.model.NfsFile
 import ebi.ac.uk.io.FileUtils
@@ -15,10 +16,12 @@ fun ExtFile.toFile(): File =
     when (this) {
         is NfsFile -> File(fileName, file.size(), type, attributes.mapTo(mutableListOf()) { it.toAttribute() })
         is FireFile -> File(fileName, size, type, attributes.mapTo(mutableListOf()) { it.toAttribute() })
+        is FireDirectory -> File(fileName, size, type, attributes.mapTo(mutableListOf()) { it.toAttribute() })
     }
 
 private val ExtFile.type
     get() = when (this) {
         is NfsFile -> if (FileUtils.isDirectory(file)) DIR_TYPE.value else FILE_TYPE.value
         is FireFile -> FILE_TYPE.value
+        is FireDirectory -> DIR_TYPE.value
     }

--- a/commons/commons-model-extended-mapping/src/test/kotlin/ebi/ac/uk/extended/mapping/from/ToExtAttributeTest.kt
+++ b/commons/commons-model-extended-mapping/src/test/kotlin/ebi/ac/uk/extended/mapping/from/ToExtAttributeTest.kt
@@ -31,6 +31,18 @@ internal class ToExtAttributeTest {
         assertValueAttribute(extendedAttribute.valueAttrs)
     }
 
+    @Test
+    fun toExtAttributes() {
+        val extendedAttributes = listOf(attribute).toExtAttributes()
+        assertThat(extendedAttributes).hasSize(1)
+
+        val extendedAttribute = extendedAttributes.first()
+        assertThat(extendedAttribute.name).isEqualTo(attribute.name)
+        assertThat(extendedAttribute.value).isEqualTo(attribute.value)
+        assertNameAttribute(extendedAttribute.nameAttrs)
+        assertValueAttribute(extendedAttribute.valueAttrs)
+    }
+
     private fun assertNameAttribute(nameAttrs: List<ExtAttributeDetail>) {
         assertThat(nameAttrs).hasSize(1)
 

--- a/commons/commons-model-extended-mapping/src/test/kotlin/ebi/ac/uk/extended/mapping/from/ToExtFileTest.kt
+++ b/commons/commons-model-extended-mapping/src/test/kotlin/ebi/ac/uk/extended/mapping/from/ToExtFileTest.kt
@@ -1,27 +1,67 @@
 package ebi.ac.uk.extended.mapping.from
 
+import ebi.ac.uk.extended.model.ExtFile
+import ebi.ac.uk.extended.model.FireDirectory
+import ebi.ac.uk.extended.model.FireFile
 import ebi.ac.uk.extended.model.NfsFile
+import ebi.ac.uk.io.sources.FilesSource
+import ebi.ac.uk.io.sources.FireBioFile
+import ebi.ac.uk.io.sources.FireDirectoryBioFile
 import ebi.ac.uk.io.sources.PathFilesSource
 import ebi.ac.uk.model.File
 import io.github.glytching.junit.extension.folder.TemporaryFolder
 import io.github.glytching.junit.extension.folder.TemporaryFolderExtension
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
-@ExtendWith(value = [MockKExtension::class, TemporaryFolderExtension::class])
+@ExtendWith(MockKExtension::class, TemporaryFolderExtension::class)
 internal class ToExtFileTest(private val tempFolder: TemporaryFolder) {
-
     private val file = File("fileName", 55L, "file", listOf(attribute))
     private val systemFile = tempFolder.createFile(file.path)
 
     @Test
-    fun toExtFile() {
+    fun `nfs file to ext file`() {
         val extFile = file.toExtFile(PathFilesSource(tempFolder.root.toPath())) as NfsFile
 
         assertThat(extFile.fileName).isEqualTo(file.path)
         assertThat(extFile.file).isEqualTo(systemFile)
+        assertAttributes(extFile)
+    }
+
+    @Test
+    fun `fire file to ext file`(
+        @MockK fileSource: FilesSource
+    ) {
+        val fireBioFile = FireBioFile("fire-id", "md5", 12, lazy { "content" })
+        every { fileSource.getFile("fileName") } returns fireBioFile
+
+        val extFile = file.toExtFile(fileSource) as FireFile
+        assertThat(extFile.fileName).isEqualTo(file.path)
+        assertThat(extFile.fireId).isEqualTo("fire-id")
+        assertThat(extFile.md5).isEqualTo("md5")
+        assertThat(extFile.size).isEqualTo(12)
+        assertAttributes(extFile)
+    }
+
+    @Test
+    fun `fire directory to ext file`(
+        @MockK fileSource: FilesSource
+    ) {
+        val fireDirectory = FireDirectoryBioFile("md5", 12)
+        every { fileSource.getFile("fileName") } returns fireDirectory
+
+        val extFile = file.toExtFile(fileSource) as FireDirectory
+        assertThat(extFile.fileName).isEqualTo(file.path)
+        assertThat(extFile.md5).isEqualTo("md5")
+        assertThat(extFile.size).isEqualTo(12)
+        assertAttributes(extFile)
+    }
+
+    private fun assertAttributes(extFile: ExtFile) {
         assertThat(extFile.attributes).hasSize(1)
         assertAttribute(extFile.attributes.first(), file.attributes.first())
     }

--- a/commons/commons-model-extended-mapping/src/test/kotlin/ebi/ac/uk/extended/mapping/to/ToAttributeTest.kt
+++ b/commons/commons-model-extended-mapping/src/test/kotlin/ebi/ac/uk/extended/mapping/to/ToAttributeTest.kt
@@ -11,7 +11,8 @@ import org.junit.jupiter.api.extension.ExtendWith
 @ExtendWith(MockKExtension::class)
 internal class ToAttributeTest {
     private val expectedNameAttribute = ExtAttributeDetail(name = "Name Attribute Name", value = "Name Attribute Value")
-    private val expectedValueAttribute = ExtAttributeDetail(name = "Value Attribute Name", value = "Value Attribute Value")
+    private val expectedValueAttribute =
+        ExtAttributeDetail(name = "Value Attribute Name", value = "Value Attribute Value")
 
     private val extAttribute = ExtAttribute(
         name = "Attribute Name",

--- a/commons/commons-model-extended-mapping/src/test/kotlin/ebi/ac/uk/extended/mapping/to/ToFileTest.kt
+++ b/commons/commons-model-extended-mapping/src/test/kotlin/ebi/ac/uk/extended/mapping/to/ToFileTest.kt
@@ -1,8 +1,11 @@
 package ebi.ac.uk.extended.mapping.to
 
 import ebi.ac.uk.extended.model.ExtAttribute
+import ebi.ac.uk.extended.model.FireDirectory
+import ebi.ac.uk.extended.model.FireFile
 import ebi.ac.uk.extended.model.NfsFile
 import ebi.ac.uk.model.Attribute
+import ebi.ac.uk.model.File
 import ebi.ac.uk.test.createFile
 import io.github.glytching.junit.extension.folder.TemporaryFolder
 import io.github.glytching.junit.extension.folder.TemporaryFolderExtension
@@ -11,6 +14,7 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockkStatic
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
@@ -23,15 +27,32 @@ internal class ToFileTest(
     private var systemFile = tempFolder.createFile("my-file", "test content")
     private val extFile = NfsFile("fileName", systemFile, listOf(extAttribute))
 
-    @Test
-    fun toExtFile() {
-        mockkStatic(TO_ATTRIBUTE_EXTENSIONS) {
-            every { extAttribute.toAttribute() } returns attribute
+    @BeforeEach
+    fun beforeEach() {
+        mockkStatic(TO_ATTRIBUTE_EXTENSIONS)
+        every { extAttribute.toAttribute() } returns attribute
+    }
 
-            val file = extFile.toFile()
-            assertThat(file.attributes).containsExactly(attribute)
-            assertThat(file.size).isEqualTo(12L)
-            assertThat(file.path).isEqualTo(extFile.fileName)
-        }
+    @Test
+    fun `from nfs file`() {
+        assertFile(extFile.toFile())
+    }
+
+    @Test
+    fun `from fire file`() {
+        val fireFile = FireFile("fileName", "fireId", "md5", 12, listOf(extAttribute))
+        assertFile(fireFile.toFile())
+    }
+
+    @Test
+    fun `from fire directory`() {
+        val fireDirectory = FireDirectory("fileName", "md5", 12, listOf(extAttribute))
+        assertFile(fireDirectory.toFile())
+    }
+
+    private fun assertFile(file: File) {
+        assertThat(file.attributes).containsExactly(attribute)
+        assertThat(file.size).isEqualTo(12L)
+        assertThat(file.path).isEqualTo(extFile.fileName)
     }
 }

--- a/commons/commons-model-extended-serialization/src/main/kotlin/uk/ac/ebi/extended/serialization/constants/ExtType.kt
+++ b/commons/commons-model-extended-serialization/src/main/kotlin/uk/ac/ebi/extended/serialization/constants/ExtType.kt
@@ -4,6 +4,7 @@ import uk.ac.ebi.extended.serialization.exception.InvalidExtTypeException
 
 private const val NFS_FILE = "nfsFile"
 private const val FIRE_FILE = "fireFile"
+private const val FIRE_DIR = "fireDirectory"
 private const val FILES_TABLE = "filesTable"
 private const val LINK = "link"
 private const val LINKS_TABLE = "linksTable"
@@ -13,6 +14,7 @@ private const val SECTIONS_TABLE = "sectionsTable"
 sealed class ExtType(val type: String) {
     object NfsFile : ExtType(NFS_FILE)
     object FireFile : ExtType(FIRE_FILE)
+    object FireDirectory : ExtType(FIRE_DIR)
     object FilesTable : ExtType(FILES_TABLE)
     object Link : ExtType(LINK)
     object LinksTable : ExtType(LINKS_TABLE)

--- a/commons/commons-model-extended-serialization/src/main/kotlin/uk/ac/ebi/extended/serialization/deserializers/EitherExtTypeDeserializer.kt
+++ b/commons/commons-model-extended-serialization/src/main/kotlin/uk/ac/ebi/extended/serialization/deserializers/EitherExtTypeDeserializer.kt
@@ -17,6 +17,7 @@ import ebi.ac.uk.extended.model.ExtSectionTable
 import uk.ac.ebi.extended.serialization.constants.ExtSerializationFields.EXT_TYPE
 import uk.ac.ebi.extended.serialization.constants.ExtType
 import uk.ac.ebi.extended.serialization.constants.ExtType.FilesTable
+import uk.ac.ebi.extended.serialization.constants.ExtType.FireDirectory
 import uk.ac.ebi.extended.serialization.constants.ExtType.FireFile
 import uk.ac.ebi.extended.serialization.constants.ExtType.Link
 import uk.ac.ebi.extended.serialization.constants.ExtType.LinksTable
@@ -39,6 +40,7 @@ class EitherExtTypeDeserializer : JsonDeserializer<Either<*, *>>() {
             is Link -> Either.left(mapper.convertNode<ExtLink>(node))
             is NfsFile -> Either.left(mapper.convertNode<ExtFile>(node))
             is FireFile -> TODO()
+            is FireDirectory -> TODO()
             is Section -> Either.left(mapper.convertNode<ExtSection>(node))
             is LinksTable -> right(mapper.convertNode<ExtLinkTable>(node))
             is FilesTable -> right(mapper.convertNode<ExtFileTable>(node))

--- a/commons/commons-model-extended-serialization/src/main/kotlin/uk/ac/ebi/extended/serialization/serializers/ExtFileSerializer.kt
+++ b/commons/commons-model-extended-serialization/src/main/kotlin/uk/ac/ebi/extended/serialization/serializers/ExtFileSerializer.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.JsonSerializer
 import com.fasterxml.jackson.databind.SerializerProvider
 import ebi.ac.uk.extended.model.ExtFile
+import ebi.ac.uk.extended.model.FireDirectory
 import ebi.ac.uk.extended.model.FireFile
 import ebi.ac.uk.extended.model.NfsFile
 import ebi.ac.uk.io.FileUtils
@@ -25,6 +26,7 @@ class ExtFileSerializer : JsonSerializer<ExtFile>() {
         when (file) {
             is NfsFile -> gen.serializeNfsFile(file)
             is FireFile -> gen.serializeFireFile(file)
+            is FireDirectory -> gen.serializeFireDirectory(file)
         }
     }
 
@@ -47,6 +49,16 @@ class ExtFileSerializer : JsonSerializer<ExtFile>() {
         writeObjectField(ATTRIBUTES, file.attributes)
         writeStringField(EXT_TYPE, ExtType.FireFile.type)
         writeStringField(FILE_TYPE, FILE_FILE_TYPE)
+        writeNumberField(FILE_SIZE, file.size)
+        writeEndObject()
+    }
+
+    private fun JsonGenerator.serializeFireDirectory(file: FireDirectory) {
+        writeStartObject()
+        writeStringField(FILE_NAME, file.fileName)
+        writeObjectField(ATTRIBUTES, file.attributes)
+        writeStringField(EXT_TYPE, ExtType.FireDirectory.type)
+        writeStringField(FILE_TYPE, FILE_DIR_TYPE)
         writeNumberField(FILE_SIZE, file.size)
         writeEndObject()
     }

--- a/commons/commons-model-extended-serialization/src/test/kotlin/uk/ac/ebi/extended/serialization/serializers/ExtFileSerializerTest.kt
+++ b/commons/commons-model-extended-serialization/src/test/kotlin/uk/ac/ebi/extended/serialization/serializers/ExtFileSerializerTest.kt
@@ -3,6 +3,7 @@ package uk.ac.ebi.extended.serialization.serializers
 import ebi.ac.uk.dsl.json.jsonArray
 import ebi.ac.uk.dsl.json.jsonObj
 import ebi.ac.uk.extended.model.ExtAttribute
+import ebi.ac.uk.extended.model.FireDirectory
 import ebi.ac.uk.extended.model.FireFile
 import ebi.ac.uk.extended.model.NfsFile
 import ebi.ac.uk.io.ext.md5
@@ -21,7 +22,7 @@ class ExtFileSerializerTest(private val tempFolder: TemporaryFolder) {
     private val testInstance = ExtSerializationService.mapper
 
     @Test
-    fun `serialize NfsFile`() {
+    fun `serialize nfs file`() {
         val file = tempFolder.createFile("test-file.txt", "content")
         val extFile = NfsFile(
             file = file,
@@ -48,7 +49,7 @@ class ExtFileSerializerTest(private val tempFolder: TemporaryFolder) {
     }
 
     @Test
-    fun `serialize FireFile`() {
+    fun `serialize fire file`() {
         val file = tempFolder.createFile("test-file.txt", "content")
         val extFile = FireFile(
             fileName = file.name,
@@ -70,6 +71,31 @@ class ExtFileSerializerTest(private val tempFolder: TemporaryFolder) {
             "extType" to "fireFile"
             "type" to "file"
             "size" to file.size()
+        }.toString()
+
+        assertThat(testInstance.serialize(extFile)).isEqualToIgnoringWhitespace(expectedJson)
+    }
+
+    @Test
+    fun `serialize fire directory`() {
+        val extFile = FireDirectory(
+            fileName = "fire-directory",
+            md5 = "md5",
+            size = 12,
+            attributes = listOf(ExtAttribute("Type", "Data", false))
+        )
+        val expectedJson = jsonObj {
+            "fileName" to "fire-directory"
+            "attributes" to jsonArray(
+                jsonObj {
+                    "name" to "Type"
+                    "value" to "Data"
+                    "reference" to false
+                }
+            )
+            "extType" to "fireDirectory"
+            "type" to "directory"
+            "size" to 12
         }.toString()
 
         assertThat(testInstance.serialize(extFile)).isEqualToIgnoringWhitespace(expectedJson)

--- a/commons/commons-model-extended/src/main/kotlin/ebi/ac/uk/extended/model/ExtendedModel.kt
+++ b/commons/commons-model-extended/src/main/kotlin/ebi/ac/uk/extended/model/ExtendedModel.kt
@@ -34,6 +34,13 @@ data class FireFile(
     override val attributes: List<ExtAttribute>
 ) : ExtFile()
 
+data class FireDirectory(
+    override val fileName: String,
+    val md5: String,
+    val size: Long,
+    override val attributes: List<ExtAttribute>
+) : ExtFile()
+
 data class NfsFile(
     override val fileName: String,
     val file: File,

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/service/FileListSerializer.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/service/FileListSerializer.kt
@@ -9,6 +9,7 @@ import ac.uk.ebi.biostd.integration.SubFormat.TsvFormat
 import ac.uk.ebi.biostd.integration.SubFormat.XmlFormat
 import ebi.ac.uk.io.sources.FilesSource
 import ebi.ac.uk.io.sources.FireBioFile
+import ebi.ac.uk.io.sources.FireDirectoryBioFile
 import ebi.ac.uk.io.sources.NfsBioFile
 import ebi.ac.uk.model.FileList
 import ebi.ac.uk.model.FilesTable
@@ -38,6 +39,7 @@ internal class FileListSerializer(
     private fun getFile(fileList: String, source: FilesSource): File {
         return when (val bioFile = source.getFile(fileList)) {
             is FireBioFile -> TODO()
+            is FireDirectoryBioFile -> TODO()
             is NfsBioFile -> bioFile.file
         }
     }

--- a/submission/persistence-filesystem/src/main/kotlin/ac/uk/ebi/biostd/persistence/filesystem/fire/FireFilesService.kt
+++ b/submission/persistence-filesystem/src/main/kotlin/ac/uk/ebi/biostd/persistence/filesystem/fire/FireFilesService.kt
@@ -6,6 +6,7 @@ import ac.uk.ebi.biostd.persistence.filesystem.request.Md5
 import ac.uk.ebi.biostd.persistence.filesystem.service.processFiles
 import ebi.ac.uk.extended.model.ExtFile
 import ebi.ac.uk.extended.model.ExtSubmission
+import ebi.ac.uk.extended.model.FireDirectory
 import ebi.ac.uk.extended.model.FireFile
 import ebi.ac.uk.extended.model.NfsFile
 import mu.KotlinLogging
@@ -35,10 +36,9 @@ fun FireFileProcessingConfig.processFile(
     file: ExtFile
 ): ExtFile = if (file is NfsFile) processNfsFile(sub.relPath, file) else file
 
-fun FireFileProcessingConfig.processNfsFile(relPath: String, nfsFile: NfsFile): FireFile {
+fun FireFileProcessingConfig.processNfsFile(relPath: String, nfsFile: NfsFile): ExtFile {
     logger.info { "processing file ${nfsFile.fileName}" }
 
-    // TODO handle directories (check S-BIAD56)
     val fileFire = previousFiles[nfsFile.md5] as FireFile?
     return if (fileFire == null) saveFile(relPath, nfsFile) else reusePreviousFile(fileFire, nfsFile)
 }
@@ -46,7 +46,12 @@ fun FireFileProcessingConfig.processNfsFile(relPath: String, nfsFile: NfsFile): 
 private fun reusePreviousFile(fireFile: FireFile, nfsFile: NfsFile) =
     FireFile(nfsFile.fileName, fireFile.fireId, fireFile.md5, fireFile.size, nfsFile.attributes)
 
-private fun FireFileProcessingConfig.saveFile(relPath: String, nfsFile: NfsFile): FireFile {
+private fun FireFileProcessingConfig.saveFile(relPath: String, nfsFile: NfsFile) =
+    if (nfsFile.file.isDirectory) fireDirectory(nfsFile) else persistFireFile(relPath, nfsFile)
+
+private fun fireDirectory(file: NfsFile) = FireDirectory(file.fileName, file.md5, file.size, file.attributes)
+
+private fun FireFileProcessingConfig.persistFireFile(relPath: String, nfsFile: NfsFile): FireFile {
     val store = fireWebClient.save(nfsFile.file, nfsFile.md5, relPath)
     return FireFile(nfsFile.fileName, store.fireOid, store.objectMd5, store.objectSize.toLong(), nfsFile.attributes)
 }

--- a/submission/persistence-filesystem/src/test/kotlin/ac/uk/ebi/biostd/persistence/fire/FireFilesServiceTest.kt
+++ b/submission/persistence-filesystem/src/test/kotlin/ac/uk/ebi/biostd/persistence/fire/FireFilesServiceTest.kt
@@ -6,6 +6,7 @@ import arrow.core.Either.Companion.left
 import ebi.ac.uk.extended.model.ExtAttribute
 import ebi.ac.uk.extended.model.ExtSection
 import ebi.ac.uk.extended.model.ExtSubmission
+import ebi.ac.uk.extended.model.FireDirectory
 import ebi.ac.uk.extended.model.FireFile
 import ebi.ac.uk.extended.model.NfsFile
 import ebi.ac.uk.io.ext.md5
@@ -41,8 +42,10 @@ class FireFilesServiceTest(
 
     @BeforeEach
     fun beforeEach() {
-        every { fireWebClient.save(file, testMd5, "S-TEST/123/S-TEST123") } returns ClientFireFile(1, "abc1", testMd5, 1, "2021-07-08")
         every { fireWebClient.setPath("abc1", "${basicExtSubmission.relPath}/folder/test.txt") } answers { nothing }
+        every {
+            fireWebClient.save(file, testMd5, "S-TEST/123/S-TEST123")
+        } returns ClientFireFile(1, "abc1", testMd5, 1, "2021-07-08")
     }
 
     @Test
@@ -108,6 +111,19 @@ class FireFilesServiceTest(
         val previousFile = FireFile("old-folder/test.txt", "abc1", testMd5, 1, listOf(attribute))
         val previousFiles = mapOf(Pair(testMd5, previousFile))
         val section = ExtSection(type = "Study", files = listOf(left(fireFile)))
+        val submission = basicExtSubmission.copy(section = section)
+        val request = FilePersistenceRequest(submission, previousFiles = previousFiles)
+
+        assertThat(testInstance.persistSubmissionFiles(request)).isEqualTo(submission)
+        verify(exactly = 0) { fireWebClient.save(file, testMd5, "S-TEST/123/S-TEST123") }
+    }
+
+    @Test
+    fun `process submission when new file is a fire directory`() {
+        val fireDirectory = FireDirectory("new-folder/inner-folder", testMd5, 1, listOf(attribute))
+        val previousFile = FireDirectory("old-folder/inner-folder", testMd5, 1, listOf(attribute))
+        val previousFiles = mapOf(Pair(testMd5, previousFile))
+        val section = ExtSection(type = "Study", files = listOf(left(fireDirectory)))
         val submission = basicExtSubmission.copy(section = section)
         val request = FilePersistenceRequest(submission, previousFiles = previousFiles)
 

--- a/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/db/converters/from/DocFileConverter.kt
+++ b/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/db/converters/from/DocFileConverter.kt
@@ -3,6 +3,7 @@ package ac.uk.ebi.biostd.persistence.doc.db.converters.from
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.DocFileFields.FILE_DOC_ATTRIBUTES
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.DocFileFields.FILE_DOC_MD5
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.DocFileFields.FILE_DOC_SIZE
+import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.FireDocFileFields.FIRE_DOC_DIRECTORY_CLASS
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.FireDocFileFields.FIRE_DOC_FILE_CLASS
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.FireDocFileFields.FIRE_FILE_DOC_FILE_NAME
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.FireDocFileFields.FIRE_FILE_DOC_ID
@@ -12,6 +13,7 @@ import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.NfsDocFileFields.NF
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.NfsDocFileFields.NFS_FILE_TYPE
 import ac.uk.ebi.biostd.persistence.doc.db.converters.to.CommonsConverter.classField
 import ac.uk.ebi.biostd.persistence.doc.model.DocFile
+import ac.uk.ebi.biostd.persistence.doc.model.FireDocDirectory
 import ac.uk.ebi.biostd.persistence.doc.model.FireDocFile
 import ac.uk.ebi.biostd.persistence.doc.model.NfsDocFile
 import org.bson.Document
@@ -29,7 +31,13 @@ class DocFileConverter(private val docAttributeConverter: DocAttributeConverter)
                 fireId = source.getString(FIRE_FILE_DOC_ID),
                 attributes = attributes,
                 md5 = md5,
-                fileSize = fileSize,
+                fileSize = fileSize
+            )
+            FIRE_DOC_DIRECTORY_CLASS -> FireDocDirectory(
+                fileName = source.getString(FIRE_FILE_DOC_FILE_NAME),
+                attributes = attributes,
+                md5 = md5,
+                fileSize = fileSize
             )
             NFS_DOC_FILE_CLASS -> NfsDocFile(
                 relPath = source.getString(NFS_FILE_DOC_REL_PATH),

--- a/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/db/converters/from/DocSectionConverter.kt
+++ b/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/db/converters/from/DocSectionConverter.kt
@@ -16,6 +16,7 @@ import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.DocSectionFields.SE
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.DocSectionFields.SEC_SECTIONS
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.DocSectionFields.SEC_TABLE_SECTIONS
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.DocSectionFields.SEC_TYPE
+import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.FireDocFileFields.FIRE_DOC_DIRECTORY_CLASS
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.FireDocFileFields.FIRE_DOC_FILE_CLASS
 import ac.uk.ebi.biostd.persistence.doc.model.DocSection
 import ac.uk.ebi.biostd.persistence.doc.model.DocSectionTable
@@ -50,10 +51,15 @@ class DocSectionConverter(
     }
 
     private fun toEitherFiles(doc: Document) = when (val clazz = doc.getString(CLASS_FIELD)) {
-        NFS_DOC_FILE_CLASS, FIRE_DOC_FILE_CLASS -> Either.left(docFileConverter.convert(doc))
+        NFS_DOC_FILE_CLASS, FIRE_DOC_FILE_CLASS, FIRE_DOC_DIRECTORY_CLASS -> Either.left(docFileConverter.convert(doc))
         DOC_FILE_TABLE_CLASS -> Either.right(docFileTableConverter.convert(doc))
         else -> throw IllegalStateException(
-            "Expecting $clazz to be one of [$NFS_DOC_FILE_CLASS , $FIRE_DOC_FILE_CLASS , $DOC_FILE_TABLE_CLASS]"
+            """Expecting $clazz to be one of
+                [$NFS_DOC_FILE_CLASS,
+                $FIRE_DOC_FILE_CLASS,
+                $FIRE_DOC_DIRECTORY_CLASS,
+                $DOC_FILE_TABLE_CLASS]
+            """.trimIndent()
         )
     }
 

--- a/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/db/converters/shared/ConverterCommonsFields.kt
+++ b/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/db/converters/shared/ConverterCommonsFields.kt
@@ -14,6 +14,7 @@ import ac.uk.ebi.biostd.persistence.doc.model.DocStat
 import ac.uk.ebi.biostd.persistence.doc.model.DocSubmission
 import ac.uk.ebi.biostd.persistence.doc.model.DocTag
 import ac.uk.ebi.biostd.persistence.doc.model.FileListDocFile
+import ac.uk.ebi.biostd.persistence.doc.model.FireDocDirectory
 import ac.uk.ebi.biostd.persistence.doc.model.FireDocFile
 import ac.uk.ebi.biostd.persistence.doc.model.NfsDocFile
 
@@ -44,6 +45,7 @@ object NfsDocFileFields {
 
 object FireDocFileFields {
     val FIRE_DOC_FILE_CLASS: String = FireDocFile::class.java.canonicalName
+    val FIRE_DOC_DIRECTORY_CLASS: String = FireDocDirectory::class.java.canonicalName
     const val FIRE_FILE_DOC_FILE_NAME = "fileName"
     const val FIRE_FILE_DOC_ID = "fireId"
 }

--- a/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/db/converters/to/FileConverter.kt
+++ b/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/db/converters/to/FileConverter.kt
@@ -3,6 +3,7 @@ package ac.uk.ebi.biostd.persistence.doc.db.converters.to
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.DocFileFields.FILE_DOC_ATTRIBUTES
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.DocFileFields.FILE_DOC_MD5
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.DocFileFields.FILE_DOC_SIZE
+import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.FireDocFileFields.FIRE_DOC_DIRECTORY_CLASS
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.FireDocFileFields.FIRE_DOC_FILE_CLASS
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.FireDocFileFields.FIRE_FILE_DOC_FILE_NAME
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.FireDocFileFields.FIRE_FILE_DOC_ID
@@ -12,6 +13,7 @@ import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.NfsDocFileFields.NF
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.NfsDocFileFields.NFS_FILE_TYPE
 import ac.uk.ebi.biostd.persistence.doc.db.converters.to.CommonsConverter.classField
 import ac.uk.ebi.biostd.persistence.doc.model.DocFile
+import ac.uk.ebi.biostd.persistence.doc.model.FireDocDirectory
 import ac.uk.ebi.biostd.persistence.doc.model.FireDocFile
 import ac.uk.ebi.biostd.persistence.doc.model.NfsDocFile
 import org.bson.Document
@@ -30,6 +32,10 @@ class FileConverter(private val attributeConverter: AttributeConverter) : Conver
                 file[classField] = FIRE_DOC_FILE_CLASS
                 file[FIRE_FILE_DOC_FILE_NAME] = docFile.fileName
                 file[FIRE_FILE_DOC_ID] = docFile.fireId
+            }
+            is FireDocDirectory -> {
+                file[classField] = FIRE_DOC_DIRECTORY_CLASS
+                file[FIRE_FILE_DOC_FILE_NAME] = docFile.fileName
             }
             is NfsDocFile -> {
                 file[classField] = NFS_DOC_FILE_CLASS

--- a/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/mapping/from/ToDocFile.kt
+++ b/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/mapping/from/ToDocFile.kt
@@ -6,13 +6,17 @@ import ac.uk.ebi.biostd.persistence.doc.model.DocFileRef
 import ac.uk.ebi.biostd.persistence.doc.model.DocFileTable
 import ac.uk.ebi.biostd.persistence.doc.model.FileListDocFile
 import ac.uk.ebi.biostd.persistence.doc.model.FileSystem.FIRE
+import ac.uk.ebi.biostd.persistence.doc.model.FileSystem.FIRE_DIR
 import ac.uk.ebi.biostd.persistence.doc.model.FileSystem.NFS
+import ac.uk.ebi.biostd.persistence.doc.model.FireDocDirectory
 import ac.uk.ebi.biostd.persistence.doc.model.FireDocFile
 import ac.uk.ebi.biostd.persistence.doc.model.NfsDocFile
 import arrow.core.Either
+import ebi.ac.uk.dsl.file
 import ebi.ac.uk.extended.model.ExtFile
 import ebi.ac.uk.extended.model.ExtFileList
 import ebi.ac.uk.extended.model.ExtFileTable
+import ebi.ac.uk.extended.model.FireDirectory
 import ebi.ac.uk.extended.model.FireFile
 import ebi.ac.uk.extended.model.NfsFile
 import ebi.ac.uk.io.ext.size
@@ -38,6 +42,16 @@ private fun toFileDocListFile(submissionId: ObjectId, extFile: ExtFile) = when (
         size = extFile.size,
         fileSystem = FIRE
     )
+    is FireDirectory -> FileListDocFile(
+        id = ObjectId(),
+        submissionId = submissionId,
+        fileName = extFile.fileName,
+        location = extFile.fileName,
+        attributes = extFile.attributes.map { it.toDocAttribute() },
+        md5 = extFile.md5,
+        size = extFile.size,
+        fileSystem = FIRE_DIR
+    )
     is NfsFile -> FileListDocFile(
         id = ObjectId(),
         submissionId = submissionId,
@@ -60,6 +74,12 @@ private fun ExtFile.toDocFile(): DocFile = when (this) {
         md5 = md5,
         fileSize = size,
     )
+    is FireDirectory -> FireDocDirectory(
+        fileName = fileName,
+        attributes = attributes.map { it.toDocAttribute() },
+        md5 = md5,
+        fileSize = size,
+    )
     is NfsFile -> NfsDocFile(
         relPath = fileName,
         fullPath = file.absolutePath,
@@ -69,5 +89,3 @@ private fun ExtFile.toDocFile(): DocFile = when (this) {
         fileSize = file.size(),
     )
 }
-
-class FireFileToFileListDocFileNotSupportedException : UnsupportedOperationException()

--- a/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/mapping/to/ToExtFile.kt
+++ b/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/mapping/to/ToExtFile.kt
@@ -5,19 +5,23 @@ import ac.uk.ebi.biostd.persistence.doc.model.DocFileList
 import ac.uk.ebi.biostd.persistence.doc.model.DocFileTable
 import ac.uk.ebi.biostd.persistence.doc.model.FileListDocFile
 import ac.uk.ebi.biostd.persistence.doc.model.FileSystem.FIRE
+import ac.uk.ebi.biostd.persistence.doc.model.FileSystem.FIRE_DIR
 import ac.uk.ebi.biostd.persistence.doc.model.FileSystem.NFS
+import ac.uk.ebi.biostd.persistence.doc.model.FireDocDirectory
 import ac.uk.ebi.biostd.persistence.doc.model.FireDocFile
 import ac.uk.ebi.biostd.persistence.doc.model.NfsDocFile
 import arrow.core.Either
 import ebi.ac.uk.extended.model.ExtFile
 import ebi.ac.uk.extended.model.ExtFileList
 import ebi.ac.uk.extended.model.ExtFileTable
+import ebi.ac.uk.extended.model.FireDirectory
 import ebi.ac.uk.extended.model.FireFile
 import ebi.ac.uk.extended.model.NfsFile
 import java.nio.file.Paths
 
 internal fun DocFile.toExtFile(): ExtFile = when (this) {
     is FireDocFile -> FireFile(fileName, fireId, md5, fileSize, attributes.toExtAttributes())
+    is FireDocDirectory -> FireDirectory(fileName, md5, fileSize, attributes.toExtAttributes())
     is NfsDocFile -> NfsFile(relPath, Paths.get(fullPath).toFile(), attributes.toExtAttributes())
 }
 
@@ -28,6 +32,7 @@ internal fun Either<DocFile, DocFileTable>.toExtFiles(): Either<ExtFile, ExtFile
 
 internal fun FileListDocFile.toExtFile(): ExtFile = when (fileSystem) {
     FIRE -> FireFile(fileName, location, md5, size, attributes.toExtAttributes())
+    FIRE_DIR -> FireDirectory(fileName, md5, size, attributes.toExtAttributes())
     NFS -> NfsFile(fileName, Paths.get(location).toFile(), attributes.toExtAttributes()).also { it.md5 = md5 }
 }
 

--- a/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/model/SubmissionModel.kt
+++ b/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/model/SubmissionModel.kt
@@ -6,18 +6,14 @@ import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.mapping.Document
 import java.time.Instant
 
-val docAttributeDetailClass: String = DocAttributeDetail::class.java.canonicalName
-val docFileClass: String = DocFile::class.java.canonicalName
 val nfsDocFileClass: String = NfsDocFile::class.java.canonicalName
 val fireDocFileClass: String = FireDocFile::class.java.canonicalName
-val docFileListClass: String = DocFileList::class.java.canonicalName
 val docFileTableClass: String = DocFileTable::class.java.canonicalName
 val docLinkClass: String = DocLink::class.java.canonicalName
 val docLinkTableClass: String = DocLinkTable::class.java.canonicalName
 val docSectionClass: String = DocSection::class.java.canonicalName
 val docSectionTableClass: String = DocSectionTable::class.java.canonicalName
 val docSubmissionClass: String = DocSubmission::class.java.canonicalName
-val docSubmissionMethodClass: String = DocSubmissionMethod::class.java.canonicalName
 
 @Document(collection = "submissions")
 data class DocSubmission(
@@ -102,6 +98,13 @@ data class FireDocFile(
     override val fileSize: Long,
 ) : DocFile(attributes, md5, fileSize)
 
+data class FireDocDirectory(
+    val fileName: String,
+    override val attributes: List<DocAttribute>,
+    override val md5: String,
+    override val fileSize: Long
+) : DocFile(attributes, md5, fileSize)
+
 data class DocFileList(
     val fileName: String,
     val files: List<DocFileRef>
@@ -125,7 +128,7 @@ data class FileListDocFile(
 )
 
 enum class FileSystem {
-    NFS, FIRE
+    NFS, FIRE, FIRE_DIR
 }
 
 data class DocSectionTable(val sections: List<DocSectionTableRow>)

--- a/submission/persistence-mongo/src/test/kotlin/ac/uk/ebi/biostd/persistence/doc/db/converters/from/DocFileConverterTest.kt
+++ b/submission/persistence-mongo/src/test/kotlin/ac/uk/ebi/biostd/persistence/doc/db/converters/from/DocFileConverterTest.kt
@@ -3,6 +3,7 @@ package ac.uk.ebi.biostd.persistence.doc.db.converters.from
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.DocFileFields.FILE_DOC_ATTRIBUTES
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.DocFileFields.FILE_DOC_MD5
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.DocFileFields.FILE_DOC_SIZE
+import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.FireDocFileFields.FIRE_DOC_DIRECTORY_CLASS
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.FireDocFileFields.FIRE_FILE_DOC_FILE_NAME
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.FireDocFileFields.FIRE_FILE_DOC_ID
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.NfsDocFileFields.FILE_LIST_DOC_FILE_FULL_PATH
@@ -10,6 +11,7 @@ import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.NfsDocFileFields.NF
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.NfsDocFileFields.NFS_FILE_TYPE
 import ac.uk.ebi.biostd.persistence.doc.db.converters.to.CommonsConverter
 import ac.uk.ebi.biostd.persistence.doc.model.DocAttribute
+import ac.uk.ebi.biostd.persistence.doc.model.FireDocDirectory
 import ac.uk.ebi.biostd.persistence.doc.model.FireDocFile
 import ac.uk.ebi.biostd.persistence.doc.model.NfsDocFile
 import ac.uk.ebi.biostd.persistence.doc.model.fireDocFileClass
@@ -59,30 +61,43 @@ internal class DocFileConverterTest(
         assertThat(result.fileSize).isEqualTo(10L)
     }
 
-    private fun createNfsFileDoc(): Document {
-        val file = Document()
+    @Test
+    fun `convert to FireDirectoryFile`() {
+        every { docAttributeConverter.convert(documentAttr) } returns docAttribute
 
-        file[CommonsConverter.classField] = nfsDocFileClass
-        file[NFS_FILE_DOC_REL_PATH] = "relPath"
-        file[FILE_LIST_DOC_FILE_FULL_PATH] = "location"
-        file[NFS_FILE_TYPE] = "file"
-        file[FILE_DOC_ATTRIBUTES] = listOf(documentAttr)
-        file[FILE_DOC_MD5] = "md5"
-        file[FILE_DOC_SIZE] = 10L
+        val result = testInstance.convert(createFireDirectoryDoc())
 
-        return file
+        require(result is FireDocDirectory)
+        assertThat(result.fileName).isEqualTo("fire-directory")
+        assertThat(result.attributes).isEqualTo(listOf(docAttribute))
+        assertThat(result.md5).isEqualTo("md5")
+        assertThat(result.fileSize).isEqualTo(10L)
     }
 
-    private fun createFireFileDoc(): Document {
-        val file = Document()
+    private fun createNfsFileDoc() = Document().apply {
+        this[CommonsConverter.classField] = nfsDocFileClass
+        this[NFS_FILE_DOC_REL_PATH] = "relPath"
+        this[FILE_LIST_DOC_FILE_FULL_PATH] = "location"
+        this[NFS_FILE_TYPE] = "file"
+        this[FILE_DOC_ATTRIBUTES] = listOf(documentAttr)
+        this[FILE_DOC_MD5] = "md5"
+        this[FILE_DOC_SIZE] = 10L
+    }
 
-        file[CommonsConverter.classField] = fireDocFileClass
-        file[FIRE_FILE_DOC_FILE_NAME] = "fileName"
-        file[FIRE_FILE_DOC_ID] = "fireId"
-        file[FILE_DOC_ATTRIBUTES] = listOf(documentAttr)
-        file[FILE_DOC_MD5] = "md5"
-        file[FILE_DOC_SIZE] = 10L
+    private fun createFireFileDoc() = Document().apply {
+        this[CommonsConverter.classField] = fireDocFileClass
+        this[FIRE_FILE_DOC_FILE_NAME] = "fileName"
+        this[FIRE_FILE_DOC_ID] = "fireId"
+        this[FILE_DOC_ATTRIBUTES] = listOf(documentAttr)
+        this[FILE_DOC_MD5] = "md5"
+        this[FILE_DOC_SIZE] = 10L
+    }
 
-        return file
+    private fun createFireDirectoryDoc() = Document().apply {
+        this[CommonsConverter.classField] = FIRE_DOC_DIRECTORY_CLASS
+        this[FIRE_FILE_DOC_FILE_NAME] = "fire-directory"
+        this[FILE_DOC_ATTRIBUTES] = listOf(documentAttr)
+        this[FILE_DOC_MD5] = "md5"
+        this[FILE_DOC_SIZE] = 10L
     }
 }

--- a/submission/persistence-mongo/src/test/kotlin/ac/uk/ebi/biostd/persistence/doc/db/converters/to/FileConverterTest.kt
+++ b/submission/persistence-mongo/src/test/kotlin/ac/uk/ebi/biostd/persistence/doc/db/converters/to/FileConverterTest.kt
@@ -9,6 +9,7 @@ import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.NfsDocFileFields.FI
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.NfsDocFileFields.NFS_FILE_DOC_REL_PATH
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.NfsDocFileFields.NFS_FILE_TYPE
 import ac.uk.ebi.biostd.persistence.doc.model.DocAttribute
+import ac.uk.ebi.biostd.persistence.doc.model.FireDocDirectory
 import ac.uk.ebi.biostd.persistence.doc.model.FireDocFile
 import ac.uk.ebi.biostd.persistence.doc.model.NfsDocFile
 import io.mockk.every
@@ -29,7 +30,7 @@ internal class FileConverterTest(
     private val testInstance = FileConverter(attributeConverter)
 
     @Test
-    fun `converter from nfsDocFile`() {
+    fun `converter from nfs doc file`() {
         every { attributeConverter.convert(docAttribute) } returns document
         val file =
             NfsDocFile(
@@ -51,7 +52,7 @@ internal class FileConverterTest(
     }
 
     @Test
-    fun `converter from FireDocFile`() {
+    fun `converter from fire doc file`() {
         every { attributeConverter.convert(docAttribute) } returns document
         val file = FireDocFile(
             fileName = FIRE_FILE_DOC_FILE_NAME,
@@ -65,6 +66,24 @@ internal class FileConverterTest(
 
         assertThat(result[FIRE_FILE_DOC_FILE_NAME]).isEqualTo("fileName")
         assertThat(result[FIRE_FILE_DOC_ID]).isEqualTo("fireId")
+        assertThat(result[FILE_DOC_ATTRIBUTES]).isEqualTo(listOf(document))
+        assertThat(result[FILE_DOC_MD5]).isEqualTo("md5")
+        assertThat(result[FILE_DOC_SIZE]).isEqualTo(10L)
+    }
+
+    @Test
+    fun `converter from fire doc directory`() {
+        every { attributeConverter.convert(docAttribute) } returns document
+        val file = FireDocDirectory(
+            fileName = "fire-directory",
+            attributes = listOf(docAttribute),
+            md5 = "md5",
+            fileSize = 10L
+        )
+
+        val result = testInstance.convert(file)
+
+        assertThat(result[FIRE_FILE_DOC_FILE_NAME]).isEqualTo("fire-directory")
         assertThat(result[FILE_DOC_ATTRIBUTES]).isEqualTo(listOf(document))
         assertThat(result[FILE_DOC_MD5]).isEqualTo("md5")
         assertThat(result[FILE_DOC_SIZE]).isEqualTo(10L)

--- a/submission/persistence-mongo/src/test/kotlin/ac/uk/ebi/biostd/persistence/doc/mapping/to/ToExtFileTest.kt
+++ b/submission/persistence-mongo/src/test/kotlin/ac/uk/ebi/biostd/persistence/doc/mapping/to/ToExtFileTest.kt
@@ -7,6 +7,7 @@ import ac.uk.ebi.biostd.persistence.doc.test.AttributeTestHelper.basicDocAttribu
 import ac.uk.ebi.biostd.persistence.doc.test.FileTestHelper.assertExtFile
 import ac.uk.ebi.biostd.persistence.doc.test.FileTestHelper.assertExtFileList
 import ac.uk.ebi.biostd.persistence.doc.test.FileTestHelper.docFileList
+import ac.uk.ebi.biostd.persistence.doc.test.FileTestHelper.fireDocDirectory
 import ac.uk.ebi.biostd.persistence.doc.test.FileTestHelper.fireDocFile
 import ac.uk.ebi.biostd.persistence.doc.test.FileTestHelper.nfsDocFile
 import ac.uk.ebi.biostd.persistence.doc.test.TEST_REL_PATH
@@ -28,7 +29,6 @@ import org.junit.jupiter.api.extension.ExtendWith
 class ToExtFileTest(temporaryFolder: TemporaryFolder) {
     private val testFile = temporaryFolder.createFile(TEST_REL_PATH)
     private val testNfsDocFile = nfsDocFile.copy(fullPath = testFile.absolutePath)
-    private val testFireDocFile = fireDocFile
 
     @Test
     fun `nfsDocFile to ext file`() {
@@ -38,13 +38,19 @@ class ToExtFileTest(temporaryFolder: TemporaryFolder) {
 
     @Test
     fun `fireDocFile to ext file`() {
-        val extFile = testFireDocFile.toExtFile()
+        val extFile = fireDocFile.toExtFile()
+        assertExtFile(extFile, testFile)
+    }
+
+    @Test
+    fun `fire directory to ext file`() {
+        val extFile = fireDocDirectory.toExtFile()
         assertExtFile(extFile, testFile)
     }
 
     @Test
     fun `to ext file table`() {
-        val docFilesTable = DocFileTable(listOf(testNfsDocFile, testFireDocFile))
+        val docFilesTable = DocFileTable(listOf(testNfsDocFile, fireDocFile))
         val extFilesTable = docFilesTable.toExtFileTable()
 
         assertThat(extFilesTable.files).hasSize(2)
@@ -54,7 +60,7 @@ class ToExtFileTest(temporaryFolder: TemporaryFolder) {
 
     @Test
     fun `to ext files`() {
-        val docFilesTable = DocFileTable(listOf(testNfsDocFile, testFireDocFile))
+        val docFilesTable = DocFileTable(listOf(testNfsDocFile, fireDocFile))
         val docFiles = listOf(left(testNfsDocFile), left(testNfsDocFile), right(docFilesTable))
         val extFiles = docFiles.map { it.toExtFiles() }
 

--- a/submission/persistence-mongo/src/test/kotlin/ac/uk/ebi/biostd/persistence/doc/test/FileTestHelper.kt
+++ b/submission/persistence-mongo/src/test/kotlin/ac/uk/ebi/biostd/persistence/doc/test/FileTestHelper.kt
@@ -2,12 +2,14 @@ package ac.uk.ebi.biostd.persistence.doc.test
 
 import ac.uk.ebi.biostd.persistence.doc.model.DocFileList
 import ac.uk.ebi.biostd.persistence.doc.model.DocFileRef
+import ac.uk.ebi.biostd.persistence.doc.model.FireDocDirectory
 import ac.uk.ebi.biostd.persistence.doc.model.FireDocFile
 import ac.uk.ebi.biostd.persistence.doc.model.NfsDocFile
 import ac.uk.ebi.biostd.persistence.doc.test.AttributeTestHelper.assertBasicExtAttribute
 import ac.uk.ebi.biostd.persistence.doc.test.AttributeTestHelper.basicDocAttribute
 import ebi.ac.uk.extended.model.ExtFile
 import ebi.ac.uk.extended.model.ExtFileList
+import ebi.ac.uk.extended.model.FireDirectory
 import ebi.ac.uk.extended.model.FireFile
 import ebi.ac.uk.extended.model.NfsFile
 import ebi.ac.uk.io.ext.md5
@@ -16,6 +18,7 @@ import org.bson.types.ObjectId
 import java.io.File
 
 internal const val TEST_REL_PATH = "file.txt"
+internal const val TEST_DIRECTORY = "fire-directory"
 internal const val TEST_FULL_PATH = "/a/full/path/file.txt"
 internal const val TEST_FILE_LIST = "file-list.tsv"
 private const val TEST_MD5 = "a-test-md5"
@@ -35,11 +38,19 @@ internal object FileTestHelper {
             md5 = TEST_MD5,
             fileSize = TEST_FIRE_FILE_SIZE,
         )
+    val fireDocDirectory =
+        FireDocDirectory(
+            fileName = TEST_DIRECTORY,
+            attributes = listOf(basicDocAttribute),
+            md5 = TEST_MD5,
+            fileSize = TEST_FIRE_FILE_SIZE,
+        )
     val docFileRef = DocFileRef(ObjectId(10, 10))
     val docFileList = DocFileList(TEST_FILE_LIST, listOf(docFileRef))
 
     fun assertExtFile(extFile: ExtFile, file: File) = when (extFile) {
         is FireFile -> assertFireFile(extFile)
+        is FireDirectory -> assertFireDirectory(extFile)
         is NfsFile -> assertNfsFile(extFile, file)
     }
 
@@ -59,6 +70,14 @@ internal object FileTestHelper {
     private fun assertFireFile(fireFile: FireFile) {
         assertThat(fireFile.fileName).isEqualTo(TEST_REL_PATH)
         assertThat(fireFile.fireId).isEqualTo(TEST_FIRE_FILE_ID)
+        assertThat(fireFile.md5).isEqualTo(TEST_MD5)
+        assertThat(fireFile.size).isEqualTo(TEST_FIRE_FILE_SIZE)
+        assertThat(fireFile.attributes).hasSize(1)
+        assertBasicExtAttribute(fireFile.attributes.first())
+    }
+
+    private fun assertFireDirectory(fireFile: FireDirectory) {
+        assertThat(fireFile.fileName).isEqualTo(TEST_DIRECTORY)
         assertThat(fireFile.md5).isEqualTo(TEST_MD5)
         assertThat(fireFile.size).isEqualTo(TEST_FIRE_FILE_SIZE)
         assertThat(fireFile.attributes).hasSize(1)

--- a/submission/persistence-sql/src/main/kotlin/ac/uk/ebi/biostd/persistence/mapping/extended/from/ToDbFile.kt
+++ b/submission/persistence-sql/src/main/kotlin/ac/uk/ebi/biostd/persistence/mapping/extended/from/ToDbFile.kt
@@ -5,12 +5,14 @@ import ac.uk.ebi.biostd.persistence.model.DbFile
 import ac.uk.ebi.biostd.persistence.model.DbFileAttribute
 import ebi.ac.uk.extended.model.ExtAttribute
 import ebi.ac.uk.extended.model.ExtFile
+import ebi.ac.uk.extended.model.FireDirectory
 import ebi.ac.uk.extended.model.FireFile
 import ebi.ac.uk.extended.model.NfsFile
 import ebi.ac.uk.io.FileUtils
 
 internal fun ExtFile.toDbFile(order: Int, tableIndex: Int = NO_TABLE_INDEX) = when (this) {
     is FireFile -> TODO()
+    is FireDirectory -> TODO()
     is NfsFile -> DbFile(
         fileName,
         order,

--- a/submission/persistence-sql/src/main/kotlin/ac/uk/ebi/biostd/persistence/mapping/extended/from/ToRefFile.kt
+++ b/submission/persistence-sql/src/main/kotlin/ac/uk/ebi/biostd/persistence/mapping/extended/from/ToRefFile.kt
@@ -4,12 +4,14 @@ import ac.uk.ebi.biostd.persistence.model.DbReferencedFile
 import ac.uk.ebi.biostd.persistence.model.DbReferencedFileAttribute
 import ebi.ac.uk.extended.model.ExtAttribute
 import ebi.ac.uk.extended.model.ExtFile
+import ebi.ac.uk.extended.model.FireDirectory
 import ebi.ac.uk.extended.model.FireFile
 import ebi.ac.uk.extended.model.NfsFile
 import ebi.ac.uk.io.ext.size
 
 internal fun ExtFile.toRefFile(order: Int) = when (this) {
     is FireFile -> TODO()
+    is FireDirectory -> TODO()
     is NfsFile -> DbReferencedFile(
         fileName,
         order,

--- a/submission/persistence-sql/src/main/kotlin/ac/uk/ebi/biostd/persistence/mapping/extended/to/ToExtFile.kt
+++ b/submission/persistence-sql/src/main/kotlin/ac/uk/ebi/biostd/persistence/mapping/extended/to/ToExtFile.kt
@@ -6,11 +6,13 @@ import ac.uk.ebi.biostd.persistence.model.ext.validAttributes
 import ebi.ac.uk.extended.model.NfsFile
 import ebi.ac.uk.io.sources.FilesSource
 import ebi.ac.uk.io.sources.FireBioFile
+import ebi.ac.uk.io.sources.FireDirectoryBioFile
 import ebi.ac.uk.io.sources.NfsBioFile
 
 internal fun DbFile.toExtFile(fileSource: FilesSource): NfsFile {
     return when (val bioFile = fileSource.getFile(name)) {
         is FireBioFile -> TODO()
+        is FireDirectoryBioFile -> TODO()
         is NfsBioFile -> NfsFile(name, bioFile.file, validAttributes.map { it.toExtAttribute() })
     }
 }
@@ -18,6 +20,7 @@ internal fun DbFile.toExtFile(fileSource: FilesSource): NfsFile {
 internal fun DbReferencedFile.toExtFile(fileSource: FilesSource): NfsFile {
     return when (val bioFile = fileSource.getFile(name)) {
         is FireBioFile -> TODO()
+        is FireDirectoryBioFile -> TODO()
         is NfsBioFile -> NfsFile(name, bioFile.file, validAttributes.map { it.toExtAttribute() })
     }
 }

--- a/submission/persistence-sql/src/test/kotlin/ac/uk/ebi/biostd/persistence/mapping/extended/to/test/DbToExtFileTestHelper.kt
+++ b/submission/persistence-sql/src/test/kotlin/ac/uk/ebi/biostd/persistence/mapping/extended/to/test/DbToExtFileTestHelper.kt
@@ -4,6 +4,7 @@ import ac.uk.ebi.biostd.persistence.model.DbFile
 import ac.uk.ebi.biostd.persistence.model.DbReferencedFile
 import ac.uk.ebi.biostd.persistence.model.ReferencedFileList
 import ebi.ac.uk.extended.model.ExtFile
+import ebi.ac.uk.extended.model.FireDirectory
 import ebi.ac.uk.extended.model.FireFile
 import ebi.ac.uk.extended.model.NfsFile
 import ebi.ac.uk.io.sources.BioFile
@@ -22,6 +23,7 @@ internal val refFileListDb get() = ReferencedFileList("fileList", sortedSetOf(re
 
 internal fun assertExtFile(extFile: ExtFile, bioFile: BioFile, fileName: String) = when (extFile) {
     is FireFile -> TODO()
+    is FireDirectory -> TODO()
     is NfsFile -> assertNfsFile(extFile, bioFile, fileName)
 }
 

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/domain/helpers/ExtFileListSource.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/domain/helpers/ExtFileListSource.kt
@@ -2,11 +2,13 @@ package ac.uk.ebi.biostd.submission.domain.helpers
 
 import ebi.ac.uk.errors.FileNotFoundException
 import ebi.ac.uk.extended.model.ExtFile
+import ebi.ac.uk.extended.model.FireDirectory
 import ebi.ac.uk.extended.model.FireFile
 import ebi.ac.uk.extended.model.NfsFile
 import ebi.ac.uk.io.sources.BioFile
 import ebi.ac.uk.io.sources.FilesSource
 import ebi.ac.uk.io.sources.FireBioFile
+import ebi.ac.uk.io.sources.FireDirectoryBioFile
 import ebi.ac.uk.io.sources.NfsBioFile
 import uk.ac.ebi.fire.client.integration.web.FireWebClient
 
@@ -25,6 +27,7 @@ class ExtFileListSource(
                 file.size,
                 lazy { fireWebClient.downloadByFireId(file.fireId, file.fileName).readText() }
             )
+            is FireDirectory -> FireDirectoryBioFile(file.md5, file.size)
             is NfsFile -> NfsBioFile(file.file)
         }
     }


### PR DESCRIPTION
- Create new type for the FIRE directories
- Skip them during file processing on FIRE mode and persist them just in the database instead
- Adjust the extended serializers