### PR TITLE
Pivotal ID # 182221666: FIRE Single File Persistence

### DIFF
--- a/commons/commons-test/src/main/kotlin/ebi/ac/uk/test/TemporaryFolderExt.kt
+++ b/commons/commons-test/src/main/kotlin/ebi/ac/uk/test/TemporaryFolderExt.kt
@@ -29,15 +29,6 @@ fun TemporaryFolder.createFile(fileName: String, content: String, charset: Chars
 }
 
 /**
- * Creates a file with the given name or replaces it if already exist.
- */
-fun TemporaryFolder.createOrReplaceFile(fileName: String): File {
-    val file = root.resolve(fileName)
-    if (file.exists()) file.delete()
-    return createFile(fileName)
-}
-
-/**
  * Creates a file with the given name and content or replaces it if already exist.
  */
 fun TemporaryFolder.deleteFile(fileName: String) {

--- a/commons/commons-util/src/main/kotlin/ebi/ac/uk/io/ext/FileExtensions.kt
+++ b/commons/commons-util/src/main/kotlin/ebi/ac/uk/io/ext/FileExtensions.kt
@@ -8,6 +8,7 @@ import java.io.FileOutputStream
 import java.nio.charset.Charset
 import java.nio.file.Files
 import java.util.zip.GZIPOutputStream
+import kotlin.text.Charsets.UTF_8
 
 fun File.notExist() = Files.exists(toPath()).not()
 
@@ -46,7 +47,7 @@ fun File.gZipTo(target: File) {
 /**
  * Creates a file with the given content in the temporary folder.
  */
-fun File.createFile(fileName: String, content: String, charset: Charset = Charsets.UTF_8): File {
+fun File.createFile(fileName: String, content: String, charset: Charset = UTF_8): File {
     val file = newFile(fileName)
     file.writeText(content, charset)
     return file
@@ -60,10 +61,19 @@ fun File.createFile(fileName: String): File {
 }
 
 /**
- * Creates a file with the given name or replaces it if already exist.
+ * Creates a file with the given name or replaces it if already exists.
  */
 fun File.createOrReplaceFile(fileName: String): File {
     val file = resolve(fileName)
     if (file.exists()) file.delete()
     return newFile(fileName)
+}
+
+/**
+ * Creates a file with the given name and content or replaces it if it already exists.
+ */
+fun File.createOrReplaceFile(fileName: String, content: String, charset: Charset = UTF_8): File {
+    val file = createFile(fileName)
+    file.writeText(content, charset)
+    return file
 }

--- a/submission/persistence-filesystem/src/main/kotlin/ac/uk/ebi/biostd/persistence/filesystem/fire/FireService.kt
+++ b/submission/persistence-filesystem/src/main/kotlin/ac/uk/ebi/biostd/persistence/filesystem/fire/FireService.kt
@@ -19,7 +19,6 @@ class FireService(
     private val fireClient: FireClient,
     private val fireTempDirPath: File,
 ) {
-
     fun getOrPersist(sub: ExtSubmission, file: ExtFile): FireFile {
         return when (file) {
             is FireFile -> reuseFireFile(sub, file)
@@ -47,7 +46,7 @@ class FireService(
 
     private fun saveFile(sub: ExtSubmission, nfsFile: NfsFile): FireFile {
         logger.info { "${sub.accNo} ${sub.owner} Persisting file ${nfsFile.fileName} on FIRE" }
-        val fireFile = fireClient.save(nfsFile.file, nfsFile.md5)
+        val fireFile = fireClient.save(nfsFile.file, nfsFile.file.md5())
         fireClient.setBioMetadata(fireFile.fireOid, sub.accNo, nfsFile.type.value, published = false)
         fireClient.setPath(fireFile.fireOid, "${sub.relPath}/${nfsFile.relPath}")
         return asFireFile(nfsFile, fireFile, ExtFileType.FILE)

--- a/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/integration/MongoDbServicesConfig.kt
+++ b/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/integration/MongoDbServicesConfig.kt
@@ -39,15 +39,13 @@ class MongoDbServicesConfig {
         submissionRequestDocDataRepository: SubmissionRequestDocDataRepository,
         fileListDocFileRepository: FileListDocFileRepository,
         serializationService: ExtSerializationService,
-        toExtSubmissionMapper: ToExtSubmissionMapper,
-        resolver: FilesResolver,
+        toExtSubmissionMapper: ToExtSubmissionMapper
     ): SubmissionQueryService = SubmissionMongoQueryService(
         submissionDocDataRepository,
         submissionRequestDocDataRepository,
         fileListDocFileRepository,
         serializationService,
-        toExtSubmissionMapper,
-        resolver
+        toExtSubmissionMapper
     )
 
     @Bean

--- a/submission/persistence-mongo/src/test/kotlin/ac/uk/ebi/biostd/persistence/doc/service/SubmissionMongoQueryServiceTest.kt
+++ b/submission/persistence-mongo/src/test/kotlin/ac/uk/ebi/biostd/persistence/doc/service/SubmissionMongoQueryServiceTest.kt
@@ -54,7 +54,6 @@ import org.testcontainers.junit.jupiter.Testcontainers
 import org.testcontainers.utility.DockerImageName
 import uk.ac.ebi.extended.serialization.integration.ExtSerializationConfig.extSerializationService
 import uk.ac.ebi.extended.serialization.service.ExtSerializationService
-import uk.ac.ebi.serialization.common.FilesResolver
 import java.time.Duration.ofSeconds
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
@@ -76,15 +75,13 @@ internal class SubmissionMongoQueryServiceTest(
     @Autowired private val requestRepository: SubmissionRequestDocDataRepository
 ) {
     private val serializationService: ExtSerializationService = extSerializationService()
-    private val fileResolver = FilesResolver(tempFolder.createDirectory("ext-files"))
     private val testInstance =
         SubmissionMongoQueryService(
             submissionRepo,
             requestRepository,
             fileListDocFileRepository,
             serializationService,
-            toExtSubmissionMapper,
-            fileResolver,
+            toExtSubmissionMapper
         )
 
     @AfterEach

--- a/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/factory/AllInOne.kt
+++ b/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/factory/AllInOne.kt
@@ -14,12 +14,12 @@ data class SubmissionSpec(
 data class SubmissionFile(val file: File, val folder: String = EMPTY)
 
 fun submissionsFiles(tempFolder: File): List<SubmissionFile> = listOf(
-    SubmissionFile(tempFolder.createOrReplaceFile("DataFile1.txt")),
-    SubmissionFile(tempFolder.createOrReplaceFile("DataFile2.txt")),
-    SubmissionFile(tempFolder.createOrReplaceFile("DataFile3.txt"), "Folder1"),
-    SubmissionFile(tempFolder.createOrReplaceFile("DataFile4.txt"), "Folder1/Folder2"),
-    SubmissionFile(tempFolder.createOrReplaceFile("DataFile5.txt")),
-    SubmissionFile(tempFolder.createOrReplaceFile("DataFile6.txt"), "Folder1"),
-    SubmissionFile(tempFolder.createOrReplaceFile("DataFile7.txt")),
-    SubmissionFile(tempFolder.createOrReplaceFile("DataFile8.txt"), "Folder1"),
+    SubmissionFile(tempFolder.createOrReplaceFile("DataFile1.txt", "content 1")),
+    SubmissionFile(tempFolder.createOrReplaceFile("DataFile2.txt", "content 2")),
+    SubmissionFile(tempFolder.createOrReplaceFile("DataFile3.txt", "content 3"), "Folder1"),
+    SubmissionFile(tempFolder.createOrReplaceFile("DataFile4.txt", "content 4"), "Folder1/Folder2"),
+    SubmissionFile(tempFolder.createOrReplaceFile("DataFile5.txt", "content 5")),
+    SubmissionFile(tempFolder.createOrReplaceFile("DataFile6.txt", "content 6"), "Folder1"),
+    SubmissionFile(tempFolder.createOrReplaceFile("DataFile7.txt", "content 7")),
+    SubmissionFile(tempFolder.createOrReplaceFile("DataFile8.txt", "content 8"), "Folder1"),
 )

--- a/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/factory/AllInOneSubmissionFactory.kt
+++ b/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/factory/AllInOneSubmissionFactory.kt
@@ -33,23 +33,23 @@ fun allInOneSubmission(accNo: String) = submission(accNo) {
         }
 
         file("DataFile1.txt") {
-            size = 0
+            size = 9
             attribute("Description", "Data File 1")
         }
 
         filesTable {
             file("DataFile2.txt") {
-                size = 0
+                size = 9
                 attribute("Description", "Data File 2")
                 attribute("Type", "Data")
             }
             file("Folder1/DataFile3.txt") {
-                size = 0
+                size = 9
                 attribute("Description", "Data File 3")
                 attribute("Type", "Data")
             }
             file("Folder1/Folder2/DataFile4.txt") {
-                size = 0
+                size = 9
                 attribute("Description", "Data File 4")
                 attribute("Type", "Data")
             }
@@ -95,23 +95,23 @@ fun allInOneRootSectionLink() = link("AF069309") {
 }
 
 fun allInOneRootSectionFile() = file("DataFile1.txt") {
-    size = 0
+    size = 9
     attribute("Description", "Data File 1")
 }
 
 fun allInOneRootSectionFilesTable() = filesTable {
     file("DataFile2.txt") {
-        size = 0
+        size = 9
         attribute("Description", "Data File 2")
         attribute("Type", "Data")
     }
     file("Folder1/DataFile3.txt") {
-        size = 0
+        size = 9
         attribute("Description", "Data File 3")
         attribute("Type", "Data")
     }
     file("Folder1/Folder2/DataFile4.txt") {
-        size = 0
+        size = 9
         attribute("Description", "Data File 4")
         attribute("Type", "Data")
     }

--- a/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/factory/AllInOneSubmissionTsv.kt
+++ b/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/factory/AllInOneSubmissionTsv.kt
@@ -34,7 +34,7 @@ fun allInOneSubmissionTsv(accNo: String) = tsv {
 
     line("File", "DataFile1.txt")
     line("Description", "Data File 1")
-    line("md5", "D41D8CD98F00B204E9800998ECF8427E")
+    line("md5", "9297AB3FBD56B42F6566284119238125")
     line()
 
     line("Files", "Description", "Type")

--- a/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/factory/TsvSubmissionFactory.kt
+++ b/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/factory/TsvSubmissionFactory.kt
@@ -54,16 +54,16 @@ fun assertAllInOneSubmissionTsv(tsv: String, accNo: String) {
     val expectedRootSectionFile = tsv {
         line("File", "DataFile1.txt")
         line("Description", "Data File 1")
-        line("md5", "D41D8CD98F00B204E9800998ECF8427E")
+        line("md5", "9297AB3FBD56B42F6566284119238125")
         line()
     }
     assertTsvBlock(lines, 16, 19, expectedRootSectionFile)
 
     val expectedRootSectionFilesTable = tsv {
         line("Files", "Description", "Type", "md5")
-        line("DataFile2.txt", "Data File 2", "Data", "D41D8CD98F00B204E9800998ECF8427E")
-        line("Folder1/DataFile3.txt", "Data File 3", "Data", "D41D8CD98F00B204E9800998ECF8427E")
-        line("Folder1/Folder2/DataFile4.txt", "Data File 4", "Data", "D41D8CD98F00B204E9800998ECF8427E")
+        line("DataFile2.txt", "Data File 2", "Data", "6685CD62B95F2C58818CB20E7292168B")
+        line("Folder1/DataFile3.txt", "Data File 3", "Data", "BFFD51760CD2C6B531756EFAC72110C3")
+        line("Folder1/Folder2/DataFile4.txt", "Data File 4", "Data", "D5F2C23B4E2DDD8FA4D6A5AD72265330")
         line()
     }
     assertTsvBlock(lines, 20, 24, expectedRootSectionFilesTable)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/182221666

- Calculate the MD5 at persistence time rather than when loading the request
- Simplify the submission request loading
- Add content to the integration tests files to cover the scenario with multiple MD5
- Remove unused code