### PR TITLE
Pivotal ID # 185273996: Fire s3 path should be relative

### DIFF
--- a/client/fire-webclient/src/main/kotlin/uk/ac/ebi/fire/client/model/FireApiFile.kt
+++ b/client/fire-webclient/src/main/kotlin/uk/ac/ebi/fire/client/model/FireApiFile.kt
@@ -10,6 +10,7 @@ data class FireApiFile(
     val createTime: String,
     val filesystemEntry: FileSystemEntry? = null,
 ) {
+    // The path shouldn't contain an initial slash in order to avoid inconsistencies with S3
     val path: String? = filesystemEntry?.path?.removePrefix("/")
     val published: Boolean = filesystemEntry?.published.orFalse()
 }

--- a/client/fire-webclient/src/main/kotlin/uk/ac/ebi/fire/client/model/FireApiFile.kt
+++ b/client/fire-webclient/src/main/kotlin/uk/ac/ebi/fire/client/model/FireApiFile.kt
@@ -10,7 +10,7 @@ data class FireApiFile(
     val createTime: String,
     val filesystemEntry: FileSystemEntry? = null,
 ) {
-    val path: String? = filesystemEntry?.path
+    val path: String? = filesystemEntry?.path?.removePrefix("/")
     val published: Boolean = filesystemEntry?.published.orFalse()
 }
 

--- a/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/wiremock/FireMockDatabase.kt
+++ b/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/wiremock/FireMockDatabase.kt
@@ -75,5 +75,6 @@ data class DbRecord(
     val firePath: String?,
     val published: Boolean,
 ) {
+    // The path is normalized to ALWAYS include an initial slash in order to mimic how FIRE's HTTP endpoint
     fun toFile(): FireApiFile = file.copy(filesystemEntry = FileSystemEntry(firePath?.let { "/$it" }, published))
 }

--- a/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/wiremock/FireMockDatabase.kt
+++ b/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/wiremock/FireMockDatabase.kt
@@ -75,5 +75,5 @@ data class DbRecord(
     val firePath: String?,
     val published: Boolean,
 ) {
-    fun toFile(): FireApiFile = file.copy(filesystemEntry = FileSystemEntry(firePath, published))
+    fun toFile(): FireApiFile = file.copy(filesystemEntry = FileSystemEntry(firePath?.let { "/$it" }, published))
 }


### PR DESCRIPTION
- Remove the initial slash from FIRE responses
- Normalize FIRE mock output to mimic the original service response