### PR TITLE
Pivotal ID # 184822139: Delete Submission Folder After Resubmission

### DIFF
--- a/submission/persistence-filesystem/src/main/kotlin/ac/uk/ebi/biostd/persistence/filesystem/api/FileStorageService.kt
+++ b/submission/persistence-filesystem/src/main/kotlin/ac/uk/ebi/biostd/persistence/filesystem/api/FileStorageService.kt
@@ -9,7 +9,7 @@ interface FileStorageService {
 
     fun persistSubmissionFile(sub: ExtSubmission, file: ExtFile): ExtFile
 
-    fun deleteSubmissionFiles(sub: ExtSubmission)
+    fun deleteSubmissionFolder(sub: ExtSubmission)
 
     fun deleteSubmissionFile(sub: ExtSubmission, file: ExtFile)
 

--- a/submission/persistence-filesystem/src/main/kotlin/ac/uk/ebi/biostd/persistence/filesystem/service/StorageService.kt
+++ b/submission/persistence-filesystem/src/main/kotlin/ac/uk/ebi/biostd/persistence/filesystem/service/StorageService.kt
@@ -43,7 +43,7 @@ class StorageService(
             NFS -> nfsFilesService.deleteSubmissionFile(sub, file)
         }
 
-    override fun deleteSubmissionFiles(sub: ExtSubmission) =
+    override fun deleteSubmissionFolder(sub: ExtSubmission) =
         when (sub.storageMode) {
             FIRE -> fireFilesService.deleteSubmissionFiles(sub)
             NFS -> nfsFilesService.deleteSubmissionFiles(sub)

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/domain/service/SubmissionService.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/domain/service/SubmissionService.kt
@@ -40,7 +40,7 @@ class SubmissionService(
 
     fun deleteSubmission(accNo: String, user: SecurityUser) {
         require(userPrivilegesService.canDelete(user.email, accNo)) { throw UserCanNotDelete(accNo, user.email) }
-        fileStorageService.deleteSubmissionFiles(queryService.getExtByAccNo(accNo, true))
+        fileStorageService.deleteSubmissionFolder(queryService.getExtByAccNo(accNo, true))
         submissionPersistenceService.expireSubmission(accNo)
         eventsPublisherService.submissionsRefresh(accNo, user.email)
     }

--- a/submission/submitter/src/test/kotlin/ac/uk/ebi/biostd/submission/submitter/request/SubmissionRequestFinalizerTest.kt
+++ b/submission/submitter/src/test/kotlin/ac/uk/ebi/biostd/submission/submitter/request/SubmissionRequestFinalizerTest.kt
@@ -60,7 +60,10 @@ class SubmissionRequestFinalizerTest(
         testInstance.finalizeRequest("S-BSST1", 1)
 
         verify(exactly = 1) { requestService.saveSubmissionRequest(processedRequest) }
-        verify(exactly = 0) { storageService.deleteSubmissionFile(any(), any()) }
+        verify(exactly = 0) {
+            storageService.deleteSubmissionFolder(any())
+            storageService.deleteSubmissionFile(any(), any())
+        }
     }
 
     @Test
@@ -77,6 +80,7 @@ class SubmissionRequestFinalizerTest(
         every { queryService.getExtByAccNo("S-BSST1", true) } returns new
         every { serializationService.fileSequence(new) } returns emptySequence()
         every { persistedRequest.withNewStatus(PROCESSED) } returns processedRequest
+        every { storageService.deleteSubmissionFolder(previous) } answers { nothing }
         every { queryService.findLatestInactiveByAccNo("S-BSST1", true) } returns previous
         every { requestService.getPersistedRequest("S-BSST1", 2) } returns persistedRequest
         every { serializationService.fileSequence(previous) } returns sequenceOf(previousFile)
@@ -87,8 +91,9 @@ class SubmissionRequestFinalizerTest(
 
         verify(exactly = 1) {
             requestService.saveSubmissionRequest(processedRequest)
-            storageService.deleteSubmissionFile(previous, previousFile)
+            storageService.deleteSubmissionFolder(previous)
         }
+        verify(exactly = 0) { storageService.deleteSubmissionFile(any(), any()) }
     }
 
     @Test
@@ -119,5 +124,6 @@ class SubmissionRequestFinalizerTest(
             storageService.deleteSubmissionFile(previous, subFile)
             requestService.saveSubmissionRequest(processedRequest)
         }
+        verify(exactly = 0) { storageService.deleteSubmissionFolder(any()) }
     }
 }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/184822139

- Change the method name to make it closer to its functionality
- Delete the submission folder for previous submission

Delivers # 184822139