### PR TITLE
Pivotal ID # 185649200: Cater For Paths Ending With Backslash

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,7 @@ include:
   - local: '/ci/pmc-processor.yml'
   - local: '/ci/exporter.yml'
   - local: '/ci/submission-releaser.yml'
+  - local: '/ci/stats-reporter.yml'
   - local: '/ci/scheduler.yml'
   - local: '/ci/bio-admin.yml'
   - local: '/ci/bio-commandline.yml'
@@ -37,6 +38,7 @@ stages:
   - auto-deploy-prod-scheduler
   - auto-deploy-prod-exporter-task
   - auto-deploy-prod-releaser-task
+  - auto-deploy-prod-stats-reporter
   - auto-deploy-prod-pmc-processor-task
   - deploy-dev-submitter
   - deploy-beta-submitter

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,6 +56,9 @@ stages:
   - deploy-dev-releaser-task
   - deploy-beta-releaser-task
   - deploy-prod-releaser-task
+  - deploy-dev-stats-reporter-task
+  - deploy-beta-stats-reporter-task
+  - deploy-prod-stats-reporter-task
   - deploy-dev-scheduler
   - deploy-beta-scheduler
   - deploy-prod-scheduler

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,7 +38,7 @@ stages:
   - auto-deploy-prod-scheduler
   - auto-deploy-prod-exporter-task
   - auto-deploy-prod-releaser-task
-  - auto-deploy-prod-stats-reporter
+  - auto-deploy-prod-stats-reporter-task
   - auto-deploy-prod-pmc-processor-task
   - deploy-dev-submitter
   - deploy-beta-submitter

--- a/commons/commons-bio/src/main/kotlin/ebi/ac/uk/errors/InvalidPathException.kt
+++ b/commons/commons-bio/src/main/kotlin/ebi/ac/uk/errors/InvalidPathException.kt
@@ -1,3 +1,9 @@
 package ebi.ac.uk.errors
 
-class InvalidPathException(path: String) : RuntimeException("The given file path contains invalid characters: $path")
+class InvalidPathException(val path: String) : RuntimeException() {
+    override val message: String
+        get() = """
+            The given file path contains invalid characters: $path
+            For more information check https://www.ebi.ac.uk/bioimage-archive/help-file-list
+        """
+}

--- a/commons/commons-bio/src/test/kotlin/ebi/ac/uk/io/sources/FileSourcesListTest.kt
+++ b/commons/commons-bio/src/test/kotlin/ebi/ac/uk/io/sources/FileSourcesListTest.kt
@@ -62,7 +62,12 @@ internal class FileSourcesListTest(
             val error = assertFailsWith<InvalidPathException> {
                 testInstance.findExtFile("./folder/file.txt", FILE_TYPE.value, attributes)
             }
-            assertThat(error.message).isEqualTo("The given file path contains invalid characters: ./folder/file.txt")
+            val expectedErrorMessage =
+                """
+                    The given file path contains invalid characters: ./folder/file.txt
+                    For more information check https://www.ebi.ac.uk/bioimage-archive/help-file-list
+                """.trimIndent()
+            assertThat(error.message).isEqualToIgnoringWhitespace(expectedErrorMessage)
         }
 
         @Test
@@ -70,7 +75,12 @@ internal class FileSourcesListTest(
             val error = assertFailsWith<InvalidPathException> {
                 testInstance.findExtFile("folder/../file.txt", FILE_TYPE.value, attributes)
             }
-            assertThat(error.message).isEqualTo("The given file path contains invalid characters: folder/../file.txt")
+            val expectedErrorMessage =
+                """
+                    The given file path contains invalid characters: folder/../file.txt
+                    For more information check https://www.ebi.ac.uk/bioimage-archive/help-file-list
+                """.trimIndent()
+            assertThat(error.message).isEqualToIgnoringWhitespace(expectedErrorMessage)
         }
 
         @Test
@@ -78,7 +88,12 @@ internal class FileSourcesListTest(
             val error = assertFailsWith<InvalidPathException> {
                 testInstance.findExtFile("folder/filé.txt", FILE_TYPE.value, attributes)
             }
-            assertThat(error.message).isEqualTo("The given file path contains invalid characters: folder/filé.txt")
+            val expectedErrorMessage =
+                """
+                    The given file path contains invalid characters: folder/filé.txt
+                    For more information check https://www.ebi.ac.uk/bioimage-archive/help-file-list
+                """.trimIndent()
+            assertThat(error.message).isEqualToIgnoringWhitespace(expectedErrorMessage)
         }
 
         @Test
@@ -86,7 +101,12 @@ internal class FileSourcesListTest(
             val error = assertFailsWith<InvalidPathException> {
                 testInstance.findExtFile("folder/inner/", DIRECTORY_TYPE.value, attributes)
             }
-            assertThat(error.message).isEqualTo("The given file path contains invalid characters: folder/inner/")
+            val expectedErrorMessage =
+                """
+                    The given file path contains invalid characters: folder/inner/
+                    For more information check https://www.ebi.ac.uk/bioimage-archive/help-file-list
+                """.trimIndent()
+            assertThat(error.message).isEqualToIgnoringWhitespace(expectedErrorMessage)
         }
     }
 }

--- a/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/test/submission/submit/SubmissionApiTest.kt
+++ b/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/test/submission/submit/SubmissionApiTest.kt
@@ -4,7 +4,6 @@ import ac.uk.ebi.biostd.client.exception.WebClientException
 import ac.uk.ebi.biostd.client.integration.commons.SubmissionFormat
 import ac.uk.ebi.biostd.client.integration.commons.SubmissionFormat.TSV
 import ac.uk.ebi.biostd.client.integration.web.BioWebClient
-import ac.uk.ebi.biostd.submission.config.FilePersistenceConfig
 import ac.uk.ebi.biostd.itest.common.SecurityTestService
 import ac.uk.ebi.biostd.itest.entities.FtpSuperUser
 import ac.uk.ebi.biostd.itest.entities.SuperUser
@@ -16,6 +15,7 @@ import ac.uk.ebi.biostd.itest.itest.getWebClient
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionPersistenceQueryService
 import ac.uk.ebi.biostd.persistence.model.DbSequence
 import ac.uk.ebi.biostd.persistence.repositories.SequenceDataRepository
+import ac.uk.ebi.biostd.submission.config.FilePersistenceConfig
 import ebi.ac.uk.asserts.assertThat
 import ebi.ac.uk.dsl.file
 import ebi.ac.uk.dsl.section
@@ -298,7 +298,10 @@ class SubmissionApiTest(
 
         assertThatExceptionOfType(WebClientException::class.java)
             .isThrownBy { webClient.submitSingle(submission, TSV) }
-            .withMessageContaining("The given file path contains invalid characters: inner/directory/")
+            .withMessageContainingAll(
+                "The given file path contains invalid characters: inner/directory/",
+                "For more information check https://www.ebi.ac.uk/bioimage-archive/help-file-list",
+            )
     }
 
     @Nested


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/185649200

- Include the file list help url in the error message for invalid paths
- Include the task to auto deploy the stats reporter task which was forgotten in a previous PR
