### PR TITLE
Pivotal ID # 181330026: Attached Directory Should Not Be Required

### DIFF
--- a/client/bio-commandline/src/main/kotlin/uk/ac/ebi/biostd/client/cli/commands/SubmitAsyncCommand.kt
+++ b/client/bio-commandline/src/main/kotlin/uk/ac/ebi/biostd/client/cli/commands/SubmitAsyncCommand.kt
@@ -1,12 +1,12 @@
 package uk.ac.ebi.biostd.client.cli.commands
 
 import com.github.ajalt.clikt.core.CliktCommand
-import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
+import ebi.ac.uk.extended.model.FileMode
 import ebi.ac.uk.extended.model.FileMode.COPY
-import ebi.ac.uk.extended.model.FileMode.MOVE
 import uk.ac.ebi.biostd.client.cli.common.CommonParameters.ON_BEHALF_HELP
 import uk.ac.ebi.biostd.client.cli.common.CommonParameters.PASSWORD_HELP
 import uk.ac.ebi.biostd.client.cli.common.CommonParameters.SERVER_HELP
@@ -20,15 +20,16 @@ import uk.ac.ebi.biostd.client.cli.dto.SubmissionRequest
 import uk.ac.ebi.biostd.client.cli.services.SubmissionService
 import java.io.File
 
-internal class SubmitAsyncCommand(private val submissionService: SubmissionService) :
-    CliktCommand(name = "submitAsync") {
+internal class SubmitAsyncCommand(
+    private val submissionService: SubmissionService
+) : CliktCommand(name = "submitAsync") {
     private val server by option("-s", "--server", help = SERVER_HELP).required()
     private val user by option("-u", "--user", help = USER_HELP).required()
     private val password by option("-p", "--password", help = PASSWORD_HELP).required()
     private val onBehalf by option("-b", "--onBehalf", help = ON_BEHALF_HELP)
     private val input by option("-i", "--input", help = INPUT_HELP).file(exists = true).required()
     private val attached by option("-a", "--attached", help = ATTACHED_HELP)
-    private val moveFiles by option("-m", "--moveFiles", help = FILE_MODE).flag(default = false)
+    private val fileMode by option("-fm", "--fileMode", help = FILE_MODE).default(COPY.name)
 
     override fun run() {
         val request = SubmissionRequest(
@@ -38,7 +39,7 @@ internal class SubmitAsyncCommand(private val submissionService: SubmissionServi
             onBehalf = onBehalf,
             file = input,
             attached = attached?.split(FILES_SEPARATOR)?.flatMap { getFiles(File(it)) }.orEmpty(),
-            fileMode = if (moveFiles) MOVE else COPY
+            fileMode = FileMode.valueOf(fileMode)
         )
 
         submissionService.submitAsync(request)

--- a/client/bio-commandline/src/main/kotlin/uk/ac/ebi/biostd/client/cli/commands/SubmitCommand.kt
+++ b/client/bio-commandline/src/main/kotlin/uk/ac/ebi/biostd/client/cli/commands/SubmitCommand.kt
@@ -5,8 +5,8 @@ import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
+import ebi.ac.uk.extended.model.FileMode
 import ebi.ac.uk.extended.model.FileMode.COPY
-import ebi.ac.uk.extended.model.FileMode.valueOf
 import uk.ac.ebi.biostd.client.cli.common.CommonParameters.ON_BEHALF_HELP
 import uk.ac.ebi.biostd.client.cli.common.CommonParameters.PASSWORD_HELP
 import uk.ac.ebi.biostd.client.cli.common.CommonParameters.SERVER_HELP
@@ -20,7 +20,9 @@ import uk.ac.ebi.biostd.client.cli.dto.SubmissionRequest
 import uk.ac.ebi.biostd.client.cli.services.SubmissionService
 import java.io.File
 
-internal class SubmitCommand(private val submissionService: SubmissionService) : CliktCommand(name = "submit") {
+internal class SubmitCommand(
+    private val submissionService: SubmissionService
+) : CliktCommand(name = "submit") {
     private val server by option("-s", "--server", help = SERVER_HELP).required()
     private val user by option("-u", "--user", help = USER_HELP).required()
     private val password by option("-p", "--password", help = PASSWORD_HELP).required()
@@ -36,8 +38,8 @@ internal class SubmitCommand(private val submissionService: SubmissionService) :
             password = password,
             onBehalf = onBehalf,
             file = input,
-            attached = attached.orEmpty().split(FILES_SEPARATOR).flatMap { getFiles(File(it)) },
-            fileMode = valueOf(fileMode)
+            attached = attached?.split(FILES_SEPARATOR)?.flatMap { getFiles(File(it)) }.orEmpty(),
+            fileMode = FileMode.valueOf(fileMode)
         )
 
         val response = submissionService.submit(request)

--- a/client/bio-commandline/src/test/kotlin/uk/ac/ebi/biostd/client/cli/commands/SubmitAsyncCommandTest.kt
+++ b/client/bio-commandline/src/test/kotlin/uk/ac/ebi/biostd/client/cli/commands/SubmitAsyncCommandTest.kt
@@ -88,7 +88,34 @@ internal class SubmitAsyncCommandTest(
                 "-p", "password",
                 "-i", "$rootFolder/Submission.tsv",
                 "-a", "$rootFolder/attachedFile1.tsv,$rootFolder/attachedFile2.tsv",
-                "--moveFiles"
+                "-fm", "MOVE"
+            )
+        )
+
+        verify(exactly = 1) { submissionService.submitAsync(request) }
+    }
+
+    @Test
+    fun `no attached files`() {
+        val submission = temporaryFolder.createFile("Submission.tsv")
+
+        val request = SubmissionRequest(
+            server = "server",
+            user = "user",
+            password = "password",
+            onBehalf = null,
+            file = submission,
+            attached = emptyList(),
+            fileMode = COPY
+        )
+        every { submissionService.submitAsync(request) } answers { nothing }
+
+        testInstance.parse(
+            listOf(
+                "-s", "server",
+                "-u", "user",
+                "-p", "password",
+                "-i", "$rootFolder/Submission.tsv"
             )
         )
 

--- a/client/bio-commandline/src/test/kotlin/uk/ac/ebi/biostd/client/cli/commands/SubmitCommandTest.kt
+++ b/client/bio-commandline/src/test/kotlin/uk/ac/ebi/biostd/client/cli/commands/SubmitCommandTest.kt
@@ -102,6 +102,36 @@ internal class SubmitCommandTest(
     }
 
     @Test
+    fun `no attached files`() {
+        val mockResponse = Submission("S-TEST123")
+
+        val submission = temporaryFolder.createFile("Submission.tsv")
+
+        val request = SubmissionRequest(
+            server = "server",
+            user = "user",
+            password = "password",
+            onBehalf = null,
+            file = submission,
+            attached = emptyList(),
+            fileMode = MOVE
+        )
+        every { submissionService.submit(request) } returns mockResponse
+
+        testInstance.parse(
+            listOf(
+                "-s", "server",
+                "-u", "user",
+                "-p", "password",
+                "-i", "$rootFolder/Submission.tsv",
+                "-fm", "MOVE"
+            )
+        )
+
+        verify(exactly = 1) { submissionService.submit(request) }
+    }
+
+    @Test
     fun `invalid file mode`() {
         temporaryFolder.createFile("Submission.tsv")
         temporaryFolder.createFile("attachedFile1.tsv")


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181330026

- Fix failure when attached files option is not provided
- Normalise the code for the submit and submit async operations