### PR TITLE
Pivotal ID # 183230982: Avoid Dots In File Paths

### DIFF
--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/json/deserialization/FileJsonDeserializer.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/json/deserialization/FileJsonDeserializer.kt
@@ -1,7 +1,6 @@
 package ac.uk.ebi.biostd.json.deserialization
 
-import ac.uk.ebi.biostd.validation.InvalidElementException
-import ac.uk.ebi.biostd.validation.REQUIRED_FILE_PATH
+import ac.uk.ebi.biostd.validation.validateFilePath
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.JsonNode
@@ -19,8 +18,7 @@ internal class FileJsonDeserializer : StdDeserializer<BioFile>(BioFile::class.ja
         val mapper = jp.codec as ObjectMapper
         val node: JsonNode = mapper.readTree(jp)
         val path = node.getNode<TextNode>(PATH.value).textValue()
-
-        require(path.isNotBlank()) { throw InvalidElementException(REQUIRED_FILE_PATH) }
+        validateFilePath(path)
 
         return BioFile(
             path = path,

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/model/TsvChunk.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/model/TsvChunk.kt
@@ -6,9 +6,8 @@ import ac.uk.ebi.biostd.tsv.deserialization.common.getIdOrElse
 import ac.uk.ebi.biostd.tsv.deserialization.common.getType
 import ac.uk.ebi.biostd.tsv.deserialization.common.toAttributes
 import ac.uk.ebi.biostd.validation.InvalidElementException
-import ac.uk.ebi.biostd.validation.REQUIRED_FILE_PATH
 import ac.uk.ebi.biostd.validation.REQUIRED_LINK_URL
-import ebi.ac.uk.base.isNotBlank
+import ac.uk.ebi.biostd.validation.validateFilePath
 import ebi.ac.uk.model.BioFile
 import ebi.ac.uk.model.FilesTable
 import ebi.ac.uk.model.Link
@@ -43,7 +42,7 @@ internal class LinkChunk(body: List<TsvChunkLine>) : TsvChunk(body) {
 class FileChunk(body: List<TsvChunkLine>) : TsvChunk(body) {
     fun asFile(): BioFile {
         val fileName = header.findSecond()
-        require(fileName.isNotBlank()) { throw InvalidElementException(REQUIRED_FILE_PATH) }
+        validateFilePath(fileName)
 
         val attributes = toAttributes(lines)
         return BioFile(fileName!!, attributes = attributes)

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/stream/FileListTsvStreamDeserializer.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/deserialization/stream/FileListTsvStreamDeserializer.kt
@@ -3,7 +3,7 @@ package ac.uk.ebi.biostd.tsv.deserialization.stream
 import ac.uk.ebi.biostd.tsv.TAB
 import ac.uk.ebi.biostd.validation.INVALID_TABLE_ROW
 import ac.uk.ebi.biostd.validation.InvalidElementException
-import ac.uk.ebi.biostd.validation.REQUIRED_FILE_PATH
+import ac.uk.ebi.biostd.validation.validateFilePath
 import ebi.ac.uk.model.Attribute
 import ebi.ac.uk.model.BioFile
 import ebi.ac.uk.model.constants.TableFields.FILES_TABLE
@@ -43,8 +43,10 @@ internal class FileListTsvStreamDeserializer {
 
     private fun deserializeRow(index: Int, row: List<String>, headers: List<String>): BioFile {
         val (fileName, attributes) = row.destructure()
-        require(fileName.isNotBlank()) {
-            throw InvalidElementException("Error at row ${index + 1}: $REQUIRED_FILE_PATH")
+        runCatching {
+            validateFilePath(fileName)
+        }.onFailure {
+            throw InvalidElementException("Error at row ${index + 1}: ${it.message}")
         }
 
         return BioFile(fileName, attributes = buildAttributes(attributes, headers, index))

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/validation/Errors.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/validation/Errors.kt
@@ -6,7 +6,7 @@ import ebi.ac.uk.model.Submission
 
 const val CHUNK_SIZE_ERROR_MSG = "Several page tab elements detected. Exactly one element must be provided"
 
-class InvalidElementException(message: String) : RuntimeException("$message. Element was not created.")
+class InvalidElementException(message: String) : RuntimeException(message)
 
 class SerializationError(val chunk: TsvChunk, val cause: Exception)
 

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/validation/FilePathValidator.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/validation/FilePathValidator.kt
@@ -1,0 +1,10 @@
+package ac.uk.ebi.biostd.validation
+
+import ebi.ac.uk.base.isNotBlank
+
+private val pathRestrictions = "[\\.*][\\/]".toRegex()
+
+fun validateFilePath(path: String?) {
+    require(path.isNotBlank()) { throw InvalidElementException(REQUIRED_FILE_PATH) }
+    require(pathRestrictions.containsMatchIn(path!!).not()) { throw InvalidElementException(INVALID_FILE_PATH) }
+}

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/validation/Messages.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/validation/Messages.kt
@@ -2,6 +2,7 @@ package ac.uk.ebi.biostd.validation
 
 internal const val REQUIRED_LINK_URL = "Link Url is required"
 internal const val REQUIRED_FILE_PATH = "File Path is required"
+internal const val INVALID_FILE_PATH = "Relative file paths are not allowed"
 internal const val REQUIRED_ROOT_SECTION = "Root Section type is required"
 internal const val MISPLACED_ATTR_NAME = "Attribute name qualifier must be after a valid attribute"
 internal const val MISPLACED_ATTR_VAL = "Attribute value qualifier must be after a valid attribute"

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/xml/XmlSerializer.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/xml/XmlSerializer.kt
@@ -1,7 +1,6 @@
 package ac.uk.ebi.biostd.xml
 
-import ac.uk.ebi.biostd.validation.InvalidElementException
-import ac.uk.ebi.biostd.validation.REQUIRED_FILE_PATH
+import ac.uk.ebi.biostd.validation.validateFilePath
 import ac.uk.ebi.biostd.xml.deserializer.AttributeXmlDeserializer
 import ac.uk.ebi.biostd.xml.deserializer.DetailsXmlDeserializer
 import ac.uk.ebi.biostd.xml.deserializer.FileStandaloneXmlDeserializer
@@ -120,7 +119,7 @@ class FileXmlStreamDeserializer : StdDeserializer<BioFile>(BioFile::class.java) 
         val mapper = p.codec as XmlMapper
         val node = p.readValueAsTree<TreeNode>()
         val path = (node.get(FileFields.PATH.value) as TextNode).textValue().trim()
-        require(path.isNotBlank()) { throw InvalidElementException(REQUIRED_FILE_PATH) }
+        validateFilePath(path)
 
         return BioFile(
             path = path,

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/xml/deserializer/FileStandaloneXmlDeserializer.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/xml/deserializer/FileStandaloneXmlDeserializer.kt
@@ -1,7 +1,6 @@
 package ac.uk.ebi.biostd.xml.deserializer
 
-import ac.uk.ebi.biostd.validation.InvalidElementException
-import ac.uk.ebi.biostd.validation.REQUIRED_FILE_PATH
+import ac.uk.ebi.biostd.validation.validateFilePath
 import ac.uk.ebi.biostd.xml.deserializer.common.BaseXmlDeserializer
 import ebi.ac.uk.model.BioFile
 import ebi.ac.uk.model.FilesTable
@@ -13,7 +12,7 @@ class FileStandaloneXmlDeserializer(
 ) : BaseXmlDeserializer<BioFile>() {
     override fun deserialize(node: Node): BioFile {
         val path = node.getNodeAttribute(FileFields.PATH)
-        require(path.isNotBlank()) { throw InvalidElementException(REQUIRED_FILE_PATH) }
+        validateFilePath(path)
 
         return BioFile(
             path = path,

--- a/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/json/deserialization/FileDeserializerTest.kt
+++ b/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/json/deserialization/FileDeserializerTest.kt
@@ -1,6 +1,7 @@
 package ac.uk.ebi.biostd.json.deserialization
 
 import ac.uk.ebi.biostd.json.JsonSerializer
+import ac.uk.ebi.biostd.validation.INVALID_FILE_PATH
 import ac.uk.ebi.biostd.validation.InvalidElementException
 import ac.uk.ebi.biostd.validation.REQUIRED_FILE_PATH
 import com.fasterxml.jackson.module.kotlin.readValue
@@ -42,7 +43,17 @@ class FileDeserializerTest {
         }.toString()
 
         val exception = assertThrows<InvalidElementException> { testInstance.readValue<BioFile>(invalidJson) }
-        assertThat(exception.message).isEqualTo("$REQUIRED_FILE_PATH. Element was not created.")
+        assertThat(exception.message).isEqualTo(REQUIRED_FILE_PATH)
+    }
+
+    @Test
+    fun `deserialize invalid path`() {
+        val invalidJson = jsonObj {
+            "path" to "./file/../with/../../relative/path.txt"
+        }.toString()
+
+        val exception = assertThrows<InvalidElementException> { testInstance.readValue<BioFile>(invalidJson) }
+        assertThat(exception.message).isEqualTo(INVALID_FILE_PATH)
     }
 
     @Test

--- a/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/tsv/FileListTsvStreamDeserializerTest.kt
+++ b/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/tsv/FileListTsvStreamDeserializerTest.kt
@@ -1,6 +1,7 @@
 package ac.uk.ebi.biostd.tsv
 
 import ac.uk.ebi.biostd.tsv.deserialization.stream.FileListTsvStreamDeserializer
+import ac.uk.ebi.biostd.validation.INVALID_FILE_PATH
 import ac.uk.ebi.biostd.validation.InvalidElementException
 import ac.uk.ebi.biostd.validation.REQUIRED_FILE_PATH
 import ebi.ac.uk.dsl.tsv.line
@@ -79,10 +80,26 @@ class FileListTsvStreamDeserializerTest(
             line()
         }
 
-        val testFile = tempFolder.createFile("invalid.tsv", tsv.toString())
+        val testFile = tempFolder.createFile("EmptyPath.tsv", tsv.toString())
         testFile.inputStream().use {
             val exception = assertThrows<InvalidElementException> { testInstance.deserializeFileList(it).toList() }
-            assertThat(exception.message).isEqualTo("Error at row 3: $REQUIRED_FILE_PATH. Element was not created.")
+            assertThat(exception.message).isEqualTo("Error at row 3: $REQUIRED_FILE_PATH")
+        }
+    }
+
+    @Test
+    fun `file list with invalid path`() {
+        val tsv = tsv {
+            line("Files", "Attr1", "Attr2")
+            line("test.txt", "a", "b")
+            line("./file/../with/../../relative/path.txt", "c", "d")
+            line()
+        }
+
+        val testFile = tempFolder.createFile("InvalidPath.tsv", tsv.toString())
+        testFile.inputStream().use {
+            val exception = assertThrows<InvalidElementException> { testInstance.deserializeFileList(it).toList() }
+            assertThat(exception.message).isEqualTo("Error at row 3: $INVALID_FILE_PATH")
         }
     }
 }

--- a/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/tsv/TsvDeserializationErrorsTest.kt
+++ b/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/tsv/TsvDeserializationErrorsTest.kt
@@ -6,6 +6,7 @@ import ac.uk.ebi.biostd.test.submissionWithInvalidValueAttributeDetail
 import ac.uk.ebi.biostd.test.submissionWithTableWithMoreAttributes
 import ac.uk.ebi.biostd.test.submissionWithTableWithNoRows
 import ac.uk.ebi.biostd.tsv.deserialization.TsvDeserializer
+import ac.uk.ebi.biostd.validation.INVALID_FILE_PATH
 import ac.uk.ebi.biostd.validation.InvalidChunkSizeException
 import ac.uk.ebi.biostd.validation.InvalidElementException
 import ac.uk.ebi.biostd.validation.MISPLACED_ATTR_NAME
@@ -84,7 +85,19 @@ class TsvDeserializationErrorsTest {
         }.toString()
 
         val exception = assertThrows<InvalidElementException> { deserializer.deserializeElement<BioFile>(tsv) }
-        assertThat(exception.message).isEqualTo("$REQUIRED_FILE_PATH. Element was not created.")
+        assertThat(exception.message).isEqualTo(REQUIRED_FILE_PATH)
+    }
+
+    @Test
+    fun `invalid file path`() {
+        val tsv = tsv {
+            line("File", "./file/../with/../../relative/path.txt")
+            line("Type", "Empty Path")
+            line()
+        }.toString()
+
+        val exception = assertThrows<InvalidElementException> { deserializer.deserializeElement<BioFile>(tsv) }
+        assertThat(exception.message).isEqualTo(INVALID_FILE_PATH)
     }
 
     @Test
@@ -110,6 +123,6 @@ class TsvDeserializationErrorsTest {
 
         val cause = exception.errors.values().first().cause
         assertThat(cause).isInstanceOf(InvalidElementException::class.java)
-        assertThat(cause).hasMessage("$expectedMessage. Element was not created.")
+        assertThat(cause).hasMessage(expectedMessage)
     }
 }

--- a/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/xml/deserializer/FileStandaloneXmlDeserializerTest.kt
+++ b/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/xml/deserializer/FileStandaloneXmlDeserializerTest.kt
@@ -1,5 +1,6 @@
 package ac.uk.ebi.biostd.xml.deserializer
 
+import ac.uk.ebi.biostd.validation.INVALID_FILE_PATH
 import ac.uk.ebi.biostd.validation.InvalidElementException
 import ac.uk.ebi.biostd.validation.REQUIRED_FILE_PATH
 import ac.uk.ebi.biostd.xml.XmlSerializer
@@ -46,6 +47,16 @@ class FileStandaloneXmlDeserializerTest {
         }.toString()
 
         val exception = assertThrows<InvalidElementException> { testInstance.readValue(xmlFile, BioFile::class.java) }
-        assertThat(exception.message).isEqualTo("$REQUIRED_FILE_PATH. Element was not created.")
+        assertThat(exception.message).isEqualTo(REQUIRED_FILE_PATH)
+    }
+
+    @Test
+    fun `deserialize file with invalid path`() {
+        val xmlFile = xml("file") {
+            "path" { -"./file/../with/../../relative/path.txt" }
+        }.toString()
+
+        val exception = assertThrows<InvalidElementException> { testInstance.readValue(xmlFile, BioFile::class.java) }
+        assertThat(exception.message).isEqualTo(INVALID_FILE_PATH)
     }
 }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/183230982

- Move all the path related logic to a single place
- Include the logic to validate relative paths
- Use the single path validation method in all the deserializers
- Reduce error messages verbosity