### PR TITLE
Pivotal ID # 183230982: Avoid Special Characters In File Paths

### DIFF
--- a/commons/commons-bio/src/main/kotlin/ebi/ac/uk/io/sources/FileSourcesList.kt
+++ b/commons/commons-bio/src/main/kotlin/ebi/ac/uk/io/sources/FileSourcesList.kt
@@ -23,7 +23,16 @@ import java.io.File
  *     - Open parenthesis ( ( )
  *     - Close parenthesis ( ) )
  */
-private val validPathPattern = "^(?!\\./)(?!.*/\$)(?!.*\\.\\./)[0-9A-Za-z!\\-_*'(). /]+(?!/\$)\$".toRegex()
+
+private val validPathPattern = buildString {
+    append("^")                        // Start of the line
+    append("(?!\\./)")                 // Negative lookahead to exclude "./"
+    append("(?!.*/\$)")                // Negative lookahead to exclude "/" at the end
+    append("(?!.*\\.\\./)")            // Negative lookahead to exclude occurrences of "../"
+    append("[0-9A-Za-z!\\-_*'(). /]+") // Character set allowing specified characters
+    append("(?!/\$)")                  // Negative lookahead to exclude "/" at the end
+    append("\$")                       // End of the line
+}.trimIndent().toRegex()
 
 @JvmInline
 value class FileSourcesList(val sources: List<FilesSource>) {

--- a/commons/commons-bio/src/main/kotlin/ebi/ac/uk/io/sources/FileSourcesList.kt
+++ b/commons/commons-bio/src/main/kotlin/ebi/ac/uk/io/sources/FileSourcesList.kt
@@ -23,7 +23,7 @@ import java.io.File
  *     - Open parenthesis ( ( )
  *     - Close parenthesis ( ) )
  */
-private val validPathPattern = "^(?!.*\\./)[0-9A-Za-z!-_*'(). ]+(?<!/)\$".toRegex()
+private val validPathPattern = "^(?!\\./)(?!.*/\$)(?!.*\\.\\./)[0-9A-Za-z!\\-_*'(). /]+(?!/\$)\$".toRegex()
 
 @JvmInline
 value class FileSourcesList(val sources: List<FilesSource>) {

--- a/commons/commons-bio/src/main/kotlin/ebi/ac/uk/io/sources/FileSourcesList.kt
+++ b/commons/commons-bio/src/main/kotlin/ebi/ac/uk/io/sources/FileSourcesList.kt
@@ -25,13 +25,13 @@ import java.io.File
  */
 
 private val validPathPattern = buildString {
-    append("^")                        // Start of the line
-    append("(?!\\./)")                 // Negative lookahead to exclude "./"
-    append("(?!.*/\$)")                // Negative lookahead to exclude "/" at the end
-    append("(?!.*\\.\\./)")            // Negative lookahead to exclude occurrences of "../"
+    append("^") // Start of the line
+    append("(?!\\./)") // Negative lookahead to exclude "./"
+    append("(?!.*/\$)") // Negative lookahead to exclude "/" at the end
+    append("(?!.*\\.\\./)") // Negative lookahead to exclude occurrences of "../"
     append("[0-9A-Za-z!\\-_*'(). /]+") // Character set allowing specified characters
-    append("(?!/\$)")                  // Negative lookahead to exclude "/" at the end
-    append("\$")                       // End of the line
+    append("(?!/\$)") // Negative lookahead to exclude "/" at the end
+    append("\$") // End of the line
 }.trimIndent().toRegex()
 
 @JvmInline

--- a/commons/commons-bio/src/main/kotlin/ebi/ac/uk/io/sources/FileSourcesList.kt
+++ b/commons/commons-bio/src/main/kotlin/ebi/ac/uk/io/sources/FileSourcesList.kt
@@ -30,7 +30,6 @@ private val validPathPattern = buildString {
     append("(?!.*/\$)") // Negative lookahead to exclude "/" at the end
     append("(?!.*\\.\\./)") // Negative lookahead to exclude occurrences of "../"
     append("[0-9A-Za-z!\\-_*'(). /]+") // Character set allowing specified characters
-    append("(?!/\$)") // Negative lookahead to exclude "/" at the end
     append("\$") // End of the line
 }.trimIndent().toRegex()
 

--- a/commons/commons-bio/src/test/kotlin/ebi/ac/uk/io/sources/FileSourcesListTest.kt
+++ b/commons/commons-bio/src/test/kotlin/ebi/ac/uk/io/sources/FileSourcesListTest.kt
@@ -97,6 +97,19 @@ internal class FileSourcesListTest(
         }
 
         @Test
+        fun `file with invalid non numeric characters`() = runTest {
+            val error = assertFailsWith<InvalidPathException> {
+                testInstance.findExtFile("Tubuline/E_KA_Exp#8_M1_12%_Tubulin_3min.Tif", FILE_TYPE.value, attributes)
+            }
+            val expectedErrorMessage =
+                """
+                    The given file path contains invalid characters: Tubuline/E_KA_Exp#8_M1_12%_Tubulin_3min.Tif
+                    For more information check https://www.ebi.ac.uk/bioimage-archive/help-file-list
+                """.trimIndent()
+            assertThat(error.message).isEqualToIgnoringWhitespace(expectedErrorMessage)
+        }
+
+        @Test
         fun `file with trailing slash`() = runTest {
             val error = assertFailsWith<InvalidPathException> {
                 testInstance.findExtFile("folder/inner/", DIRECTORY_TYPE.value, attributes)

--- a/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/test/submission/submit/SubmissionApiTest.kt
+++ b/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/test/submission/submit/SubmissionApiTest.kt
@@ -259,7 +259,7 @@ class SubmissionApiTest(
         tempFolder.createDirectory("h_EglN1-Δβ2β3-GFP")
         tempFolder.createDirectory("h_EglN1-Δβ2β3-GFP/#4")
         val file1 = tempFolder.createFile("file_16-10.txt")
-        val file2 = tempFolder.createFile("merged-4.tif")
+        val file2 = tempFolder.createFile("merged-%.tif")
         val submission = tsv {
             line("Submission", "S-BSST1610")
             line("Title", "Submission")
@@ -271,14 +271,14 @@ class SubmissionApiTest(
 
             line("Files")
             line("file_16-10.txt")
-            line("h_EglN1-Δβ2β3-GFP/#4/merged-4.tif")
+            line("h_EglN1-Δβ2β3-GFP/#4/merged-%.tif")
             line()
         }.toString()
 
         webClient.uploadFiles(listOf(file1, file2))
         assertThatExceptionOfType(WebClientException::class.java)
             .isThrownBy { webClient.submitSingle(submission, TSV) }
-            .withMessageContaining("The given file path contains invalid characters: h_EglN1-Δβ2β3-GFP/#4/merged-4.tif")
+            .withMessageContaining("The given file path contains invalid characters: h_EglN1-Δβ2β3-GFP/#4/merged-%.tif")
     }
 
     @Test


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/183230982

Fix regex expression to escape the hyphen character and ensure relative paths are avoided
