### PR TITLE
Pivotal ID # 184014407: Multiple Reference Files In Resubmission

### DIFF
--- a/commons/commons-model-extended/src/main/kotlin/ebi/ac/uk/extended/model/ExtFileExtensions.kt
+++ b/commons/commons-model-extended/src/main/kotlin/ebi/ac/uk/extended/model/ExtFileExtensions.kt
@@ -1,0 +1,8 @@
+package ebi.ac.uk.extended.model
+
+fun ExtFile.copyWithAttributes(attributes: List<ExtAttribute>): ExtFile {
+    return when (this) {
+        is FireFile -> this.copy(attributes = attributes)
+        is NfsFile -> this.copy(attributes = attributes)
+    }
+}

--- a/commons/commons-model-extended/src/test/kotlin/ebi/ac/uk/extended/model/ExtFileExtensionsTest.kt
+++ b/commons/commons-model-extended/src/test/kotlin/ebi/ac/uk/extended/model/ExtFileExtensionsTest.kt
@@ -1,0 +1,53 @@
+package ebi.ac.uk.extended.model
+
+import ebi.ac.uk.extended.model.ExtFileType.FILE
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.io.File
+
+@ExtendWith(MockKExtension::class)
+class ExtFileExtensionsTest {
+    @Test
+    fun `copy fire file`() {
+        val fireFile = FireFile(
+            "fire-id",
+            "fire-path",
+            true,
+            "file-path",
+            "rel-path",
+            "md5",
+            1L,
+            FILE,
+            listOf(ExtAttribute("Attribute", "Old"))
+        )
+        val newAttributes = listOf(ExtAttribute("Override", "New"))
+        val copied = fireFile.copyWithAttributes(newAttributes)
+
+        assertThat(copied).isEqualToIgnoringGivenFields(fireFile, "attributes")
+        assertThat(copied.attributes).isEqualTo(newAttributes)
+    }
+
+    @Test
+    fun `copy nfs file`(
+        @MockK file: File
+    ) {
+        val nfsFile = NfsFile(
+            "file-path",
+            "rel-path",
+            file,
+            "full-path",
+            "md5",
+            1L,
+            listOf(ExtAttribute("Attribute", "Old")),
+            FILE
+        )
+        val newAttributes = listOf(ExtAttribute("Override", "New"))
+        val copied = nfsFile.copyWithAttributes(newAttributes)
+
+        assertThat(copied).isEqualToIgnoringGivenFields(nfsFile, "attributes")
+        assertThat(copied.attributes).isEqualTo(newAttributes)
+    }
+}

--- a/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/db/repositories/Repositories.kt
+++ b/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/db/repositories/Repositories.kt
@@ -94,7 +94,7 @@ interface FileListDocFileRepository : MongoRepository<FileListDocFile, ObjectId>
         accNo: String,
         version: Int,
         filePath: String,
-    ): FileListDocFile?
+    ): List<FileListDocFile>
 }
 
 interface SubmissionStatsRepository : MongoRepository<DocSubmissionStats, ObjectId> {

--- a/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/service/SubmissionMongoPersistenceQueryService.kt
+++ b/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/service/SubmissionMongoPersistenceQueryService.kt
@@ -83,6 +83,7 @@ internal class SubmissionMongoPersistenceQueryService(
         val subData = submissionRepo.getSubData(accNo)
         return fileListDocFileRepository
             .findBySubmissionAccNoAndSubmissionVersionAndFilePath(accNo, version, path)
+            .firstOrNull()
             ?.file
             ?.toExtFile(subData.released, submissionRepo.getSubData(accNo).relPath)
     }

--- a/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/helpers/SubmissionFilesSource.kt
+++ b/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/helpers/SubmissionFilesSource.kt
@@ -1,9 +1,11 @@
 package ac.uk.ebi.biostd.submission.helpers
 
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionPersistenceQueryService
+import ebi.ac.uk.extended.mapping.from.toExtAttribute
 import ebi.ac.uk.extended.model.ExtFile
 import ebi.ac.uk.extended.model.FireFile
 import ebi.ac.uk.extended.model.NfsFile
+import ebi.ac.uk.extended.model.copyWithAttributes
 import ebi.ac.uk.io.sources.DbFile
 import ebi.ac.uk.io.sources.FilesSource
 import ebi.ac.uk.io.sources.PathSource
@@ -23,7 +25,7 @@ class SubmissionFilesSource(
         get() = "Previous version files"
 
     override fun getExtFile(path: String, dbFile: DbFile?, attributes: List<Attribute>): ExtFile? {
-        return findSubmissionFile(path)
+        return findSubmissionFile(path)?.copyWithAttributes(attributes.map { it.toExtAttribute() })
     }
 
     override fun getFile(path: String): File? {

--- a/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/submitter/request/SubmissionRequestSaver.kt
+++ b/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/submitter/request/SubmissionRequestSaver.kt
@@ -5,6 +5,7 @@ import ac.uk.ebi.biostd.persistence.common.service.SubmissionPersistenceService
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionRequestFilesPersistenceService
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionRequestPersistenceService
 import ebi.ac.uk.extended.model.ExtSubmission
+import ebi.ac.uk.extended.model.copyWithAttributes
 import mu.KotlinLogging
 import uk.ac.ebi.events.service.EventsPublisherService
 import uk.ac.ebi.extended.serialization.service.FileProcessingService
@@ -36,7 +37,7 @@ class SubmissionRequestSaver(
     private fun assembleSubmission(sub: ExtSubmission): ExtSubmission {
         return fileProcessingService.processFiles(sub) { file ->
             val requestFile = filesRequestService.getSubmissionRequestFile(sub.accNo, sub.version, file.filePath)
-            return@processFiles requestFile.file
+            return@processFiles requestFile.file.copyWithAttributes(file.attributes)
         }
     }
 }

--- a/submission/submitter/src/test/kotlin/ac/uk/ebi/biostd/submission/submitter/request/SubmissionRequestSaverTest.kt
+++ b/submission/submitter/src/test/kotlin/ac/uk/ebi/biostd/submission/submitter/request/SubmissionRequestSaverTest.kt
@@ -7,7 +7,9 @@ import ac.uk.ebi.biostd.persistence.common.service.SubmissionPersistenceService
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionRequestFilesPersistenceService
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionRequestPersistenceService
 import ebi.ac.uk.extended.model.ExtFile
+import ebi.ac.uk.extended.model.ExtFileType.FILE
 import ebi.ac.uk.extended.model.ExtSubmission
+import ebi.ac.uk.extended.model.NfsFile
 import ebi.ac.uk.model.constants.ACC_NO
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -18,6 +20,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import uk.ac.ebi.events.service.EventsPublisherService
 import uk.ac.ebi.extended.serialization.service.FileProcessingService
+import java.io.File
 
 @ExtendWith(MockKExtension::class)
 internal class SubmissionRequestSaverTest(
@@ -41,13 +44,15 @@ internal class SubmissionRequestSaverTest(
         @MockK submission: ExtSubmission,
         @MockK subFile: ExtFile,
         @MockK requestFile: SubmissionRequestFile,
-        @MockK updatedSubFile: ExtFile,
+        @MockK updatedFile: File,
     ) {
         val accNo = "ABC-123"
         val version = 1
         val filePath = "the-file-path"
         val notifyTo = "user@ebi.ac.uk"
+        val updatedSubFile = NfsFile("file.txt", "Files/file.txt", updatedFile, "file", "md5", 1, type = FILE)
 
+        every { subFile.attributes } returns emptyList()
         every { eventsPublisherService.submissionSubmitted(accNo, notifyTo) } answers { nothing }
         every { persistenceService.expirePreviousVersions(accNo) } answers { nothing }
         every { persistenceService.saveSubmission(submission) } answers { submission }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/184014407

- Set the proper attributes to a file that's referenced multiple times
- Change the referenced files method in order to support multiple file references