### PR TITLE
Pivotal ID # 181416527: Fixes for FIRE

### DIFF
--- a/client/fire-webclient/src/main/kotlin/uk/ac/ebi/fire/client/api/FireClient.kt
+++ b/client/fire-webclient/src/main/kotlin/uk/ac/ebi/fire/client/api/FireClient.kt
@@ -6,7 +6,6 @@ import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.util.LinkedMultiValueMap
-import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.RestTemplate
 import org.springframework.web.client.getForObject
 import org.springframework.web.client.postForObject
@@ -21,21 +20,16 @@ internal const val FIRE_MD5_HEADER = "x-fire-md5"
 internal const val FIRE_PATH_HEADER = "x-fire-path"
 internal const val FIRE_SIZE_HEADER = "x-fire-size"
 
-internal const val SUBMISSION_FILE_RELPATH_HEADER = "file-relpath"
-
 const val FIRE_OBJECTS_URL = "/fire/objects"
-
-private typealias HttpException = HttpClientErrorException
 
 internal class FireClient(
     private val tmpDirPath: String,
     private val template: RestTemplate
 ) : FireOperations {
-    override fun save(file: File, md5: String, relPath: String): FireFile {
+    override fun save(file: File, md5: String): FireFile {
         val headers = HttpHeaders().apply {
             set(FIRE_MD5_HEADER, md5)
             set(FIRE_SIZE_HEADER, file.size().toString())
-            set(SUBMISSION_FILE_RELPATH_HEADER, relPath)
         }
         val formData = listOf(FIRE_FILE_PARAM to FileSystemResource(file))
         val body = LinkedMultiValueMap(formData.groupBy({ it.first }, { it.second }))

--- a/client/fire-webclient/src/main/kotlin/uk/ac/ebi/fire/client/integration/web/FireOperations.kt
+++ b/client/fire-webclient/src/main/kotlin/uk/ac/ebi/fire/client/integration/web/FireOperations.kt
@@ -4,7 +4,7 @@ import uk.ac.ebi.fire.client.model.FireFile
 import java.io.File
 
 interface FireOperations {
-    fun save(file: File, md5: String, relPath: String): FireFile
+    fun save(file: File, md5: String): FireFile
 
     fun setPath(fireOid: String, path: String)
 

--- a/client/fire-webclient/src/test/kotlin/uk/ac/ebi/fire/client/api/FireClientTest.kt
+++ b/client/fire-webclient/src/test/kotlin/uk/ac/ebi/fire/client/api/FireClientTest.kt
@@ -45,12 +45,11 @@ class FireClientTest(
             template.postForObject(FIRE_OBJECTS_URL, capture(httpEntitySlot), FireFile::class.java)
         } returns fireFile
 
-        testInstance.save(file, "the-md5", "relPath")
+        testInstance.save(file, "the-md5")
 
         val httpEntity = httpEntitySlot.captured
         assertThat(httpEntity.headers[FIRE_MD5_HEADER]!!.first()).isEqualTo("the-md5")
         assertThat(httpEntity.headers[FIRE_SIZE_HEADER]!!.first()).isEqualTo(file.size().toString())
-        assertThat(httpEntity.headers[SUBMISSION_FILE_RELPATH_HEADER]!!.first()).isEqualTo("relPath")
         assertThat(httpEntity.body!![FIRE_FILE_PARAM]!!.first()).isEqualTo(FileSystemResource(file))
         verify(exactly = 1) { template.postForObject(FIRE_OBJECTS_URL, capture(httpEntitySlot), FireFile::class.java) }
     }

--- a/commons/commons-model-extended/src/main/kotlin/ebi/ac/uk/extended/model/ExtSubmissionExtensions.kt
+++ b/commons/commons-model-extended/src/main/kotlin/ebi/ac/uk/extended/model/ExtSubmissionExtensions.kt
@@ -11,11 +11,19 @@ val ExtSubmission.allFileList
 val ExtSubmission.allSectionsFiles
     get(): List<ExtFile> = allSections.flatMap { it.allFiles }
 
+fun ExtSubmission.allFiles(): Sequence<ExtFile> = allFileListFiles().plus(allSectionsFiles).plus(pageTabFiles)
+
+/**
+ * Returns all file list files. Note that sequence is used instead regular iterable to avoid loading all submission
+ * files before start processing.
+ */
+fun ExtSubmission.allFileListFiles(): Sequence<ExtFile> =
+    allFileList
+        .flatMap { it.files + it.pageTabFiles }
+        .asSequence()
+
 val ExtSubmission.isCollection
     get(): Boolean = section.type == PROJECT_TYPE
-
-val ExtSubmission.filesPath
-    get(): String = "$relPath/Files"
 
 val ExtSubmission.computedTitle
     get(): String? = title ?: section.title

--- a/commons/commons-model-extended/src/test/kotlin/ebi/ac/uk/extended/model/ExtSubmissionExtensionsTest.kt
+++ b/commons/commons-model-extended/src/test/kotlin/ebi/ac/uk/extended/model/ExtSubmissionExtensionsTest.kt
@@ -1,11 +1,23 @@
 package ebi.ac.uk.extended.model
 
+import arrow.core.Either.Companion.left
+import ebi.ac.uk.io.ext.md5
+import ebi.ac.uk.io.ext.size
+import io.github.glytching.junit.extension.folder.TemporaryFolder
+import io.github.glytching.junit.extension.folder.TemporaryFolderExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 
-class ExtSubmissionExtensionsTest {
+@ExtendWith(TemporaryFolderExtension::class)
+class ExtSubmissionExtensionsTest(
+    tempFolder: TemporaryFolder
+) {
+    private val innerFile = tempFolder.createFile("file.txt")
+    private val referencedFile = tempFolder.createFile("referenced.txt")
+
     @Test
     fun computedTitle() {
         val submissionTitle = testSubmission(subTitle = "submission title", secTitle = null)
@@ -15,6 +27,40 @@ class ExtSubmissionExtensionsTest {
         assertThat(submissionTitle.computedTitle).isEqualTo("submission title")
         assertThat(submissionNoTitleSecTitle.computedTitle).isEqualTo("section title")
         assertThat(submissionNoTitleNoSecTitle.computedTitle).isNull()
+    }
+
+    @Test
+    fun `get all submission files`() {
+        val innerExtFile = NfsFile(
+            "my-folder/file.txt",
+            "Files/my-folder/file.txt",
+            innerFile,
+            innerFile.absolutePath,
+            innerFile.md5(),
+            innerFile.size(),
+            listOf()
+        )
+        val referencedExtFile = NfsFile(
+            "my-folder/referenced.txt",
+            "Files/my-folder/referenced.txt",
+            referencedFile,
+            referencedFile.absolutePath,
+            referencedFile.md5(),
+            referencedFile.size(),
+            listOf()
+        )
+        val submission = testSubmission("Test Submission").copy(
+            section = ExtSection(
+                type = "Study",
+                files = listOf(left(innerExtFile)),
+                fileList = ExtFileList("a/file-list", listOf(referencedExtFile))
+            )
+        )
+
+        val files = submission.allFiles().toList()
+
+        assertThat(files).hasSize(2)
+        assertThat(files).containsOnly(innerExtFile, referencedExtFile)
     }
 
     private fun testSubmission(subTitle: String? = null, secTitle: String? = null): ExtSubmission = ExtSubmission(

--- a/submission/persistence-common-api/src/main/kotlin/ac/uk/ebi/biostd/persistence/common/service/SubmissionOperations.kt
+++ b/submission/persistence-common-api/src/main/kotlin/ac/uk/ebi/biostd/persistence/common/service/SubmissionOperations.kt
@@ -16,10 +16,13 @@ interface SubmissionPersistenceService {
     fun releaseSubmission(accNo: String, owner: String, relPath: String)
 }
 
+@Suppress("TooManyFunctions")
 interface SubmissionQueryService {
     fun existByAccNo(accNo: String): Boolean
 
     fun findExtByAccNo(accNo: String, includeFileListFiles: Boolean = false): ExtSubmission?
+
+    fun findLatestExtByAccNo(accNo: String, includeFileListFiles: Boolean = false): ExtSubmission?
 
     fun getExtByAccNo(accNo: String, includeFileListFiles: Boolean = false): ExtSubmission
 

--- a/submission/persistence-filesystem/src/main/kotlin/ac/uk/ebi/biostd/persistence/filesystem/fire/FireFilesService.kt
+++ b/submission/persistence-filesystem/src/main/kotlin/ac/uk/ebi/biostd/persistence/filesystem/fire/FireFilesService.kt
@@ -26,7 +26,7 @@ class FireFilesService(
         val (sub, _, previousFiles) = request
         logger.info { "${sub.accNo} ${sub.owner} Persisting files of submission ${sub.accNo} on FIRE" }
 
-        cleanFtpFolder(sub)
+        cleanSubmissionFolder(sub)
         val config = FireFileProcessingConfig(sub.accNo, sub.owner, sub.relPath, fireWebClient, previousFiles)
         val processed = processFiles(sub) { config.processFile(request.submission, it) }
 
@@ -35,15 +35,16 @@ class FireFilesService(
         return processed
     }
 
-    private fun cleanFtpFolder(submission: ExtSubmission) {
+    private fun cleanSubmissionFolder(submission: ExtSubmission) {
         submissionQueryService
             .findLatestExtByAccNo(submission.accNo, includeFileListFiles = true)
             ?.allFiles()
             ?.filterIsInstance<FireFile>()
-            ?.forEach { fireFile -> unpublishFile(fireFile.fireId) }
+            ?.forEach { fireFile -> cleanFile(fireFile.fireId) }
     }
 
-    private fun unpublishFile(fireId: String) {
+    // TODO Pivotal ID # 181595553: Separate unsetting path from un-publishing once #180902516 is merged
+    private fun cleanFile(fireId: String) {
         fireWebClient.unpublish(fireId)
         fireWebClient.unsetPath(fireId)
     }

--- a/submission/persistence-filesystem/src/main/kotlin/ac/uk/ebi/biostd/persistence/filesystem/fire/FireFilesService.kt
+++ b/submission/persistence-filesystem/src/main/kotlin/ac/uk/ebi/biostd/persistence/filesystem/fire/FireFilesService.kt
@@ -1,5 +1,6 @@
 package ac.uk.ebi.biostd.persistence.filesystem.fire
 
+import ac.uk.ebi.biostd.persistence.common.service.SubmissionQueryService
 import ac.uk.ebi.biostd.persistence.filesystem.api.FilesService
 import ac.uk.ebi.biostd.persistence.filesystem.request.FilePersistenceRequest
 import ac.uk.ebi.biostd.persistence.filesystem.request.Md5
@@ -9,6 +10,7 @@ import ebi.ac.uk.extended.model.ExtSubmission
 import ebi.ac.uk.extended.model.FireDirectory
 import ebi.ac.uk.extended.model.FireFile
 import ebi.ac.uk.extended.model.NfsFile
+import ebi.ac.uk.extended.model.allFiles
 import ebi.ac.uk.io.ext.md5
 import ebi.ac.uk.io.ext.size
 import mu.KotlinLogging
@@ -16,17 +18,34 @@ import uk.ac.ebi.fire.client.integration.web.FireWebClient
 
 private val logger = KotlinLogging.logger {}
 
-class FireFilesService(private val fireWebClient: FireWebClient) : FilesService {
+class FireFilesService(
+    private val fireWebClient: FireWebClient,
+    private val submissionQueryService: SubmissionQueryService
+) : FilesService {
     override fun persistSubmissionFiles(request: FilePersistenceRequest): ExtSubmission {
         val (sub, _, previousFiles) = request
         logger.info { "${sub.accNo} ${sub.owner} Persisting files of submission ${sub.accNo} on FIRE" }
 
+        cleanFtpFolder(sub)
         val config = FireFileProcessingConfig(sub.accNo, sub.owner, sub.relPath, fireWebClient, previousFiles)
         val processed = processFiles(sub) { config.processFile(request.submission, it) }
 
         logger.info { "${sub.accNo} ${sub.owner} Finished persisting files of submission ${sub.accNo} on FIRE" }
 
         return processed
+    }
+
+    private fun cleanFtpFolder(submission: ExtSubmission) {
+        submissionQueryService
+            .findLatestExtByAccNo(submission.accNo, includeFileListFiles = true)
+            ?.allFiles()
+            ?.filterIsInstance<FireFile>()
+            ?.forEach { fireFile -> unpublishFile(fireFile.fireId) }
+    }
+
+    private fun unpublishFile(fireId: String) {
+        fireWebClient.unpublish(fireId)
+        fireWebClient.unsetPath(fireId)
     }
 }
 
@@ -65,7 +84,8 @@ private fun FireFileProcessingConfig.saveFile(subRelPath: String, nfsFile: NfsFi
     return when {
         nfsFile.file.isDirectory -> FireDirectory(filePath, relPath, file.md5(), file.size(), attributes)
         else -> {
-            val store = fireWebClient.save(nfsFile.file, nfsFile.md5, "$subRelPath/${nfsFile.relPath}")
+            val store = fireWebClient.save(nfsFile.file, nfsFile.md5)
+            fireWebClient.setPath(store.fireOid, "$subRelPath/$relPath")
             FireFile(filePath, relPath, store.fireOid, store.objectMd5, store.objectSize.toLong(), attributes)
         }
     }

--- a/submission/persistence-filesystem/src/main/kotlin/ac/uk/ebi/biostd/persistence/filesystem/fire/FireFtpService.kt
+++ b/submission/persistence-filesystem/src/main/kotlin/ac/uk/ebi/biostd/persistence/filesystem/fire/FireFtpService.kt
@@ -2,11 +2,8 @@ package ac.uk.ebi.biostd.persistence.filesystem.fire
 
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionQueryService
 import ac.uk.ebi.biostd.persistence.filesystem.api.FtpService
-import ebi.ac.uk.extended.model.ExtFile
-import ebi.ac.uk.extended.model.ExtSubmission
 import ebi.ac.uk.extended.model.FireFile
-import ebi.ac.uk.extended.model.allFileList
-import ebi.ac.uk.extended.model.allSectionsFiles
+import ebi.ac.uk.extended.model.allFiles
 import mu.KotlinLogging
 import uk.ac.ebi.fire.client.integration.web.FireWebClient
 
@@ -26,41 +23,13 @@ class FireFtpService(
 
     override fun generateFtpLinks(accNo: String) {
         val submission = submissionQueryService.getExtByAccNo(accNo, includeFileListFiles = true)
-        cleanFtpFolder(submission.relPath)
-        publishFiles(submission)
-    }
-
-    private fun publishFiles(submission: ExtSubmission) =
-        allFiles(submission)
+        submission.allFiles()
             .filterIsInstance<FireFile>()
             .forEach { publishFile(it, submission.relPath) }
-
-    private fun allFiles(sub: ExtSubmission): Sequence<ExtFile> =
-        allFileListFiles(sub).plus(sub.allSectionsFiles).plus(sub.pageTabFiles)
-
-    /**
-     * Returns all file list files. Note that sequence is used instead regular iterable to avoid loading all submission
-     * files before start processing.
-     */
-    private fun allFileListFiles(extSubmission: ExtSubmission): Sequence<ExtFile> =
-        extSubmission
-            .allFileList
-            .flatMap { it.files + it.pageTabFiles }
-            .asSequence()
+    }
 
     private fun publishFile(file: FireFile, relPath: String) {
         fireWebClient.setPath(file.fireId, "$relPath/${file.relPath}")
         fireWebClient.publish(file.fireId)
-    }
-
-    private fun cleanFtpFolder(relPath: String) {
-        fireWebClient
-            .findAllInPath(relPath)
-            .forEach { unpublishFile(it.fireOid) }
-    }
-
-    private fun unpublishFile(fireId: String) {
-        fireWebClient.unpublish(fireId)
-        fireWebClient.unsetPath(fireId)
     }
 }

--- a/submission/persistence-filesystem/src/main/kotlin/ac/uk/ebi/biostd/persistence/filesystem/nfs/NfsFtpService.kt
+++ b/submission/persistence-filesystem/src/main/kotlin/ac/uk/ebi/biostd/persistence/filesystem/nfs/NfsFtpService.kt
@@ -26,7 +26,7 @@ class NfsFtpService(
     }
 
     override fun generateFtpLinks(accNo: String) {
-        val sub = submissionQueryService.getExtByAccNo(accNo)
+        val sub = submissionQueryService.getExtByAccNo(accNo, includeFileListFiles = true)
 
         logger.info { "${sub.accNo} ${sub.owner} Started processing FTP links for submission $accNo over NFS" }
 

--- a/submission/persistence-filesystem/src/main/kotlin/ac/uk/ebi/biostd/persistence/filesystem/pagetab/FirePageTabService.kt
+++ b/submission/persistence-filesystem/src/main/kotlin/ac/uk/ebi/biostd/persistence/filesystem/pagetab/FirePageTabService.kt
@@ -47,7 +47,9 @@ class FirePageTabService(
 
     private fun saveFileListFile(file: File, subFolder: String, filePath: String): FireFile {
         val relPath = "Files/$filePath"
-        val db = fireWebClient.save(file, file.md5(), "$subFolder/$relPath")
+        val db = fireWebClient.save(file, file.md5())
+        fireWebClient.setPath(db.fireOid, "$subFolder/$relPath")
+
         return FireFile(filePath, relPath, db.fireOid, db.objectMd5, db.objectSize.toLong(), listOf())
     }
 
@@ -59,7 +61,9 @@ class FirePageTabService(
 
     private fun saveSubFile(file: File, subFolder: String): FireFile {
         val name = file.name
-        val db = fireWebClient.save(file, file.md5(), "$subFolder/$name")
+        val db = fireWebClient.save(file, file.md5())
+        fireWebClient.setPath(db.fireOid, "$subFolder/$name")
+
         return FireFile(name, name, db.fireOid, db.objectMd5, db.objectSize.toLong(), listOf())
     }
 }

--- a/submission/persistence-filesystem/src/test/kotlin/ac/uk/ebi/biostd/persistence/fire/FireFilesServiceTest.kt
+++ b/submission/persistence-filesystem/src/test/kotlin/ac/uk/ebi/biostd/persistence/fire/FireFilesServiceTest.kt
@@ -1,5 +1,6 @@
 package ac.uk.ebi.biostd.persistence.fire
 
+import ac.uk.ebi.biostd.persistence.common.service.SubmissionQueryService
 import ac.uk.ebi.biostd.persistence.filesystem.fire.FireFilesService
 import ac.uk.ebi.biostd.persistence.filesystem.request.FilePersistenceRequest
 import arrow.core.Either.Companion.left
@@ -29,34 +30,51 @@ import uk.ac.ebi.fire.client.model.FireFile as ClientFireFile
 @ExtendWith(MockKExtension::class, TemporaryFolderExtension::class)
 class FireFilesServiceTest(
     tempFolder: TemporaryFolder,
-    @MockK private val fireWebClient: FireWebClient
+    @MockK private val fireWebClient: FireWebClient,
+    @MockK private val submissionQueryService: SubmissionQueryService
 ) {
     private val file = tempFolder.createFile("test.txt")
     private val testMd5 = file.md5()
     private val attribute = ExtAttribute("Type", "Test")
-    private val testInstance = FireFilesService(fireWebClient)
+    private val testInstance = FireFilesService(fireWebClient, submissionQueryService)
 
     @AfterEach
     fun afterEach() = clearAllMocks()
 
     @BeforeEach
     fun beforeEach() {
-        every { fireWebClient.setPath("abc1", "${basicExtSubmission.relPath}/folder/test.txt") } answers { nothing }
+        every { submissionQueryService.findLatestExtByAccNo(basicExtSubmission.accNo, true) } returns null
+        every { fireWebClient.save(file, testMd5) } returns ClientFireFile(1, "abc1", testMd5, 1, "2021-07-08")
         every {
-            fireWebClient.save(file, testMd5, "S-TEST/123/S-TEST123/Files/folder/test.txt")
-        } returns ClientFireFile(1, "abc1", testMd5, 1, "2021-07-08")
+            fireWebClient.setPath("abc1", "${basicExtSubmission.relPath}/Files/folder/test.txt")
+        } answers { nothing }
     }
 
     @Test
-    fun `process submission with non existing file`() {
+    fun `process submission with new file and previous version`() {
+        val previousFile = FireFile("test.txt", "Files/test.txt", "dda2", "md5", 1L, listOf())
+        val previousVersion = basicExtSubmission.copy(
+            version = 1,
+            section = ExtSection(type = "Study", files = listOf(left(previousFile)))
+        )
+
         val nfsFile = createNfsFile("folder/test.txt", "Files/folder/test.txt", file, listOf(attribute))
         val section = ExtSection(type = "Study", files = listOf(left(nfsFile)))
         val submission = basicExtSubmission.copy(section = section)
 
+        every { fireWebClient.unpublish("dda2") } answers { nothing }
+        every { fireWebClient.unsetPath("dda2") } answers { nothing }
+        every { submissionQueryService.findLatestExtByAccNo(basicExtSubmission.accNo, true) } returns previousVersion
+
         val processed = testInstance.persistSubmissionFiles(FilePersistenceRequest(submission))
 
         assertFireFile(processed, "test.txt", "folder/test.txt")
-        verify(exactly = 1) { fireWebClient.save(file, testMd5, "S-TEST/123/S-TEST123/Files/folder/test.txt") }
+        verify(exactly = 1) {
+            fireWebClient.unpublish("dda2")
+            fireWebClient.unsetPath("dda2")
+            fireWebClient.save(file, testMd5)
+            fireWebClient.setPath("abc1", "S-TEST/123/S-TEST123/Files/folder/test.txt")
+        }
     }
 
     @Test
@@ -71,7 +89,10 @@ class FireFilesServiceTest(
         val processed = testInstance.persistSubmissionFiles(request)
 
         assertFireFile(processed, "test.txt", "folder/test.txt")
-        verify(exactly = 0) { fireWebClient.save(file, testMd5, "S-TEST/123/S-TEST123/Files/folder/test.txt") }
+        verify(exactly = 0) {
+            fireWebClient.save(file, testMd5)
+            fireWebClient.setPath("abc1", "S-TEST/123/S-TEST123/Files/folder/test.txt")
+        }
     }
 
     @Test
@@ -87,7 +108,10 @@ class FireFilesServiceTest(
         val processed = testInstance.persistSubmissionFiles(request)
 
         assertFireFile(processed, "test.txt", "folder/test.txt")
-        verify(exactly = 1) { fireWebClient.save(file, testMd5, "S-TEST/123/S-TEST123/Files/folder/test.txt") }
+        verify(exactly = 1) {
+            fireWebClient.save(file, testMd5)
+            fireWebClient.setPath("abc1", "S-TEST/123/S-TEST123/Files/folder/test.txt")
+        }
     }
 
     @Test
@@ -103,7 +127,10 @@ class FireFilesServiceTest(
         val processed = testInstance.persistSubmissionFiles(request)
 
         assertFireFile(processed, "test.txt", "new-folder/test.txt")
-        verify(exactly = 0) { fireWebClient.save(file, testMd5, "S-TEST/123/S-TEST123/Files/folder/test.txt") }
+        verify(exactly = 0) {
+            fireWebClient.save(file, testMd5)
+            fireWebClient.setPath("abc1", "S-TEST/123/S-TEST123/Files/folder/test.txt")
+        }
     }
 
     @Test
@@ -117,7 +144,10 @@ class FireFilesServiceTest(
         val request = FilePersistenceRequest(submission, previousFiles = previousFiles)
 
         assertThat(testInstance.persistSubmissionFiles(request)).isEqualTo(submission)
-        verify(exactly = 0) { fireWebClient.save(file, testMd5, "S-TEST/123/S-TEST123/Files/folder/test.txt") }
+        verify(exactly = 0) {
+            fireWebClient.save(file, testMd5)
+            fireWebClient.setPath("abc1", "S-TEST/123/S-TEST123/Files/folder/test.txt")
+        }
     }
 
 //    @Test

--- a/submission/persistence-filesystem/src/test/kotlin/ac/uk/ebi/biostd/persistence/fire/FireFtpServiceTest.kt
+++ b/submission/persistence-filesystem/src/test/kotlin/ac/uk/ebi/biostd/persistence/fire/FireFtpServiceTest.kt
@@ -20,14 +20,12 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import uk.ac.ebi.fire.client.integration.web.FireWebClient
-import uk.ac.ebi.fire.client.model.FireFile as ClientFireFile
 
 @ExtendWith(MockKExtension::class)
 class FireFtpServiceTest(
     @MockK(relaxUnitFun = true) private val fireWebClient: FireWebClient,
     @MockK private val submissionQueryService: SubmissionQueryService
 ) {
-    private val clientFireFile = ClientFireFile(1, "abc1", "md5", 1, "2021-09-21")
     private val fileFileList = fireFile(FILE_FILE_LIST)
     private val innerFileListFile = fireFile(INNER_FILE_FILE_LIST)
     private val extSub = createExtSubmission(fileFileList, innerFileListFile)
@@ -38,7 +36,6 @@ class FireFtpServiceTest(
 
     @BeforeEach
     fun beforeEach() {
-        every { fireWebClient.findAllInPath(extSub.relPath) } returns listOf(clientFireFile)
         every { submissionQueryService.getReferencedFiles(extSub.accNo, "fileName1") } returns listOf(fileFileList)
         every { submissionQueryService.getReferencedFiles(extSub.accNo, "fileName2") } returns listOf(innerFileListFile)
     }
@@ -51,7 +48,6 @@ class FireFtpServiceTest(
 
         testInstance.releaseSubmissionFiles(extSub.accNo, extSub.owner, extSub.relPath)
 
-        verifyCleanFtpFolder()
         verifyFtpPublish()
     }
 
@@ -63,13 +59,7 @@ class FireFtpServiceTest(
 
         testInstance.generateFtpLinks(submission.accNo)
 
-        verifyCleanFtpFolder()
         verifyFtpPublish()
-    }
-
-    private fun verifyCleanFtpFolder() = verify(exactly = 1) {
-        fireWebClient.unpublish(FILE_FILE_LIST)
-        fireWebClient.unsetPath(FILE_FILE_LIST)
     }
 
     private fun verifyFtpPublish() = verify(exactly = 1) {

--- a/submission/persistence-filesystem/src/test/kotlin/ac/uk/ebi/biostd/persistence/nfs/NfsFtpServiceTest.kt
+++ b/submission/persistence-filesystem/src/test/kotlin/ac/uk/ebi/biostd/persistence/nfs/NfsFtpServiceTest.kt
@@ -50,7 +50,7 @@ internal class NfsFtpServiceTest(
 
     @Test
     fun `create ftp folder`() {
-        every { submissionQueryService.getExtByAccNo("S-BSST0") } returns extSubmission
+        every { submissionQueryService.getExtByAccNo("S-BSST0", true) } returns extSubmission
 
         testInstance.generateFtpLinks("S-BSST0")
 

--- a/submission/persistence-filesystem/src/test/kotlin/ac/uk/ebi/biostd/persistence/pagetab/FirePageTabServiceTest.kt
+++ b/submission/persistence-filesystem/src/test/kotlin/ac/uk/ebi/biostd/persistence/pagetab/FirePageTabServiceTest.kt
@@ -21,6 +21,7 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockkStatic
+import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -48,6 +49,7 @@ class FirePageTabServiceTest(
         assertSubmissionTabFiles(result)
         assertSectionTabFiles(result.section)
         assertThatEither(result.section.sections.first()).hasLeftValueSatisfying { assertSubSectionTabFiles(it) }
+        verifySetFirePath()
     }
 
     private fun setUpGeneratePageTab(submission: ExtSubmission) {
@@ -74,7 +76,7 @@ class FirePageTabServiceTest(
     }
 
     private fun setUpFireWebClient() {
-        every { fireWebClient.save(any(), any(), any()) } returns
+        every { fireWebClient.save(any(), any()) } returns
             FireFileWeb(1, "$FILE_LIST_JSON2-fireId", "md5", 1, "creationTime") andThen
             FireFileWeb(2, "$FILE_LIST_XML2-fireId", "md5", 1, "creationTime") andThen
             FireFileWeb(3, "$FILE_LIST_TSV2-fireId", "md5", 1, "creationTime") andThen
@@ -84,6 +86,28 @@ class FirePageTabServiceTest(
             FireFileWeb(7, "$SUB_JSON-fireId", "md5", 1, "creationTime") andThen
             FireFileWeb(8, "$SUB_XML-fireId", "md5", 1, "creationTime") andThen
             FireFileWeb(9, "$SUB_TSV-fireId", "md5", 1, "creationTime")
+
+        every { fireWebClient.setPath("$SUB_TSV-fireId", "S-TEST/123/S-TEST123/$SUB_TSV") } answers { nothing }
+        every { fireWebClient.setPath("$SUB_XML-fireId", "S-TEST/123/S-TEST123/$SUB_XML") } answers { nothing }
+        every { fireWebClient.setPath("$SUB_JSON-fireId", "S-TEST/123/S-TEST123/$SUB_JSON") } answers { nothing }
+        every {
+            fireWebClient.setPath("$FILE_LIST_TSV1-fireId", "S-TEST/123/S-TEST123/Files/data/$FILE_LIST_TSV1")
+        } answers { nothing }
+        every {
+            fireWebClient.setPath("$FILE_LIST_TSV2-fireId", "S-TEST/123/S-TEST123/Files/data/$FILE_LIST_TSV2")
+        } answers { nothing }
+        every {
+            fireWebClient.setPath("$FILE_LIST_XML1-fireId", "S-TEST/123/S-TEST123/Files/data/$FILE_LIST_XML1")
+        } answers { nothing }
+        every {
+            fireWebClient.setPath("$FILE_LIST_XML2-fireId", "S-TEST/123/S-TEST123/Files/data/$FILE_LIST_XML2")
+        } answers { nothing }
+        every {
+            fireWebClient.setPath("$FILE_LIST_JSON1-fireId", "S-TEST/123/S-TEST123/Files/data/$FILE_LIST_JSON1")
+        } answers { nothing }
+        every {
+            fireWebClient.setPath("$FILE_LIST_JSON2-fireId", "S-TEST/123/S-TEST123/Files/data/$FILE_LIST_JSON2")
+        } answers { nothing }
     }
 
     private fun sectionWithoutTabFiles() = ExtSection(
@@ -154,6 +178,18 @@ class FirePageTabServiceTest(
                 listOf()
             )
         )
+    }
+
+    private fun verifySetFirePath() = verify(exactly = 1) {
+        fireWebClient.setPath("$SUB_TSV-fireId", "S-TEST/123/S-TEST123/$SUB_TSV")
+        fireWebClient.setPath("$SUB_XML-fireId", "S-TEST/123/S-TEST123/$SUB_XML")
+        fireWebClient.setPath("$SUB_JSON-fireId", "S-TEST/123/S-TEST123/$SUB_JSON")
+        fireWebClient.setPath("$FILE_LIST_TSV1-fireId", "S-TEST/123/S-TEST123/Files/data/$FILE_LIST_TSV1")
+        fireWebClient.setPath("$FILE_LIST_TSV2-fireId", "S-TEST/123/S-TEST123/Files/data/$FILE_LIST_TSV2")
+        fireWebClient.setPath("$FILE_LIST_XML1-fireId", "S-TEST/123/S-TEST123/Files/data/$FILE_LIST_XML1")
+        fireWebClient.setPath("$FILE_LIST_XML2-fireId", "S-TEST/123/S-TEST123/Files/data/$FILE_LIST_XML2")
+        fireWebClient.setPath("$FILE_LIST_JSON1-fireId", "S-TEST/123/S-TEST123/Files/data/$FILE_LIST_JSON1")
+        fireWebClient.setPath("$FILE_LIST_JSON2-fireId", "S-TEST/123/S-TEST123/Files/data/$FILE_LIST_JSON2")
     }
 
     companion object {

--- a/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/db/repositories/Repositories.kt
+++ b/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/db/repositories/Repositories.kt
@@ -18,6 +18,9 @@ interface SubmissionMongoRepository : MongoRepository<DocSubmission, ObjectId> {
     @Query("{ 'accNo': '?0', 'version': { \$gte: 0 } }")
     fun findByAccNo(accNo: String): DocSubmission?
 
+    @Query("{ 'accNo': '?0', 'version': { \$gte: 0 }, 'status': 'PROCESSED' }")
+    fun findLatestByAccNo(accNo: String): DocSubmission?
+
     fun existsByAccNo(accNo: String): Boolean
 
     fun getByAccNoAndVersion(accNo: String, version: Int): DocSubmission

--- a/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/service/SubmissionMongoQueryService.kt
+++ b/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/service/SubmissionMongoQueryService.kt
@@ -46,6 +46,11 @@ internal class SubmissionMongoQueryService(
         return findByAccNo?.let { toExtSubmissionMapper.toExtSubmission(it, includeFileListFiles) }
     }
 
+    override fun findLatestExtByAccNo(accNo: String, includeFileListFiles: Boolean): ExtSubmission? {
+        val findByAccNo = submissionRepo.findLatestByAccNo(accNo)
+        return findByAccNo?.let { toExtSubmissionMapper.toExtSubmission(it, includeFileListFiles) }
+    }
+
     override fun getExtByAccNo(accNo: String, includeFileListFiles: Boolean): ExtSubmission {
         val submission = submissionRepo.getByAccNo(accNo)
         return toExtSubmissionMapper.toExtSubmission(submission, includeFileListFiles)

--- a/submission/persistence-mongo/src/test/kotlin/ac/uk/ebi/biostd/persistence/doc/service/SubmissionMongoQueryServiceTest.kt
+++ b/submission/persistence-mongo/src/test/kotlin/ac/uk/ebi/biostd/persistence/doc/service/SubmissionMongoQueryServiceTest.kt
@@ -10,6 +10,7 @@ import ac.uk.ebi.biostd.persistence.doc.mapping.to.ToExtSubmissionMapper
 import ac.uk.ebi.biostd.persistence.doc.model.DocAttribute
 import ac.uk.ebi.biostd.persistence.doc.model.DocFileList
 import ac.uk.ebi.biostd.persistence.doc.model.DocProcessingStatus.PROCESSED
+import ac.uk.ebi.biostd.persistence.doc.model.DocProcessingStatus.REQUESTED as DOC_REQUESTED
 import ac.uk.ebi.biostd.persistence.doc.model.DocSection
 import ac.uk.ebi.biostd.persistence.doc.model.DocSubmissionRequest
 import ac.uk.ebi.biostd.persistence.doc.model.FileListDocFile
@@ -83,6 +84,12 @@ internal class SubmissionMongoQueryServiceTest(
             toExtSubmissionMapper
         )
 
+    @AfterEach
+    fun afterEach() {
+        submissionRepo.deleteAll()
+        fileListDocFileRepository.deleteAll()
+    }
+
     @Nested
     inner class ExpireSubmissions {
         @Test
@@ -101,6 +108,34 @@ internal class SubmissionMongoQueryServiceTest(
 
             assertThat(submissionRepo.findByAccNo("S-BSST1")).isNull()
             assertThat(submissionRepo.findByAccNo("S-BSST101")).isNull()
+        }
+    }
+
+    @Nested
+    inner class FindSubmissions {
+        @Test
+        fun `find latest by accNo`() {
+            submissionRepo.save(docSubmission.copy(accNo = "S-BSST1", version = -1, status = PROCESSED))
+            submissionRepo.save(docSubmission.copy(accNo = "S-BSST1", version = 2, status = PROCESSED))
+            submissionRepo.save(docSubmission.copy(accNo = "S-BSST1", version = 3, status = DOC_REQUESTED))
+
+            val result = submissionRepo.findLatestByAccNo("S-BSST1")
+            assertThat(result).isNotNull
+            assertThat(result!!.version).isEqualTo(2)
+            assertThat(result.status).isEqualTo(PROCESSED)
+        }
+
+        @Test
+        fun `find latest by accNo for new submission`() {
+            submissionRepo.save(docSubmission.copy(accNo = "S-BSST2", version = 1, status = DOC_REQUESTED))
+            assertThat(submissionRepo.findLatestByAccNo("S-BSST2")).isNull()
+        }
+
+        @Test
+        fun `find latest by accNo for submission with old expired version`() {
+            submissionRepo.save(docSubmission.copy(accNo = "S-BSST3", version = -1, status = PROCESSED))
+            submissionRepo.save(docSubmission.copy(accNo = "S-BSST3", version = 2, status = DOC_REQUESTED))
+            assertThat(submissionRepo.findLatestByAccNo("S-BSST3")).isNull()
         }
     }
 
@@ -134,12 +169,6 @@ internal class SubmissionMongoQueryServiceTest(
         fun beforeEach() {
             submissionRepo.save(submission)
             fileListDocFileRepository.save(fileListFile)
-        }
-
-        @AfterEach
-        fun afterEach() {
-            submissionRepo.deleteAll()
-            fileListDocFileRepository.deleteAll()
         }
 
         @Test

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/common/config/FileSystemConfig.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/common/config/FileSystemConfig.kt
@@ -1,6 +1,7 @@
 package ac.uk.ebi.biostd.common.config
 
 import ac.uk.ebi.biostd.common.config.SubmitterConfig.FilesHandlerConfig
+import ac.uk.ebi.biostd.persistence.common.service.SubmissionQueryService
 import ac.uk.ebi.biostd.persistence.filesystem.api.FilesService
 import ac.uk.ebi.biostd.persistence.filesystem.fire.FireFilesService
 import ac.uk.ebi.biostd.persistence.filesystem.nfs.NfsFilesService
@@ -14,8 +15,9 @@ import uk.ac.ebi.fire.client.integration.web.FireWebClient
 @Configuration
 @Import(value = [WebConfig::class, FilesHandlerConfig::class])
 class FileSystemConfig(
+    private val fireWebClient: FireWebClient,
     private val folderResolver: SubmissionFolderResolver,
-    private val fireWebClient: FireWebClient
+    private val submissionQueryService: SubmissionQueryService,
 ) {
     @Bean
     @ConditionalOnProperty(
@@ -28,5 +30,5 @@ class FileSystemConfig(
 
     @Bean
     @ConditionalOnProperty(prefix = "app.persistence", name = ["enableFire"], havingValue = "true")
-    fun fireFileService(): FilesService = FireFilesService(fireWebClient)
+    fun fireFileService(): FilesService = FireFilesService(fireWebClient, submissionQueryService)
 }

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/web/resources/FireResource.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/web/resources/FireResource.kt
@@ -34,7 +34,7 @@ class FireResource(
         @RequestParam("md5") md5: String,
         @RequestParam("accNo") accNo: String
     ): FireFile {
-        val persisted = fireWebClient.save(tempFileGenerator.asFile(multipartFile), md5, "")
+        val persisted = fireWebClient.save(tempFileGenerator.asFile(multipartFile), md5)
         fireWebClient.setPath(persisted.fireOid, path)
         return persisted
     }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181416527

- Set the path to the files of every submission even if these are private
- Clean submission folder before files processing
- Remove unnecessary parameter in the FIRE save operation
- Include referenced files in the releasing process
