### PR TITLE
Pivotal ID # 182595703: Submission Suppressing Workflow

### DIFF
--- a/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/test/submission/submit/ResubmissionApiTest.kt
+++ b/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/test/submission/submit/ResubmissionApiTest.kt
@@ -217,7 +217,7 @@ class ResubmissionApiTest(
 
         assertThatExceptionOfType(WebClientException::class.java)
             .isThrownBy { getWebClient(serverPort, RegularUser).submitSingle(version2, TSV) }
-            .withMessageContaining("The user {$regularUser} is not allowed to suppress the submission S-RSTST4")
+            .withMessageContaining("The release date of a public study cannot be changed")
     }
 
     @Test

--- a/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/exceptions/InvalidDateException.kt
+++ b/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/exceptions/InvalidDateException.kt
@@ -5,3 +5,5 @@ class InvalidDateFormatException(date: String) : RuntimeException(
 )
 
 class PastReleaseDateException : RuntimeException("Release date cannot be in the past")
+
+class InvalidReleaseDateException : RuntimeException("The release date of a public study cannot be changed")

--- a/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/exceptions/InvalidPermissionsException.kt
+++ b/submission/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/exceptions/InvalidPermissionsException.kt
@@ -32,8 +32,3 @@ class UserCanNotRelease(
     accNo: String,
     user: String
 ) : InvalidPermissionsException("The user {$user} is not allowed to release the submission $accNo")
-
-class UserCanNotSuppress(
-    accNo: String,
-    user: String
-) : InvalidPermissionsException("The user {$user} is not allowed to suppress the submission $accNo")

--- a/submission/submitter/src/test/kotlin/ac/uk/ebi/biostd/submission/service/TimesServiceTest.kt
+++ b/submission/submitter/src/test/kotlin/ac/uk/ebi/biostd/submission/service/TimesServiceTest.kt
@@ -1,16 +1,18 @@
 package ac.uk.ebi.biostd.submission.service
 
 import ac.uk.ebi.biostd.submission.exceptions.InvalidDateFormatException
+import ac.uk.ebi.biostd.submission.exceptions.InvalidReleaseDateException
 import ac.uk.ebi.biostd.submission.exceptions.PastReleaseDateException
-import ac.uk.ebi.biostd.submission.exceptions.UserCanNotSuppress
 import ac.uk.ebi.biostd.submission.model.SubmitRequest
 import ebi.ac.uk.model.extensions.releaseDate
 import ebi.ac.uk.security.integration.components.IUserPrivilegesService
+import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockkStatic
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -35,6 +37,9 @@ class TimesServiceTest(
         every { request.previousVersion } returns null
         every { request.submission.releaseDate } returns null
     }
+
+    @AfterEach
+    fun afterEach() = clearAllMocks()
 
     @Nested
     inner class ModificationTime {
@@ -64,11 +69,16 @@ class TimesServiceTest(
 
     @Nested
     inner class ReleaseTime {
+        private val previousReleaseTime = OffsetDateTime.of(2016, 10, 10, 0, 0, 0, 0, UTC)
+
         @BeforeEach
         fun beforeEach() {
             every { request.accNo } returns "S-BSST1"
-            every { request.previousVersion } returns null
             every { request.submitter.email } returns "user@test.org"
+            every { request.previousVersion?.released } returns true
+            every { privilegesService.canSuppress("user@test.org") } returns false
+            every { request.previousVersion?.releaseTime } returns previousReleaseTime
+            every { request.previousVersion?.creationTime } returns previousReleaseTime
         }
 
         @Test
@@ -90,6 +100,7 @@ class TimesServiceTest(
 
         @Test
         fun `when release date is in the past`() {
+            every { request.previousVersion } returns null
             every { request.submission.releaseDate } returns "2016-10-10T09:27:04.000Z"
 
             val error = assertThrows<PastReleaseDateException> { testInstance.getTimes(request) }
@@ -97,7 +108,17 @@ class TimesServiceTest(
         }
 
         @Test
+        fun `when updating existing submission`() {
+            every { request.submission.releaseDate } returns "2016-10-10T21:16:36.000Z"
+
+            val times = testInstance.getTimes(request)
+            assertThat(times.released).isTrue()
+            assertThat(times.releaseTime).isEqualTo(previousReleaseTime)
+        }
+
+        @Test
         fun `when publishing private submission`() {
+            every { request.previousVersion?.released } returns false
             every { request.submission.releaseDate } returns "2018-12-31T09:27:04.000Z"
 
             val times = testInstance.getTimes(request)
@@ -108,8 +129,10 @@ class TimesServiceTest(
         @Test
         fun `when updating private submission release date`() {
             val releaseTime = OffsetDateTime.of(2019, 10, 10, 0, 0, 0, 0, UTC)
+            val previousReleaseTime = OffsetDateTime.of(2020, 10, 10, 0, 0, 0, 0, UTC)
 
             every { request.previousVersion?.released } returns false
+            every { request.previousVersion?.releaseTime } returns previousReleaseTime
             every { request.submission.releaseDate } returns "2019-10-10T09:27:04.000Z"
 
             val times = testInstance.getTimes(request)
@@ -118,14 +141,20 @@ class TimesServiceTest(
         }
 
         @Test
+        fun `when updating public submission release date`() {
+            every { request.submission.releaseDate } returns "2015-10-10T21:16:36.000Z"
+
+            val error = assertThrows<InvalidReleaseDateException> { testInstance.getTimes(request) }
+            assertThat(error.message).isEqualTo("The release date of a public study cannot be changed")
+        }
+
+        @Test
         fun `when submitter cant suppress`() {
             every { request.previousVersion?.released } returns true
-            every { privilegesService.canSuppress("user@test.org") } returns false
             every { request.submission.releaseDate } returns "2020-10-10T09:27:04.000Z"
 
-            val error = assertThrows<UserCanNotSuppress> { testInstance.getTimes(request) }
-            assertThat(error.message)
-                .isEqualTo("The user {user@test.org} is not allowed to suppress the submission S-BSST1")
+            val error = assertThrows<InvalidReleaseDateException> { testInstance.getTimes(request) }
+            assertThat(error.message).isEqualTo("The release date of a public study cannot be changed")
         }
 
         @Test


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/182595703

- Have the previous release time into consideration
- Throw a single clearer exception when a regular user tries to update the release date of a public study