### PR TITLE
Pivotal ID # 179609612: Submit Large Files To Fire

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -11,6 +11,7 @@ import TestVersions.WiremockVersion
 import TestVersions.XmlUnitVersion
 import Versions.CliKtVersion
 import Versions.CommonsCsvVersion
+import Versions.CommonsFileUploadVersion
 import Versions.CommonsIOVersion
 import Versions.CommonsLang3Version
 import Versions.GuavaVersion
@@ -71,6 +72,7 @@ object Versions {
     const val JpaEntityGraphVersion = "2.2.3"
     const val MongockVersion = "4.3.8"
 
+    const val CommonsFileUploadVersion = "1.4"
     const val CommonsLang3Version = "3.8.1"
     const val CommonsIOVersion = "2.6"
     const val CommonsCsvVersion = "1.8"
@@ -181,6 +183,7 @@ object Dependencies {
     const val ArrowData = "io.arrow-kt:arrow-data:$KotlinArrowVersion"
 
     // Apache
+    const val CommonsFileUpload = "commons-fileupload:commons-fileupload:$CommonsFileUploadVersion"
     const val CommonsLang3 = "org.apache.commons:commons-lang3:$CommonsLang3Version"
     const val CommonsIO = "commons-io:commons-io:$CommonsIOVersion"
     const val Poi = "org.apache.poi:poi:$PoiVersion"

--- a/client/fire-webclient/src/main/kotlin/uk/ac/ebi/fire/client/integration/web/FireAuthRequestInitializer.kt
+++ b/client/fire-webclient/src/main/kotlin/uk/ac/ebi/fire/client/integration/web/FireAuthRequestInitializer.kt
@@ -1,0 +1,13 @@
+package uk.ac.ebi.fire.client.integration.web
+
+import org.springframework.http.client.ClientHttpRequest
+import org.springframework.http.client.ClientHttpRequestInitializer
+
+class FireAuthRequestInitializer(
+    private val username: String,
+    private val password: String
+) : ClientHttpRequestInitializer {
+    override fun initialize(request: ClientHttpRequest) {
+        request.headers.setBasicAuth(username, password)
+    }
+}

--- a/client/fire-webclient/src/main/kotlin/uk/ac/ebi/fire/client/integration/web/FireWebClient.kt
+++ b/client/fire-webclient/src/main/kotlin/uk/ac/ebi/fire/client/integration/web/FireWebClient.kt
@@ -1,6 +1,6 @@
 package uk.ac.ebi.fire.client.integration.web
 
-import org.springframework.http.client.support.BasicAuthenticationInterceptor
+import org.springframework.http.client.SimpleClientHttpRequestFactory
 import org.springframework.web.client.RestTemplate
 import org.springframework.web.util.DefaultUriBuilderFactory
 import uk.ac.ebi.fire.client.api.FireClient
@@ -20,8 +20,13 @@ class FireWebClient private constructor(
         private fun createRestTemplate(fireHost: String, username: String, password: String) =
             RestTemplate().apply {
                 uriTemplateHandler = DefaultUriBuilderFactory(fireHost)
-                interceptors.add(BasicAuthenticationInterceptor(username, password))
                 errorHandler = FireWebClientErrorHandler()
+                clientHttpRequestInitializers.add(FireAuthRequestInitializer(username, password))
+                requestFactory = SimpleClientHttpRequestFactory().apply {
+                    setReadTimeout(0)
+                    setConnectTimeout(0)
+                    setBufferRequestBody(false)
+                }
             }
     }
 }

--- a/submission/submission-webapp/build.gradle.kts
+++ b/submission/submission-webapp/build.gradle.kts
@@ -1,4 +1,5 @@
 import Dependencies.Arrow
+import Dependencies.CommonsFileUpload
 import Dependencies.CommonsIO
 import Dependencies.JpaEntityGraph
 import Dependencies.KotlinLogging
@@ -86,6 +87,7 @@ dependencies {
     implementation(SpringBootStartedAdminClient)
 
     implementation(Arrow)
+    implementation(CommonsFileUpload)
     implementation(CommonsIO)
     implementation(MySql)
     implementation(JpaEntityGraph)

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/common/config/WebConfig.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/common/config/WebConfig.kt
@@ -17,14 +17,10 @@ import org.springframework.http.converter.HttpMessageConverter
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity
 import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
-import org.springframework.web.multipart.commons.CommonsMultipartResolver
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 import uk.ac.ebi.extended.serialization.service.ExtSerializationService
 import uk.ac.ebi.fire.client.integration.web.FireWebClient
-import kotlin.text.Charsets.UTF_8
-
-private const val MAX_UPLOAD_SIZE = 20000000000
 
 @Configuration
 @Suppress("MagicNumber")

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/common/config/WebConfig.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/common/config/WebConfig.kt
@@ -48,13 +48,6 @@ internal class WebConfig(
             properties.fire.password
         )
 
-    @Bean
-    fun multipartResolver(): CommonsMultipartResolver =
-        CommonsMultipartResolver().apply {
-            setDefaultEncoding(UTF_8.displayName())
-            setMaxUploadSize(MAX_UPLOAD_SIZE)
-        }
-
     override fun configureContentNegotiation(configurer: ContentNegotiationConfigurer) {
         configurer.defaultContentType(MediaType.APPLICATION_JSON)
     }

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/common/config/WebConfig.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/common/config/WebConfig.kt
@@ -17,10 +17,14 @@ import org.springframework.http.converter.HttpMessageConverter
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity
 import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.multipart.commons.CommonsMultipartResolver
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 import uk.ac.ebi.extended.serialization.service.ExtSerializationService
 import uk.ac.ebi.fire.client.integration.web.FireWebClient
+import kotlin.text.Charsets.UTF_8
+
+private const val MAX_UPLOAD_SIZE = 20000000000
 
 @Configuration
 @Suppress("MagicNumber")
@@ -43,6 +47,13 @@ internal class WebConfig(
             properties.fire.username,
             properties.fire.password
         )
+
+    @Bean
+    fun multipartResolver(): CommonsMultipartResolver =
+        CommonsMultipartResolver().apply {
+            setDefaultEncoding(UTF_8.displayName())
+            setMaxUploadSize(MAX_UPLOAD_SIZE)
+        }
 
     override fun configureContentNegotiation(configurer: ContentNegotiationConfigurer) {
         configurer.defaultContentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/179609612

Configure the FIRE web client to handle the submission of large files:
- Set the maximum request size in the Rest Template to 20 GB
- Create a custom multipart resolver that is able to handle files of this size
- Add custom request initializer instead the interceptor in order to avoid replacing the request factory