### PR TITLE
Pivotal ID # 183230982: Avoid Special Characters In File Paths

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,12 +76,12 @@ nfs-itest:
   script: gradle clean :submission:submission-webapp:itest -PenableFire=false --rerun-tasks --stacktrace
 
 fire-itest:
-  needs: [ "build-test" ]
+  needs: [ "nfs-itest" ]
   stage: fire-itest
   script: gradle clean :submission:submission-webapp:itest -PenableFire=true --rerun-tasks --stacktrace
 
 fire-caos-itest:
-  needs: [ "build-test" ]
+  needs: [ "fire-itest" ]
   stage: fire-caos-itest
   script: gradle clean :submission:submission-webapp:itest -PenableFire=true --rerun-tasks --stacktrace
   variables:

--- a/submission/file-sources/src/main/kotlin/uk/ac/ebi/io/sources/SubmissionFilesSource.kt
+++ b/submission/file-sources/src/main/kotlin/uk/ac/ebi/io/sources/SubmissionFilesSource.kt
@@ -1,6 +1,6 @@
 package uk.ac.ebi.io.sources
 
-import ac.uk.ebi.biostd.persistence.common.service.SubmissionPersistenceQueryService
+import ac.uk.ebi.biostd.persistence.common.service.SubmissionFilesPersistenceService
 import ebi.ac.uk.extended.mapping.from.toExtAttribute
 import ebi.ac.uk.extended.model.ExtFile
 import ebi.ac.uk.extended.model.ExtSubmission
@@ -17,7 +17,7 @@ class SubmissionFilesSource(
     private val nfsFiles: PathSource,
     private val fireClient: FireClient,
     private val previousVersionFiles: Map<String, ExtFile>,
-    private val queryService: SubmissionPersistenceQueryService,
+    private val filesRepository: SubmissionFilesPersistenceService,
 ) : FilesSource {
     override val description: String
         get() = "Previous version files"
@@ -31,7 +31,7 @@ class SubmissionFilesSource(
     }
 
     private fun findSubmissionFile(path: String): ExtFile? {
-        return previousVersionFiles[path] ?: queryService.findReferencedFile(sub, path)
+        return previousVersionFiles[path] ?: filesRepository.findReferencedFile(sub, path)
     }
 
     private fun getFile(file: ExtFile): File? {

--- a/submission/persistence-common-api/src/main/kotlin/ac/uk/ebi/biostd/persistence/common/service/SubmissionOperations.kt
+++ b/submission/persistence-common-api/src/main/kotlin/ac/uk/ebi/biostd/persistence/common/service/SubmissionOperations.kt
@@ -48,7 +48,9 @@ interface SubmissionPersistenceQueryService {
      * @param filter the submission filter
      **/
     fun getSubmissionsByUser(owner: String, filter: SubmissionFilter): List<BasicSubmission>
+}
 
+interface SubmissionFilesPersistenceService {
     fun getReferencedFiles(sub: ExtSubmission, fileListName: String): Sequence<ExtFile>
 
     fun findReferencedFile(sub: ExtSubmission, path: String): ExtFile?

--- a/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/integration/MongoDbServicesConfig.kt
+++ b/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/integration/MongoDbServicesConfig.kt
@@ -3,6 +3,7 @@ package ac.uk.ebi.biostd.persistence.doc.integration
 import ac.uk.ebi.biostd.persistence.common.service.CollectionDataService
 import ac.uk.ebi.biostd.persistence.common.service.StatsDataService
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionDraftPersistenceService
+import ac.uk.ebi.biostd.persistence.common.service.SubmissionFilesPersistenceService
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionPersistenceQueryService
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionRequestFilesPersistenceService
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionRequestPersistenceService
@@ -11,14 +12,12 @@ import ac.uk.ebi.biostd.persistence.doc.db.data.SubmissionDocDataRepository
 import ac.uk.ebi.biostd.persistence.doc.db.data.SubmissionDraftDocDataRepository
 import ac.uk.ebi.biostd.persistence.doc.db.data.SubmissionRequestDocDataRepository
 import ac.uk.ebi.biostd.persistence.doc.db.data.SubmissionStatsDataRepository
-import ac.uk.ebi.biostd.persistence.doc.db.repositories.FileListDocFileRepository
 import ac.uk.ebi.biostd.persistence.doc.db.repositories.SubmissionRequestFilesRepository
-import ac.uk.ebi.biostd.persistence.doc.mapping.to.ToExtFileListMapper
-import ac.uk.ebi.biostd.persistence.doc.mapping.to.ToExtSectionMapper
 import ac.uk.ebi.biostd.persistence.doc.mapping.to.ToExtSubmissionMapper
 import ac.uk.ebi.biostd.persistence.doc.service.CollectionMongoDataService
 import ac.uk.ebi.biostd.persistence.doc.service.StatsMongoDataService
 import ac.uk.ebi.biostd.persistence.doc.service.SubmissionDraftMongoPersistenceService
+import ac.uk.ebi.biostd.persistence.doc.service.SubmissionMongoFilesPersistenceService
 import ac.uk.ebi.biostd.persistence.doc.service.SubmissionMongoPersistenceQueryService
 import ac.uk.ebi.biostd.persistence.doc.service.SubmissionRequestFilesMongoPersistenceService
 import ac.uk.ebi.biostd.persistence.doc.service.SubmissionRequestMongoPersistenceService
@@ -34,12 +33,11 @@ import uk.ac.ebi.serialization.common.FilesResolver
     MongoDbReposConfig::class,
     MongoDbQueryConfig::class,
     SerializationConfiguration::class,
-    ToSubmissionConfig::class
+    ToExtSubmissionConfig::class,
 )
 class MongoDbServicesConfig {
     @Bean
     internal fun submissionQueryService(
-        fileListDocFileRepository: FileListDocFileDocDataRepository,
         submissionDocDataRepository: SubmissionDocDataRepository,
         submissionRequestDocDataRepository: SubmissionRequestDocDataRepository,
         serializationService: ExtSerializationService,
@@ -48,9 +46,13 @@ class MongoDbServicesConfig {
         submissionDocDataRepository,
         toExtSubmissionMapper,
         serializationService,
-        fileListDocFileRepository,
         submissionRequestDocDataRepository,
     )
+
+    @Bean
+    internal fun submissionFilesPersistenceService(
+        fileListDocFileRepository: FileListDocFileDocDataRepository,
+    ): SubmissionFilesPersistenceService = SubmissionMongoFilesPersistenceService(fileListDocFileRepository)
 
     @Bean
     internal fun submissionRequestPersistenceService(
@@ -59,7 +61,7 @@ class MongoDbServicesConfig {
     ): SubmissionRequestPersistenceService = SubmissionRequestMongoPersistenceService(serializationService, requestRepo)
 
     @Bean
-    internal fun submissionFilesPersistenceService(
+    internal fun submissionRequestFilesPersistenceService(
         extSerializationService: ExtSerializationService,
         requestRepository: SubmissionRequestDocDataRepository,
         requestFilesRepository: SubmissionRequestFilesRepository,
@@ -73,23 +75,6 @@ class MongoDbServicesConfig {
     internal fun projectDataService(
         submissionDocDataRepository: SubmissionDocDataRepository,
     ): CollectionDataService = CollectionMongoDataService(submissionDocDataRepository)
-
-    @Bean
-    internal fun toExtFileListMapper(
-        fileListDocFileRepository: FileListDocFileRepository,
-        extSerializationService: ExtSerializationService,
-        extFilesResolver: FilesResolver,
-    ): ToExtFileListMapper = ToExtFileListMapper(fileListDocFileRepository, extSerializationService, extFilesResolver)
-
-    @Bean
-    internal fun toExtSectionMapper(
-        toExtFileListMapper: ToExtFileListMapper,
-    ): ToExtSectionMapper = ToExtSectionMapper(toExtFileListMapper)
-
-    @Bean
-    internal fun toExtSubmissionMapper(
-        toExtSectionMapper: ToExtSectionMapper,
-    ): ToExtSubmissionMapper = ToExtSubmissionMapper(toExtSectionMapper)
 
     @Bean
     internal fun submissionDraftMongoService(

--- a/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/integration/ToExtSubmissionConfig.kt
+++ b/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/integration/ToExtSubmissionConfig.kt
@@ -1,0 +1,30 @@
+package ac.uk.ebi.biostd.persistence.doc.integration
+
+import ac.uk.ebi.biostd.persistence.doc.db.repositories.FileListDocFileRepository
+import ac.uk.ebi.biostd.persistence.doc.mapping.to.ToExtFileListMapper
+import ac.uk.ebi.biostd.persistence.doc.mapping.to.ToExtSectionMapper
+import ac.uk.ebi.biostd.persistence.doc.mapping.to.ToExtSubmissionMapper
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import uk.ac.ebi.extended.serialization.service.ExtSerializationService
+import uk.ac.ebi.serialization.common.FilesResolver
+
+@Configuration
+class ToExtSubmissionConfig {
+    @Bean
+    internal fun toExtFileListMapper(
+        fileListDocFileRepository: FileListDocFileRepository,
+        extSerializationService: ExtSerializationService,
+        extFilesResolver: FilesResolver,
+    ): ToExtFileListMapper = ToExtFileListMapper(fileListDocFileRepository, extSerializationService, extFilesResolver)
+
+    @Bean
+    internal fun toExtSectionMapper(
+        toExtFileListMapper: ToExtFileListMapper,
+    ): ToExtSectionMapper = ToExtSectionMapper(toExtFileListMapper)
+
+    @Bean
+    internal fun toExtSubmissionMapper(
+        toExtSectionMapper: ToExtSectionMapper,
+    ): ToExtSubmissionMapper = ToExtSubmissionMapper(toExtSectionMapper)
+}

--- a/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/service/SubmissionMongoFilesPersistenceService.kt
+++ b/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/service/SubmissionMongoFilesPersistenceService.kt
@@ -1,0 +1,32 @@
+package ac.uk.ebi.biostd.persistence.doc.service
+
+import ac.uk.ebi.biostd.persistence.common.service.SubmissionFilesPersistenceService
+import ac.uk.ebi.biostd.persistence.doc.db.data.FileListDocFileDocDataRepository
+import ac.uk.ebi.biostd.persistence.doc.mapping.to.toExtFile
+import ebi.ac.uk.extended.model.ExtFile
+import ebi.ac.uk.extended.model.ExtSubmission
+
+internal class SubmissionMongoFilesPersistenceService(
+    private val fileListDocFileRepository: FileListDocFileDocDataRepository,
+) : SubmissionFilesPersistenceService {
+    override fun getReferencedFiles(
+        sub: ExtSubmission,
+        fileListName: String,
+    ): Sequence<ExtFile> {
+        return fileListDocFileRepository
+            .findAllBySubmissionAccNoAndSubmissionVersionGreaterThanAndFileListName(sub.accNo, 0, fileListName)
+            .asSequence()
+            .map { it.file.toExtFile(sub.released, sub.relPath) }
+    }
+
+    override fun findReferencedFile(
+        sub: ExtSubmission,
+        path: String,
+    ): ExtFile? {
+        return fileListDocFileRepository
+            .findBySubmissionAccNoAndSubmissionVersionAndFilePath(sub.accNo, sub.version, path)
+            .firstOrNull()
+            ?.file
+            ?.toExtFile(sub.released, sub.relPath)
+    }
+}

--- a/submission/persistence-mongo/src/test/kotlin/ac/uk/ebi/biostd/persistence/doc/service/SubmissionMongoFilesPersistenceServiceTest.kt
+++ b/submission/persistence-mongo/src/test/kotlin/ac/uk/ebi/biostd/persistence/doc/service/SubmissionMongoFilesPersistenceServiceTest.kt
@@ -1,0 +1,141 @@
+package ac.uk.ebi.biostd.persistence.doc.service
+
+import ac.uk.ebi.biostd.persistence.doc.db.data.FileListDocFileDocDataRepository
+import ac.uk.ebi.biostd.persistence.doc.integration.MongoDbReposConfig
+import ac.uk.ebi.biostd.persistence.doc.integration.MongoDbServicesConfig
+import ac.uk.ebi.biostd.persistence.doc.mapping.from.toDocFile
+import ac.uk.ebi.biostd.persistence.doc.model.FileListDocFile
+import ac.uk.ebi.biostd.persistence.doc.test.beans.TestConfig
+import ac.uk.ebi.biostd.persistence.doc.test.doc.REL_PATH
+import ac.uk.ebi.biostd.persistence.doc.test.doc.SUB_ACC_NO
+import ac.uk.ebi.biostd.persistence.doc.test.doc.testDocSubmission
+import ebi.ac.uk.db.MINIMUM_RUNNING_TIME
+import ebi.ac.uk.db.MONGO_VERSION
+import ebi.ac.uk.extended.model.ExtFileType.FILE
+import ebi.ac.uk.extended.model.ExtSubmission
+import ebi.ac.uk.extended.model.FireFile
+import ebi.ac.uk.extended.model.NfsFile
+import ebi.ac.uk.extended.model.createNfsFile
+import ebi.ac.uk.io.ext.md5
+import ebi.ac.uk.io.ext.size
+import ebi.ac.uk.util.collections.second
+import io.github.glytching.junit.extension.folder.TemporaryFolder
+import io.github.glytching.junit.extension.folder.TemporaryFolderExtension
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.bson.types.ObjectId
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.testcontainers.containers.MongoDBContainer
+import org.testcontainers.containers.startupcheck.MinimumDurationRunningStartupCheckStrategy
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.utility.DockerImageName
+import java.time.Duration.ofSeconds
+
+@ExtendWith(MockKExtension::class, SpringExtension::class, TemporaryFolderExtension::class)
+@Testcontainers
+@SpringBootTest(classes = [MongoDbReposConfig::class, MongoDbServicesConfig::class, TestConfig::class])
+class SubmissionMongoFilesPersistenceServiceTest(
+    tempFolder: TemporaryFolder,
+    @MockK private val submission: ExtSubmission,
+    @Autowired private val fileListDocFileRepository: FileListDocFileDocDataRepository,
+) {
+    private val testInstance = SubmissionMongoFilesPersistenceService(fileListDocFileRepository)
+
+    @AfterEach
+    fun afterEach() {
+        fileListDocFileRepository.deleteAll()
+    }
+
+    private val nfsReferencedFile = tempFolder.createFile("nfsReferenced.txt")
+    private val nfsFile = createNfsFile("nfsReferenced.txt", "Files/nfsReferenced.txt", nfsReferencedFile)
+    private val nfsFileListFile = FileListDocFile(
+        id = ObjectId(),
+        submissionId = testDocSubmission.id,
+        file = nfsFile.toDocFile(),
+        fileListName = "test-file-list",
+        index = 1,
+        submissionVersion = testDocSubmission.version,
+        submissionAccNo = testDocSubmission.accNo
+    )
+    private val fireReferencedFile = tempFolder.createFile("fireReferenced.txt")
+    private val fireFile = FireFile(
+        fireId = "fire-oid",
+        firePath = null,
+        published = false,
+        filePath = "fireReferenced.txt",
+        relPath = "Files/fireReferenced.txt",
+        md5 = fireReferencedFile.md5(),
+        size = fireReferencedFile.size(),
+        type = FILE,
+        attributes = emptyList()
+    )
+    private val fireFileListFile = FileListDocFile(
+        ObjectId(),
+        testDocSubmission.id,
+        fireFile.toDocFile(),
+        fileListName = "test-file-list",
+        index = 2,
+        submissionVersion = testDocSubmission.version,
+        submissionAccNo = testDocSubmission.accNo
+    )
+
+    @BeforeEach
+    fun beforeEach() {
+        setUpMockSubmission()
+        fileListDocFileRepository.save(nfsFileListFile)
+        fileListDocFileRepository.save(fireFileListFile)
+    }
+
+    @Test
+    fun `get referenced files`() {
+        val files = testInstance.getReferencedFiles(submission, "test-file-list").toList()
+        assertThat(files).hasSize(2)
+
+        val nfsFile = files.first() as NfsFile
+        assertThat(nfsFile.file).isEqualTo(nfsReferencedFile)
+        assertThat(nfsFile.fullPath).isEqualTo(nfsReferencedFile.absolutePath)
+
+        val fireFile = files.second() as FireFile
+        assertThat(fireFile.fireId).isEqualTo("fire-oid")
+        assertThat(fireFile.filePath).isEqualTo("fireReferenced.txt")
+        assertThat(fireFile.relPath).isEqualTo("Files/fireReferenced.txt")
+        assertThat(fireFile.firePath).isEqualTo("${submission.relPath}/Files/fireReferenced.txt")
+    }
+
+    @Test
+    fun `non existing referenced files`() {
+        val result = testInstance.getReferencedFiles(submission, "non-existing-fileListName")
+
+        assertThat(result.toList()).hasSize(0)
+    }
+
+    private fun setUpMockSubmission() {
+        every { submission.accNo } returns SUB_ACC_NO
+        every { submission.relPath } returns REL_PATH
+        every { submission.released } returns false
+    }
+
+    companion object {
+        @Container
+        val mongoContainer: MongoDBContainer = MongoDBContainer(DockerImageName.parse(MONGO_VERSION))
+            .withStartupCheckStrategy(MinimumDurationRunningStartupCheckStrategy(ofSeconds(MINIMUM_RUNNING_TIME)))
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun propertySource(register: DynamicPropertyRegistry) {
+            register.add("spring.data.mongodb.uri") { mongoContainer.getReplicaSetUrl("biostudies-test") }
+            register.add("spring.data.mongodb.database") { "biostudies-test" }
+        }
+    }
+}

--- a/submission/submission-security/src/test/kotlin/ebi/ac/uk/security/util/SecurityUtilTest.kt
+++ b/submission/submission-security/src/test/kotlin/ebi/ac/uk/security/util/SecurityUtilTest.kt
@@ -14,12 +14,12 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.DynamicTest.dynamicTest
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestFactory
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.DynamicTest
-import org.junit.jupiter.api.DynamicTest.dynamicTest
 import org.junit.jupiter.api.extension.ExtendWith
 import java.util.Optional
 
@@ -100,7 +100,7 @@ class SecurityUtilTest(
         @Test
         fun `check password is set as invalid when normal user security token is used`() {
             val userToken = testInstance.createToken(simpleUser)
-            every { userRepository.getById(SecurityTestEntities.userId) } returns simpleUser
+            every { userRepository.getReferenceById(SecurityTestEntities.userId) } returns simpleUser
 
             assertThat(testInstance.checkPassword(ByteArray(1), userToken)).isFalse
         }

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/common/config/GeneralConfig.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/common/config/GeneralConfig.kt
@@ -1,7 +1,7 @@
 package ac.uk.ebi.biostd.common.config
 
 import ac.uk.ebi.biostd.common.properties.ApplicationProperties
-import ac.uk.ebi.biostd.persistence.common.service.SubmissionPersistenceQueryService
+import ac.uk.ebi.biostd.persistence.common.service.SubmissionFilesPersistenceService
 import ac.uk.ebi.biostd.submission.domain.helpers.TempFileGenerator
 import ac.uk.ebi.biostd.submission.helpers.FilesSourceFactory
 import ac.uk.ebi.biostd.submission.service.FileSourcesService
@@ -20,8 +20,8 @@ internal class GeneralConfig {
     fun fireFilesSourceFactory(
         fireClient: FireClient,
         applicationProperties: ApplicationProperties,
-        queryService: SubmissionPersistenceQueryService,
-    ): FilesSourceFactory = FilesSourceFactory(fireClient, applicationProperties, queryService)
+        filesRepository: SubmissionFilesPersistenceService,
+    ): FilesSourceFactory = FilesSourceFactory(fireClient, applicationProperties, filesRepository)
 
     @Bean
     fun fileSourcesService(

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/common/config/SubmissionConfig.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/common/config/SubmissionConfig.kt
@@ -6,6 +6,7 @@ import ac.uk.ebi.biostd.integration.SerializationService
 import ac.uk.ebi.biostd.persistence.common.service.CollectionDataService
 import ac.uk.ebi.biostd.persistence.common.service.StatsDataService
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionDraftPersistenceService
+import ac.uk.ebi.biostd.persistence.common.service.SubmissionFilesPersistenceService
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionMetaQueryService
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionPersistenceQueryService
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionPersistenceService
@@ -50,11 +51,16 @@ class SubmissionConfig(
     @Bean
     fun submissionQueryService(
         submissionPersistenceQueryService: SubmissionPersistenceQueryService,
+        filesRepository: SubmissionFilesPersistenceService,
         serializationService: SerializationService,
         toSubmissionMapper: ToSubmissionMapper,
         toFileListMapper: ToFileListMapper,
     ): SubmissionQueryService = SubmissionQueryService(
-        submissionPersistenceQueryService, serializationService, toSubmissionMapper, toFileListMapper
+        submissionPersistenceQueryService,
+        filesRepository,
+        serializationService,
+        toSubmissionMapper,
+        toFileListMapper,
     )
 
     @Bean
@@ -77,7 +83,7 @@ class SubmissionConfig(
     )
 
     @Bean
-    fun submissionStagesHanlder(
+    fun submissionStagesHandler(
         submissionSubmitter: SubmissionSubmitter,
         eventsPublisherService: EventsPublisherService,
     ): SubmissionStagesHandler = SubmissionStagesHandler(submissionSubmitter, eventsPublisherService)
@@ -92,7 +98,8 @@ class SubmissionConfig(
     @Bean
     fun extSubmissionQueryService(
         queryService: SubmissionPersistenceQueryService,
-    ): ExtSubmissionQueryService = ExtSubmissionQueryService(queryService)
+        filesRepository: SubmissionFilesPersistenceService,
+    ): ExtSubmissionQueryService = ExtSubmissionQueryService(filesRepository, queryService)
 
     @Bean
     fun extSubmissionService(

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/domain/service/ExtSubmissionQueryService.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/domain/service/ExtSubmissionQueryService.kt
@@ -1,6 +1,7 @@
 package ac.uk.ebi.biostd.submission.domain.service
 
 import ac.uk.ebi.biostd.persistence.common.request.SubmissionFilter
+import ac.uk.ebi.biostd.persistence.common.service.SubmissionFilesPersistenceService
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionPersistenceQueryService
 import ac.uk.ebi.biostd.submission.web.model.ExtPageRequest
 import ebi.ac.uk.extended.model.ExtFileTable
@@ -10,6 +11,7 @@ import org.springframework.data.domain.PageImpl
 import java.time.OffsetDateTime
 
 class ExtSubmissionQueryService(
+    private val filesRepository: SubmissionFilesPersistenceService,
     private val submissionPersistenceQueryService: SubmissionPersistenceQueryService,
 ) {
 
@@ -21,7 +23,7 @@ class ExtSubmissionQueryService(
 
     fun getReferencedFiles(accNo: String, fileListName: String): ExtFileTable {
         val sub = submissionPersistenceQueryService.getExtByAccNo(accNo, false)
-        val files = submissionPersistenceQueryService.getReferencedFiles(sub, fileListName)
+        val files = filesRepository.getReferencedFiles(sub, fileListName)
         return ExtFileTable(files.toList())
     }
 

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/domain/service/SubmissionQueryService.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/domain/service/SubmissionQueryService.kt
@@ -4,6 +4,7 @@ import ac.uk.ebi.biostd.integration.SerializationService
 import ac.uk.ebi.biostd.integration.SubFormat
 import ac.uk.ebi.biostd.persistence.common.model.BasicSubmission
 import ac.uk.ebi.biostd.persistence.common.request.SubmissionFilter
+import ac.uk.ebi.biostd.persistence.common.service.SubmissionFilesPersistenceService
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionPersistenceQueryService
 import ebi.ac.uk.extended.mapping.to.ToFileListMapper
 import ebi.ac.uk.extended.mapping.to.ToSubmissionMapper
@@ -13,6 +14,7 @@ import java.nio.file.Files
 
 class SubmissionQueryService(
     private val submissionPersistenceQueryService: SubmissionPersistenceQueryService,
+    private val filesRepository: SubmissionFilesPersistenceService,
     private val serializationService: SerializationService,
     private val toSubmissionMapper: ToSubmissionMapper,
     private val toFileListMapper: ToFileListMapper,
@@ -27,7 +29,7 @@ class SubmissionQueryService(
 
     fun getFileList(accNo: String, fileListName: String, format: SubFormat): File {
         val submission = submissionPersistenceQueryService.getExtByAccNo(accNo)
-        val fileList = submissionPersistenceQueryService.getReferencedFiles(submission, fileListName)
+        val fileList = filesRepository.getReferencedFiles(submission, fileListName)
         val targetFile = Files.createTempFile(accNo, fileListName)
         return toFileListMapper.serialize(fileList, format, targetFile.toFile())
     }

--- a/submission/submission-webapp/src/test/kotlin/ac/uk/ebi/biostd/submission/domain/service/ext/ExtSubmissionPersistenceQueryServiceTest.kt
+++ b/submission/submission-webapp/src/test/kotlin/ac/uk/ebi/biostd/submission/domain/service/ext/ExtSubmissionPersistenceQueryServiceTest.kt
@@ -1,6 +1,7 @@
 package ac.uk.ebi.biostd.submission.domain.service.ext
 
 import ac.uk.ebi.biostd.persistence.common.request.SubmissionFilter
+import ac.uk.ebi.biostd.persistence.common.service.SubmissionFilesPersistenceService
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionPersistenceQueryService
 import ac.uk.ebi.biostd.submission.domain.service.ExtSubmissionQueryService
 import ac.uk.ebi.biostd.submission.web.model.ExtPageRequest
@@ -20,9 +21,10 @@ import org.springframework.data.domain.Pageable
 
 @ExtendWith(MockKExtension::class)
 internal class ExtSubmissionPersistenceQueryServiceTest(
+    @MockK private val filesRepository: SubmissionFilesPersistenceService,
     @MockK private val submissionQueryService: SubmissionPersistenceQueryService,
 ) {
-    private val testInstance = ExtSubmissionQueryService(submissionQueryService)
+    private val testInstance = ExtSubmissionQueryService(filesRepository, submissionQueryService)
 
     @Test
     fun `get ext submission`() {

--- a/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/helpers/FilesSourceFactory.kt
+++ b/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/helpers/FilesSourceFactory.kt
@@ -1,7 +1,7 @@
 package ac.uk.ebi.biostd.submission.helpers
 
 import ac.uk.ebi.biostd.common.properties.ApplicationProperties
-import ac.uk.ebi.biostd.persistence.common.service.SubmissionPersistenceQueryService
+import ac.uk.ebi.biostd.persistence.common.service.SubmissionFilesPersistenceService
 import ebi.ac.uk.extended.model.ExtSubmission
 import ebi.ac.uk.extended.model.allInnerSubmissionFiles
 import ebi.ac.uk.io.sources.FilesSource
@@ -15,7 +15,7 @@ import java.nio.file.Paths
 class FilesSourceFactory(
     private val fireClient: FireClient,
     private val applicationProperties: ApplicationProperties,
-    private val queryService: SubmissionPersistenceQueryService,
+    private val filesRepository: SubmissionFilesPersistenceService,
 ) {
     fun createFireSource(): FilesSource = FireFilesSource(fireClient)
 
@@ -26,6 +26,6 @@ class FilesSourceFactory(
             .allInnerSubmissionFiles
             .groupBy { it.filePath }
             .mapValues { it.value.first() }
-        return SubmissionFilesSource(sub, nfsFiles, fireClient, previousVersionFiles, queryService)
+        return SubmissionFilesSource(sub, nfsFiles, fireClient, previousVersionFiles, filesRepository)
     }
 }

--- a/submission/submitter/src/test/kotlin/ac/uk/ebi/biostd/submission/helpers/FilesSourceFactoryTest.kt
+++ b/submission/submitter/src/test/kotlin/ac/uk/ebi/biostd/submission/helpers/FilesSourceFactoryTest.kt
@@ -1,7 +1,7 @@
 package ac.uk.ebi.biostd.submission.helpers
 
 import ac.uk.ebi.biostd.common.properties.ApplicationProperties
-import ac.uk.ebi.biostd.persistence.common.service.SubmissionPersistenceQueryService
+import ac.uk.ebi.biostd.persistence.common.service.SubmissionFilesPersistenceService
 import arrow.core.Either.Companion.left
 import ebi.ac.uk.extended.model.ExtSection
 import ebi.ac.uk.extended.model.createNfsFile
@@ -23,10 +23,10 @@ class FilesSourceFactoryTest(
     private val tempFolder: TemporaryFolder,
     @MockK private val fireClient: FireClient,
     @MockK private val applicationProperties: ApplicationProperties,
-    @MockK private val queryService: SubmissionPersistenceQueryService,
+    @MockK private val filesRepository: SubmissionFilesPersistenceService,
 ) {
     private val attributes = emptyList<Attribute>()
-    private val testInstance = FilesSourceFactory(fireClient, applicationProperties, queryService)
+    private val testInstance = FilesSourceFactory(fireClient, applicationProperties, filesRepository)
 
     @Test
     fun `submission source`() {
@@ -35,8 +35,8 @@ class FilesSourceFactoryTest(
         val sub = basicExtSubmission.copy(section = ExtSection(type = "Exp", files = listOf(left(innerFile))))
 
         every { applicationProperties.submissionPath } returns "sub-path"
-        every { queryService.findReferencedFile(sub, "ghost.txt") } returns null
-        every { queryService.findReferencedFile(sub, "ref.txt") } returns refFile
+        every { filesRepository.findReferencedFile(sub, "ghost.txt") } returns null
+        every { filesRepository.findReferencedFile(sub, "ref.txt") } returns refFile
 
         val fileSource = testInstance.createSubmissionSource(sub)
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/183230982

PR # 2/4

- Refactor out the methods related to the referenced files in the persistence layer in order to isolate this logic from the whole submission
- Fix a couple of "TooManyFunctions" warning
- Fix typos
- Change gitlab build from concurrent to sequential