### PR TITLE
Pivotal ID # 179922324: File Mode CLI Option

### DIFF
--- a/client/bio-commandline/src/main/kotlin/uk/ac/ebi/biostd/client/cli/commands/DeleteCommand.kt
+++ b/client/bio-commandline/src/main/kotlin/uk/ac/ebi/biostd/client/cli/commands/DeleteCommand.kt
@@ -5,11 +5,11 @@ import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.multiple
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
-import uk.ac.ebi.biostd.client.cli.common.CommonParameters.ACC_NO_HELP
 import uk.ac.ebi.biostd.client.cli.common.CommonParameters.ON_BEHALF_HELP
 import uk.ac.ebi.biostd.client.cli.common.CommonParameters.PASSWORD_HELP
 import uk.ac.ebi.biostd.client.cli.common.CommonParameters.SERVER_HELP
 import uk.ac.ebi.biostd.client.cli.common.CommonParameters.USER_HELP
+import uk.ac.ebi.biostd.client.cli.common.SubmissionParameters.ACC_NO_HELP
 import uk.ac.ebi.biostd.client.cli.dto.DeletionRequest
 import uk.ac.ebi.biostd.client.cli.services.SubmissionService
 

--- a/client/bio-commandline/src/main/kotlin/uk/ac/ebi/biostd/client/cli/commands/SubmitAsyncCommand.kt
+++ b/client/bio-commandline/src/main/kotlin/uk/ac/ebi/biostd/client/cli/commands/SubmitAsyncCommand.kt
@@ -1,11 +1,20 @@
 package uk.ac.ebi.biostd.client.cli.commands
 
 import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
-import uk.ac.ebi.biostd.client.cli.common.CommonParameters
+import ebi.ac.uk.extended.model.FileMode.COPY
+import ebi.ac.uk.extended.model.FileMode.MOVE
+import uk.ac.ebi.biostd.client.cli.common.CommonParameters.ON_BEHALF_HELP
+import uk.ac.ebi.biostd.client.cli.common.CommonParameters.PASSWORD_HELP
+import uk.ac.ebi.biostd.client.cli.common.CommonParameters.SERVER_HELP
+import uk.ac.ebi.biostd.client.cli.common.CommonParameters.USER_HELP
 import uk.ac.ebi.biostd.client.cli.common.FILES_SEPARATOR
+import uk.ac.ebi.biostd.client.cli.common.SubmissionParameters.ATTACHED_HELP
+import uk.ac.ebi.biostd.client.cli.common.SubmissionParameters.INPUT_HELP
+import uk.ac.ebi.biostd.client.cli.common.SubmissionParameters.MOVE_FILES
 import uk.ac.ebi.biostd.client.cli.common.getFiles
 import uk.ac.ebi.biostd.client.cli.dto.SubmissionRequest
 import uk.ac.ebi.biostd.client.cli.services.SubmissionService
@@ -13,12 +22,13 @@ import java.io.File
 
 internal class SubmitAsyncCommand(private val submissionService: SubmissionService) :
     CliktCommand(name = "submitAsync") {
-    private val server by option("-s", "--server", help = CommonParameters.SERVER_HELP).required()
-    private val user by option("-u", "--user", help = CommonParameters.USER_HELP).required()
-    private val password by option("-p", "--password", help = CommonParameters.PASSWORD_HELP).required()
-    private val onBehalf by option("-b", "--onBehalf", help = CommonParameters.ON_BEHALF_HELP)
-    private val input by option("-i", "--input", help = CommonParameters.INPUT_HELP).file(exists = true).required()
-    private val attached by option("-a", "--attached", help = CommonParameters.ATTACHED_HELP)
+    private val server by option("-s", "--server", help = SERVER_HELP).required()
+    private val user by option("-u", "--user", help = USER_HELP).required()
+    private val password by option("-p", "--password", help = PASSWORD_HELP).required()
+    private val onBehalf by option("-b", "--onBehalf", help = ON_BEHALF_HELP)
+    private val input by option("-i", "--input", help = INPUT_HELP).file(exists = true).required()
+    private val attached by option("-a", "--attached", help = ATTACHED_HELP)
+    private val moveFiles by option("-m", "--moveFiles", help = MOVE_FILES).flag(default = false)
 
     override fun run() {
         val request = SubmissionRequest(
@@ -27,7 +37,8 @@ internal class SubmitAsyncCommand(private val submissionService: SubmissionServi
             password = password,
             onBehalf = onBehalf,
             file = input,
-            attached = attached?.split(FILES_SEPARATOR)?.flatMap { getFiles(File(it)) }.orEmpty()
+            attached = attached?.split(FILES_SEPARATOR)?.flatMap { getFiles(File(it)) }.orEmpty(),
+            fileMode = if (moveFiles) MOVE else COPY
         )
 
         submissionService.submitAsync(request)

--- a/client/bio-commandline/src/main/kotlin/uk/ac/ebi/biostd/client/cli/commands/SubmitAsyncCommand.kt
+++ b/client/bio-commandline/src/main/kotlin/uk/ac/ebi/biostd/client/cli/commands/SubmitAsyncCommand.kt
@@ -14,7 +14,7 @@ import uk.ac.ebi.biostd.client.cli.common.CommonParameters.USER_HELP
 import uk.ac.ebi.biostd.client.cli.common.FILES_SEPARATOR
 import uk.ac.ebi.biostd.client.cli.common.SubmissionParameters.ATTACHED_HELP
 import uk.ac.ebi.biostd.client.cli.common.SubmissionParameters.INPUT_HELP
-import uk.ac.ebi.biostd.client.cli.common.SubmissionParameters.MOVE_FILES
+import uk.ac.ebi.biostd.client.cli.common.SubmissionParameters.FILE_MODE
 import uk.ac.ebi.biostd.client.cli.common.getFiles
 import uk.ac.ebi.biostd.client.cli.dto.SubmissionRequest
 import uk.ac.ebi.biostd.client.cli.services.SubmissionService
@@ -28,7 +28,7 @@ internal class SubmitAsyncCommand(private val submissionService: SubmissionServi
     private val onBehalf by option("-b", "--onBehalf", help = ON_BEHALF_HELP)
     private val input by option("-i", "--input", help = INPUT_HELP).file(exists = true).required()
     private val attached by option("-a", "--attached", help = ATTACHED_HELP)
-    private val moveFiles by option("-m", "--moveFiles", help = MOVE_FILES).flag(default = false)
+    private val moveFiles by option("-m", "--moveFiles", help = FILE_MODE).flag(default = false)
 
     override fun run() {
         val request = SubmissionRequest(

--- a/client/bio-commandline/src/main/kotlin/uk/ac/ebi/biostd/client/cli/commands/SubmitCommand.kt
+++ b/client/bio-commandline/src/main/kotlin/uk/ac/ebi/biostd/client/cli/commands/SubmitCommand.kt
@@ -1,16 +1,20 @@
 package uk.ac.ebi.biostd.client.cli.commands
 
 import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
-import uk.ac.ebi.biostd.client.cli.common.CommonParameters.ATTACHED_HELP
-import uk.ac.ebi.biostd.client.cli.common.CommonParameters.INPUT_HELP
+import ebi.ac.uk.extended.model.FileMode.COPY
+import ebi.ac.uk.extended.model.FileMode.MOVE
 import uk.ac.ebi.biostd.client.cli.common.CommonParameters.ON_BEHALF_HELP
 import uk.ac.ebi.biostd.client.cli.common.CommonParameters.PASSWORD_HELP
 import uk.ac.ebi.biostd.client.cli.common.CommonParameters.SERVER_HELP
 import uk.ac.ebi.biostd.client.cli.common.CommonParameters.USER_HELP
 import uk.ac.ebi.biostd.client.cli.common.FILES_SEPARATOR
+import uk.ac.ebi.biostd.client.cli.common.SubmissionParameters.ATTACHED_HELP
+import uk.ac.ebi.biostd.client.cli.common.SubmissionParameters.INPUT_HELP
+import uk.ac.ebi.biostd.client.cli.common.SubmissionParameters.MOVE_FILES
 import uk.ac.ebi.biostd.client.cli.common.getFiles
 import uk.ac.ebi.biostd.client.cli.dto.SubmissionRequest
 import uk.ac.ebi.biostd.client.cli.services.SubmissionService
@@ -23,6 +27,7 @@ internal class SubmitCommand(private val submissionService: SubmissionService) :
     private val onBehalf by option("-b", "--onBehalf", help = ON_BEHALF_HELP)
     private val input by option("-i", "--input", help = INPUT_HELP).file(exists = true).required()
     private val attached by option("-a", "--attached", help = ATTACHED_HELP)
+    private val moveFiles by option("-m", "--moveFiles", help = MOVE_FILES).flag(default = false)
 
     override fun run() {
         val request = SubmissionRequest(
@@ -31,7 +36,8 @@ internal class SubmitCommand(private val submissionService: SubmissionService) :
             password = password,
             onBehalf = onBehalf,
             file = input,
-            attached = attached?.split(FILES_SEPARATOR)?.flatMap { getFiles(File(it)) }.orEmpty()
+            attached = attached?.split(FILES_SEPARATOR)?.flatMap { getFiles(File(it)) }.orEmpty(),
+            fileMode = if (moveFiles) MOVE else COPY
         )
 
         val response = submissionService.submit(request)

--- a/client/bio-commandline/src/main/kotlin/uk/ac/ebi/biostd/client/cli/commands/SubmitCommand.kt
+++ b/client/bio-commandline/src/main/kotlin/uk/ac/ebi/biostd/client/cli/commands/SubmitCommand.kt
@@ -1,12 +1,12 @@
 package uk.ac.ebi.biostd.client.cli.commands
 
 import com.github.ajalt.clikt.core.CliktCommand
-import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 import ebi.ac.uk.extended.model.FileMode.COPY
-import ebi.ac.uk.extended.model.FileMode.MOVE
+import ebi.ac.uk.extended.model.FileMode.valueOf
 import uk.ac.ebi.biostd.client.cli.common.CommonParameters.ON_BEHALF_HELP
 import uk.ac.ebi.biostd.client.cli.common.CommonParameters.PASSWORD_HELP
 import uk.ac.ebi.biostd.client.cli.common.CommonParameters.SERVER_HELP
@@ -14,7 +14,7 @@ import uk.ac.ebi.biostd.client.cli.common.CommonParameters.USER_HELP
 import uk.ac.ebi.biostd.client.cli.common.FILES_SEPARATOR
 import uk.ac.ebi.biostd.client.cli.common.SubmissionParameters.ATTACHED_HELP
 import uk.ac.ebi.biostd.client.cli.common.SubmissionParameters.INPUT_HELP
-import uk.ac.ebi.biostd.client.cli.common.SubmissionParameters.MOVE_FILES
+import uk.ac.ebi.biostd.client.cli.common.SubmissionParameters.FILE_MODE
 import uk.ac.ebi.biostd.client.cli.common.getFiles
 import uk.ac.ebi.biostd.client.cli.dto.SubmissionRequest
 import uk.ac.ebi.biostd.client.cli.services.SubmissionService
@@ -27,7 +27,7 @@ internal class SubmitCommand(private val submissionService: SubmissionService) :
     private val onBehalf by option("-b", "--onBehalf", help = ON_BEHALF_HELP)
     private val input by option("-i", "--input", help = INPUT_HELP).file(exists = true).required()
     private val attached by option("-a", "--attached", help = ATTACHED_HELP)
-    private val moveFiles by option("-m", "--moveFiles", help = MOVE_FILES).flag(default = false)
+    private val fileMode by option("-fm", "--fileMode", help = FILE_MODE).default(COPY.name)
 
     override fun run() {
         val request = SubmissionRequest(
@@ -36,8 +36,8 @@ internal class SubmitCommand(private val submissionService: SubmissionService) :
             password = password,
             onBehalf = onBehalf,
             file = input,
-            attached = attached?.split(FILES_SEPARATOR)?.flatMap { getFiles(File(it)) }.orEmpty(),
-            fileMode = if (moveFiles) MOVE else COPY
+            attached = attached.orEmpty().split(FILES_SEPARATOR).flatMap { getFiles(File(it)) },
+            fileMode = valueOf(fileMode)
         )
 
         val response = submissionService.submit(request)

--- a/client/bio-commandline/src/main/kotlin/uk/ac/ebi/biostd/client/cli/common/Parameters.kt
+++ b/client/bio-commandline/src/main/kotlin/uk/ac/ebi/biostd/client/cli/common/Parameters.kt
@@ -13,7 +13,7 @@ internal object SubmissionParameters {
     const val ACC_NO_HELP = "The submission accession number"
     const val ATTACHED_HELP = "Comma separated list of paths to the files referenced in the submission"
     const val INPUT_HELP = "Path to the file containing the submission page tab"
-    const val MOVE_FILES = "Indicates that the files should be moved instead of copied"
+    const val FILE_MODE = "Indicates the mode used to process the files. Valid values are COPY or MOVE"
 }
 
 internal object MigrationParameters {

--- a/client/bio-commandline/src/main/kotlin/uk/ac/ebi/biostd/client/cli/common/Parameters.kt
+++ b/client/bio-commandline/src/main/kotlin/uk/ac/ebi/biostd/client/cli/common/Parameters.kt
@@ -4,16 +4,20 @@ const val FILES_SEPARATOR = ','
 
 internal object CommonParameters {
     const val SERVER_HELP = "BioStudies host url"
-    const val ATTACHED_HELP = "Comma separated list of paths to the files referenced in the submission"
     const val USER_HELP = "User that will perform the submission"
     const val PASSWORD_HELP = "The user password"
     const val ON_BEHALF_HELP = "The user password"
+}
+
+internal object SubmissionParameters {
+    const val ACC_NO_HELP = "The submission accession number"
+    const val ATTACHED_HELP = "Comma separated list of paths to the files referenced in the submission"
     const val INPUT_HELP = "Path to the file containing the submission page tab"
-    const val ACC_NO_HELP = "The accession number of the submission"
+    const val MOVE_FILES = "Indicates that the files should be moved instead of copied"
 }
 
 internal object MigrationParameters {
-    const val ACC_NO = "Accession number of the submission to migrate"
+    const val ACC_NO = "Accession number of the submission to be migrated"
     const val SOURCE = "BioStudies environment to take the submission from"
     const val TARGET = "BioStudies environment to migrate the submission to"
     const val SOURCE_USER = "BioStudies user in the source environment"

--- a/client/bio-commandline/src/main/kotlin/uk/ac/ebi/biostd/client/cli/dto/SubmissionRequest.kt
+++ b/client/bio-commandline/src/main/kotlin/uk/ac/ebi/biostd/client/cli/dto/SubmissionRequest.kt
@@ -1,5 +1,6 @@
 package uk.ac.ebi.biostd.client.cli.dto
 
+import ebi.ac.uk.extended.model.FileMode
 import java.io.File
 
 internal data class SubmissionRequest(
@@ -8,5 +9,6 @@ internal data class SubmissionRequest(
     val password: String,
     val onBehalf: String?,
     val file: File,
-    val attached: List<File>
+    val attached: List<File>,
+    val fileMode: FileMode
 )

--- a/client/bio-commandline/src/main/kotlin/uk/ac/ebi/biostd/client/cli/services/SubmissionService.kt
+++ b/client/bio-commandline/src/main/kotlin/uk/ac/ebi/biostd/client/cli/services/SubmissionService.kt
@@ -25,10 +25,13 @@ internal class SubmissionService {
     fun migrate(request: MigrationRequest) = performRequest { migrateRequest(request) }
 
     private fun submitRequest(request: SubmissionRequest): Submission =
-        bioWebClient(request.server, request.user, request.password).submitSingle(request.file, request.attached).body
+        bioWebClient(request.server, request.user, request.password)
+            .submitSingle(request.file, request.attached, fileMode = request.fileMode)
+            .body
 
     private fun submitAsyncRequest(request: SubmissionRequest) =
-        bioWebClient(request.server, request.user, request.password).asyncSubmitSingle(request.file, request.attached)
+        bioWebClient(request.server, request.user, request.password)
+            .asyncSubmitSingle(request.file, request.attached, fileMode = request.fileMode)
 
     private fun deleteRequest(request: DeletionRequest) =
         bioWebClient(request.server, request.user, request.password).deleteSubmissions(request.accNoList)

--- a/client/bio-commandline/src/test/kotlin/uk/ac/ebi/biostd/client/cli/commands/SubmitAsyncCommandTest.kt
+++ b/client/bio-commandline/src/test/kotlin/uk/ac/ebi/biostd/client/cli/commands/SubmitAsyncCommandTest.kt
@@ -4,7 +4,6 @@ import com.github.ajalt.clikt.core.IncorrectOptionValueCount
 import com.github.ajalt.clikt.core.MissingParameter
 import ebi.ac.uk.extended.model.FileMode.COPY
 import ebi.ac.uk.extended.model.FileMode.MOVE
-import ebi.ac.uk.model.Submission
 import ebi.ac.uk.test.clean
 import io.github.glytching.junit.extension.folder.TemporaryFolder
 import io.github.glytching.junit.extension.folder.TemporaryFolderExtension
@@ -22,11 +21,11 @@ import uk.ac.ebi.biostd.client.cli.dto.SubmissionRequest
 import uk.ac.ebi.biostd.client.cli.services.SubmissionService
 
 @ExtendWith(MockKExtension::class, TemporaryFolderExtension::class)
-internal class SubmitCommandTest(
+internal class SubmitAsyncCommandTest(
     private val temporaryFolder: TemporaryFolder,
     @MockK private val submissionService: SubmissionService
 ) {
-    private var testInstance = SubmitCommand(submissionService)
+    private var testInstance = SubmitAsyncCommand(submissionService)
     private val rootFolder: String = temporaryFolder.root.absolutePath
 
     @AfterEach
@@ -36,9 +35,7 @@ internal class SubmitCommandTest(
     }
 
     @Test
-    fun `submit successful`() {
-        val mockResponse = Submission("S-TEST123")
-
+    fun `submit async successful`() {
         val submission = temporaryFolder.createFile("Submission.tsv")
         val attachedFile1 = temporaryFolder.createFile("attachedFile1.tsv")
         val attachedFile2 = temporaryFolder.createFile("attachedFile2.tsv")
@@ -52,7 +49,7 @@ internal class SubmitCommandTest(
             attached = listOf(attachedFile1, attachedFile2),
             fileMode = COPY
         )
-        every { submissionService.submit(request) } returns mockResponse
+        every { submissionService.submitAsync(request) } answers { nothing }
 
         testInstance.parse(
             listOf(
@@ -64,13 +61,11 @@ internal class SubmitCommandTest(
             )
         )
 
-        verify(exactly = 1) { submissionService.submit(request) }
+        verify(exactly = 1) { submissionService.submitAsync(request) }
     }
 
     @Test
-    fun `submit successful moving files`() {
-        val mockResponse = Submission("S-TEST123")
-
+    fun `submit async successful moving files`() {
         val submission = temporaryFolder.createFile("Submission.tsv")
         val attachedFile1 = temporaryFolder.createFile("attachedFile1.tsv")
         val attachedFile2 = temporaryFolder.createFile("attachedFile2.tsv")
@@ -84,7 +79,7 @@ internal class SubmitCommandTest(
             attached = listOf(attachedFile1, attachedFile2),
             fileMode = MOVE
         )
-        every { submissionService.submit(request) } returns mockResponse
+        every { submissionService.submitAsync(request) } answers { nothing }
 
         testInstance.parse(
             listOf(
@@ -97,7 +92,7 @@ internal class SubmitCommandTest(
             )
         )
 
-        verify(exactly = 1) { submissionService.submit(request) }
+        verify(exactly = 1) { submissionService.submitAsync(request) }
     }
 
     @Test

--- a/client/bio-commandline/src/test/kotlin/uk/ac/ebi/biostd/client/cli/commands/SubmitCommandTest.kt
+++ b/client/bio-commandline/src/test/kotlin/uk/ac/ebi/biostd/client/cli/commands/SubmitCommandTest.kt
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import uk.ac.ebi.biostd.client.cli.dto.SubmissionRequest
 import uk.ac.ebi.biostd.client.cli.services.SubmissionService
+import java.lang.IllegalArgumentException
 
 @ExtendWith(MockKExtension::class, TemporaryFolderExtension::class)
 internal class SubmitCommandTest(
@@ -93,11 +94,31 @@ internal class SubmitCommandTest(
                 "-p", "password",
                 "-i", "$rootFolder/Submission.tsv",
                 "-a", "$rootFolder/attachedFile1.tsv,$rootFolder/attachedFile2.tsv",
-                "--moveFiles"
+                "-fm", "MOVE"
             )
         )
 
         verify(exactly = 1) { submissionService.submit(request) }
+    }
+
+    @Test
+    fun `invalid file mode`() {
+        temporaryFolder.createFile("Submission.tsv")
+        temporaryFolder.createFile("attachedFile1.tsv")
+        temporaryFolder.createFile("attachedFile2.tsv")
+
+        assertThrows<IllegalArgumentException> {
+            testInstance.parse(
+                listOf(
+                    "-s", "server",
+                    "-u", "user",
+                    "-p", "password",
+                    "-i", "$rootFolder/Submission.tsv",
+                    "-a", "$rootFolder/attachedFile1.tsv,$rootFolder/attachedFile2.tsv",
+                    "-fm", "INVALID"
+                )
+            )
+        }
     }
 
     @Test

--- a/client/bio-webclient/src/main/kotlin/ac/uk/ebi/biostd/client/api/MultiPartAsyncSubmissionClient.kt
+++ b/client/bio-webclient/src/main/kotlin/ac/uk/ebi/biostd/client/api/MultiPartAsyncSubmissionClient.kt
@@ -4,8 +4,10 @@ import ac.uk.ebi.biostd.client.extensions.setSubmissionType
 import ac.uk.ebi.biostd.client.integration.commons.SubmissionFormat
 import ac.uk.ebi.biostd.client.integration.web.MultipartAsyncSubmissionOperations
 import ac.uk.ebi.biostd.integration.SerializationService
+import ebi.ac.uk.extended.model.FileMode
 import ebi.ac.uk.model.Submission
 import ebi.ac.uk.model.constants.FILES
+import ebi.ac.uk.model.constants.FILE_MODE
 import ebi.ac.uk.model.constants.SUBMISSION
 import org.springframework.core.io.FileSystemResource
 import org.springframework.http.HttpEntity
@@ -22,22 +24,38 @@ class MultiPartAsyncSubmissionClient(
     private val template: RestTemplate,
     private val serializationService: SerializationService
 ) : MultipartAsyncSubmissionOperations {
-    override fun asyncSubmitSingle(submission: File, files: List<File>, attrs: Map<String, String>) {
+    override fun asyncSubmitSingle(
+        submission: File,
+        files: List<File>,
+        attrs: Map<String, String>,
+        fileMode: FileMode
+    ) {
         val headers = HttpHeaders().apply { contentType = MediaType.MULTIPART_FORM_DATA }
-        val multiPartBody = getMultipartBody(files, FileSystemResource(submission))
+        val multiPartBody = getMultipartBody(files, fileMode, FileSystemResource(submission))
         attrs.entries.forEach { multiPartBody.add(it.key, it.value) }
         template.postForEntity<String>("$SUBMIT_URL/direct", (HttpEntity(multiPartBody, headers)))
     }
 
-    override fun asyncSubmitSingle(submission: String, format: SubmissionFormat, files: List<File>) {
+    override fun asyncSubmitSingle(
+        submission: String,
+        format: SubmissionFormat,
+        files: List<File>,
+        fileMode: FileMode
+    ) {
         val headers = createHeaders(format)
-        val body = getMultipartBody(files, submission)
+        val body = getMultipartBody(files, fileMode, submission)
         template.postForEntity<String>(SUBMIT_URL, HttpEntity(body, headers))
     }
 
-    override fun asyncSubmitSingle(submission: Submission, format: SubmissionFormat, files: List<File>) {
+    override fun asyncSubmitSingle(
+        submission: Submission,
+        format: SubmissionFormat,
+        files: List<File>,
+        fileMode: FileMode
+    ) {
         val headers = createHeaders(format)
-        val body = getMultipartBody(files, serializationService.serializeSubmission(submission, format.asSubFormat()))
+        val serializedSubmission = serializationService.serializeSubmission(submission, format.asSubFormat())
+        val body = getMultipartBody(files, fileMode, serializedSubmission)
         template.postForEntity<String>(SUBMIT_URL, HttpEntity(body, headers))
     }
 
@@ -47,10 +65,11 @@ class MultiPartAsyncSubmissionClient(
         setSubmissionType(format.submissionType)
     }
 
-    private fun getMultipartBody(files: List<File>, submission: Any) =
+    private fun getMultipartBody(files: List<File>, fileMode: FileMode, submission: Any) =
         LinkedMultiValueMap(
             files.map { FILES to FileSystemResource(it) }
                 .plus(SUBMISSION to submission)
+                .plus(FILE_MODE to fileMode.name)
                 .groupBy({ it.first }, { it.second })
         )
 }

--- a/client/bio-webclient/src/main/kotlin/ac/uk/ebi/biostd/client/api/MultiPartSubmissionClient.kt
+++ b/client/bio-webclient/src/main/kotlin/ac/uk/ebi/biostd/client/api/MultiPartSubmissionClient.kt
@@ -8,8 +8,10 @@ import ac.uk.ebi.biostd.integration.SerializationService
 import ac.uk.ebi.biostd.integration.SubFormat.Companion.JSON
 import ac.uk.ebi.biostd.integration.SubFormat.JsonFormat.JsonPretty
 import ebi.ac.uk.api.ClientResponse
+import ebi.ac.uk.extended.model.ExtAttributeDetail
 import ebi.ac.uk.extended.model.FileMode
 import ebi.ac.uk.model.Submission
+import ebi.ac.uk.model.constants.ATTRIBUTES
 import ebi.ac.uk.model.constants.FILES
 import ebi.ac.uk.model.constants.FILE_MODE
 import ebi.ac.uk.model.constants.SUBMISSION
@@ -39,7 +41,7 @@ internal class MultiPartSubmissionClient(
     ): SubmissionResponse {
         val headers = HttpHeaders().apply { contentType = MediaType.MULTIPART_FORM_DATA }
         val multiPartBody = getMultipartBody(files, fileMode, FileSystemResource(submission)).apply {
-            attrs.entries.forEach { add(it.key, it.value) }
+            attrs.entries.forEach { add(ATTRIBUTES, ExtAttributeDetail(it.key, it.value)) }
         }
 
         return template.postForEntity<String>("$SUBMIT_URL/direct", (HttpEntity(multiPartBody, headers)))

--- a/client/bio-webclient/src/main/kotlin/ac/uk/ebi/biostd/client/integration/web/SubmissionClient.kt
+++ b/client/bio-webclient/src/main/kotlin/ac/uk/ebi/biostd/client/integration/web/SubmissionClient.kt
@@ -17,6 +17,8 @@ import ebi.ac.uk.api.security.UserProfile
 import ebi.ac.uk.base.EMPTY
 import ebi.ac.uk.extended.model.ExtFileTable
 import ebi.ac.uk.extended.model.ExtSubmission
+import ebi.ac.uk.extended.model.FileMode
+import ebi.ac.uk.extended.model.FileMode.COPY
 import ebi.ac.uk.model.Collection
 import ebi.ac.uk.model.Group
 import ebi.ac.uk.model.Submission
@@ -77,15 +79,44 @@ interface SubmissionOperations {
 }
 
 interface MultipartSubmissionOperations {
-    fun submitSingle(submission: String, format: SubmissionFormat, files: List<File>): SubmissionResponse
-    fun submitSingle(submission: Submission, format: SubmissionFormat, files: List<File>): SubmissionResponse
-    fun submitSingle(submission: File, files: List<File>, attrs: Map<String, String> = emptyMap()): SubmissionResponse
+    fun submitSingle(
+        submission: String,
+        format: SubmissionFormat,
+        files: List<File>,
+        fileMode: FileMode = COPY
+    ): SubmissionResponse
+
+    fun submitSingle(
+        submission: Submission,
+        format: SubmissionFormat,
+        files: List<File>,
+        fileMode: FileMode = COPY
+    ): SubmissionResponse
+
+    fun submitSingle(
+        submission: File,
+        files: List<File>,
+        attrs: Map<String, String> = emptyMap(),
+        fileMode: FileMode = COPY
+    ): SubmissionResponse
 }
 
 interface MultipartAsyncSubmissionOperations {
-    fun asyncSubmitSingle(submission: String, format: SubmissionFormat, files: List<File>)
-    fun asyncSubmitSingle(submission: Submission, format: SubmissionFormat, files: List<File>)
-    fun asyncSubmitSingle(submission: File, files: List<File>, attrs: Map<String, String> = emptyMap())
+    fun asyncSubmitSingle(submission: String, format: SubmissionFormat, files: List<File>, fileMode: FileMode = COPY)
+
+    fun asyncSubmitSingle(
+        submission: Submission,
+        format: SubmissionFormat,
+        files: List<File>,
+        fileMode: FileMode = COPY
+    )
+
+    fun asyncSubmitSingle(
+        submission: File,
+        files: List<File>,
+        attrs: Map<String, String> = emptyMap(),
+        fileMode: FileMode = COPY
+    )
 }
 
 interface SecurityOperations {

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/common/config/WebConfig.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/common/config/WebConfig.kt
@@ -12,13 +12,8 @@ import ac.uk.ebi.biostd.submission.converters.ExtPageSubmissionConverter
 import ac.uk.ebi.biostd.submission.converters.ExtSubmissionConverter
 import ac.uk.ebi.biostd.submission.converters.JsonPagetabConverter
 import ac.uk.ebi.biostd.submission.converters.OnBehalfUserRequestResolver
-import ebi.ac.uk.extended.model.ExtAttributeDetail
-import ebi.ac.uk.model.constants.AttributeFields.NAME
-import ebi.ac.uk.model.constants.AttributeFields.VALUE
-import org.springframework.boot.configurationprocessor.json.JSONObject
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.core.convert.converter.Converter
 import org.springframework.format.FormatterRegistry
 import org.springframework.http.MediaType
 import org.springframework.http.converter.HttpMessageConverter

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/common/config/WebConfig.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/common/config/WebConfig.kt
@@ -6,13 +6,20 @@ import ac.uk.ebi.biostd.files.web.common.GroupPathDescriptorResolver
 import ac.uk.ebi.biostd.files.web.common.UserPathDescriptorResolver
 import ac.uk.ebi.biostd.integration.SerializationService
 import ac.uk.ebi.biostd.submission.converters.BioUserResolver
+import ac.uk.ebi.biostd.submission.converters.ExtAttributeDetailConverter
 import ac.uk.ebi.biostd.submission.converters.ExtFileTableConverter
 import ac.uk.ebi.biostd.submission.converters.ExtPageSubmissionConverter
 import ac.uk.ebi.biostd.submission.converters.ExtSubmissionConverter
 import ac.uk.ebi.biostd.submission.converters.JsonPagetabConverter
 import ac.uk.ebi.biostd.submission.converters.OnBehalfUserRequestResolver
+import ebi.ac.uk.extended.model.ExtAttributeDetail
+import ebi.ac.uk.model.constants.AttributeFields.NAME
+import ebi.ac.uk.model.constants.AttributeFields.VALUE
+import org.springframework.boot.configurationprocessor.json.JSONObject
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.convert.converter.Converter
+import org.springframework.format.FormatterRegistry
 import org.springframework.http.MediaType
 import org.springframework.http.converter.HttpMessageConverter
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity
@@ -62,5 +69,9 @@ internal class WebConfig(
         argumentResolvers.add(submitterResolver())
         argumentResolvers.add(OnBehalfUserRequestResolver())
         argumentResolvers.add(FileListPathDescriptorResolver())
+    }
+
+    override fun addFormatters(registry: FormatterRegistry) {
+        registry.addConverter(ExtAttributeDetailConverter())
     }
 }

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/converters/ExtAttributeDetailConverter.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/converters/ExtAttributeDetailConverter.kt
@@ -1,0 +1,14 @@
+package ac.uk.ebi.biostd.submission.converters
+
+import ebi.ac.uk.extended.model.ExtAttributeDetail
+import ebi.ac.uk.model.constants.AttributeFields.NAME
+import ebi.ac.uk.model.constants.AttributeFields.VALUE
+import org.springframework.boot.configurationprocessor.json.JSONObject
+import org.springframework.core.convert.converter.Converter
+
+class ExtAttributeDetailConverter : Converter<String, ExtAttributeDetail> {
+    override fun convert(source: String): ExtAttributeDetail {
+        val attribute = JSONObject(source)
+        return ExtAttributeDetail(attribute[NAME.value].toString(), attribute[VALUE.value].toString())
+    }
+}

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/web/resources/MultipartSubmitResource.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/web/resources/MultipartSubmitResource.kt
@@ -9,6 +9,7 @@ import ac.uk.ebi.biostd.submission.web.handlers.SubmitWebHandler
 import ac.uk.ebi.biostd.submission.web.model.ContentSubmitWebRequest
 import ac.uk.ebi.biostd.submission.web.model.FileSubmitWebRequest
 import ac.uk.ebi.biostd.submission.web.model.OnBehalfRequest
+import ebi.ac.uk.extended.model.ExtAttributeDetail
 import ebi.ac.uk.extended.model.FileMode
 import ebi.ac.uk.model.Submission
 import ebi.ac.uk.model.constants.ATTRIBUTES
@@ -131,17 +132,18 @@ class MultipartSubmitResource(
         @RequestParam(SUBMISSION) file: MultipartFile,
         @RequestParam(FILES) files: Array<MultipartFile>,
         @RequestParam(FILE_MODE, defaultValue = "COPY") mode: FileMode,
-        @RequestParam attributes: Map<String, String> = emptyMap()
+        @RequestParam(ATTRIBUTES) attributes: Array<ExtAttributeDetail>?
     ): Submission {
         val tempFiles = tempFileGenerator.asFiles(files)
         val subFile = tempFileGenerator.asFile(file)
+
         val contentWebRequest = FileSubmitWebRequest(
             submission = subFile,
             onBehalfRequest = onBehalfRequest,
             user = user,
             format = TSV,
             fileMode = mode,
-            attrs = attributes.filterNot { it.key == FILE_MODE },
+            attrs = attributes?.associate { it.name to it.value } ?: emptyMap(),
             files = tempFiles
         )
 

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/web/resources/MultipartSubmitResource.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/web/resources/MultipartSubmitResource.kt
@@ -141,7 +141,7 @@ class MultipartSubmitResource(
             user = user,
             format = TSV,
             fileMode = mode,
-            attrs = attributes,
+            attrs = attributes.filterNot { it.key == FILE_MODE },
             files = tempFiles
         )
 

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/web/resources/MultipartSubmitResource.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/web/resources/MultipartSubmitResource.kt
@@ -143,7 +143,7 @@ class MultipartSubmitResource(
             user = user,
             format = TSV,
             fileMode = mode,
-            attrs = attributes?.associate { it.name to it.value } ?: emptyMap(),
+            attrs = attributes.orEmpty().associate { it.name to it.value },
             files = tempFiles
         )
 

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/web/resources/submit/async/MultipartAsyncSubmitResource.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/web/resources/submit/async/MultipartAsyncSubmitResource.kt
@@ -132,7 +132,7 @@ class MultipartAsyncSubmitResource(
             user = user,
             format = TSV,
             fileMode = mode,
-            attrs = attributes,
+            attrs = attributes.filterNot { it.key == FILE_MODE },
             files = tempFiles
         )
         submitWebHandler.submitAsync(contentWebRequest)

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/web/resources/submit/async/MultipartAsyncSubmitResource.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/web/resources/submit/async/MultipartAsyncSubmitResource.kt
@@ -133,7 +133,7 @@ class MultipartAsyncSubmitResource(
             user = user,
             format = TSV,
             fileMode = mode,
-            attrs = attributes?.associate { it.name to it.value } ?: emptyMap(),
+            attrs = attributes.orEmpty().associate { it.name to it.value },
             files = tempFiles
         )
         submitWebHandler.submitAsync(contentWebRequest)

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/web/resources/submit/async/MultipartAsyncSubmitResource.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/web/resources/submit/async/MultipartAsyncSubmitResource.kt
@@ -9,6 +9,7 @@ import ac.uk.ebi.biostd.submission.web.handlers.SubmitWebHandler
 import ac.uk.ebi.biostd.submission.web.model.ContentSubmitWebRequest
 import ac.uk.ebi.biostd.submission.web.model.FileSubmitWebRequest
 import ac.uk.ebi.biostd.submission.web.model.OnBehalfRequest
+import ebi.ac.uk.extended.model.ExtAttributeDetail
 import ebi.ac.uk.extended.model.FileMode
 import ebi.ac.uk.model.constants.ATTRIBUTES
 import ebi.ac.uk.model.constants.FILES
@@ -122,7 +123,7 @@ class MultipartAsyncSubmitResource(
         @RequestParam(SUBMISSION) file: MultipartFile,
         @RequestParam(FILES) files: Array<MultipartFile>,
         @RequestParam(FILE_MODE, defaultValue = "COPY") mode: FileMode,
-        @RequestParam attributes: Map<String, String> = emptyMap()
+        @RequestParam(ATTRIBUTES) attributes: Array<ExtAttributeDetail>?
     ) {
         val tempFiles = tempFileGenerator.asFiles(files)
         val subFile = tempFileGenerator.asFile(file)
@@ -132,7 +133,7 @@ class MultipartAsyncSubmitResource(
             user = user,
             format = TSV,
             fileMode = mode,
-            attrs = attributes.filterNot { it.key == FILE_MODE },
+            attrs = attributes?.associate { it.name to it.value } ?: emptyMap(),
             files = tempFiles
         )
         submitWebHandler.submitAsync(contentWebRequest)

--- a/submission/submission-webapp/src/test/kotlin/ac/uk/ebi/biostd/submission/converters/ExtAttributeDetailConverterTest.kt
+++ b/submission/submission-webapp/src/test/kotlin/ac/uk/ebi/biostd/submission/converters/ExtAttributeDetailConverterTest.kt
@@ -1,0 +1,28 @@
+package ac.uk.ebi.biostd.submission.converters
+
+import ebi.ac.uk.dsl.json.jsonObj
+import ebi.ac.uk.extended.model.ExtAttributeDetail
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.boot.configurationprocessor.json.JSONException
+
+class ExtAttributeDetailConverterTest {
+    private val testInstance = ExtAttributeDetailConverter()
+
+    @Test
+    fun convert() {
+        val attribute = jsonObj {
+            "name" to "Overridden"
+            "value" to "New Value"
+        }.toString()
+
+        assertThat(testInstance.convert(attribute)).isEqualTo(ExtAttributeDetail("Overridden", "New Value"))
+    }
+
+    @Test
+    fun `convert invalid`() {
+        val attribute = jsonObj { "name" to "Overridden" }.toString()
+        assertThrows<JSONException> { testInstance.convert(attribute) }
+    }
+}


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/179922324

-  Add an option to move files instead of copying in the CLI submit operations
- Adjust the involved endpoints and web client's methods
- Add a converter for the "attributes" parameter
