### PR TITLE
Pivotal ID # 186547510: Configurable Notifications E-Mail Subject

### DIFF
--- a/submission/notifications/src/main/kotlin/ebi/ac/uk/notifications/integration/templates/NotificationSubjectModel.kt
+++ b/submission/notifications/src/main/kotlin/ebi/ac/uk/notifications/integration/templates/NotificationSubjectModel.kt
@@ -1,0 +1,14 @@
+package ebi.ac.uk.notifications.integration.templates
+
+import ebi.ac.uk.notifications.integration.model.NotificationTemplate
+import ebi.ac.uk.notifications.integration.model.NotificationTemplateModel
+
+internal class NotificationSubjectTemplate(content: String) : NotificationTemplate<NotificationSubjectModel>(content)
+
+internal class NotificationSubjectModel(
+    private val accNo: String
+) : NotificationTemplateModel {
+    override fun getParams(): List<Pair<String, String>> = listOf(
+        "ACC_NO" to accNo,
+    )
+}

--- a/submission/notifications/src/main/kotlin/ebi/ac/uk/notifications/service/RtNotificationService.kt
+++ b/submission/notifications/src/main/kotlin/ebi/ac/uk/notifications/service/RtNotificationService.kt
@@ -3,6 +3,8 @@ package ebi.ac.uk.notifications.service
 import ebi.ac.uk.base.EMPTY
 import ebi.ac.uk.extended.model.ExtSubmission
 import ebi.ac.uk.extended.model.computedTitle
+import ebi.ac.uk.notifications.integration.templates.NotificationSubjectModel
+import ebi.ac.uk.notifications.integration.templates.NotificationSubjectTemplate
 import ebi.ac.uk.notifications.integration.templates.SubmissionReleaseModel
 import ebi.ac.uk.notifications.integration.templates.SubmissionReleaseTemplate
 import ebi.ac.uk.notifications.integration.templates.SuccessfulSubmissionModel
@@ -11,6 +13,7 @@ import ebi.ac.uk.notifications.util.TemplateLoader
 import ebi.ac.uk.util.date.toStringDate
 
 internal const val FROM = "biostudies@ebi.ac.uk"
+internal const val EMAIL_SUBJECT_TEMPLATE = "subject/%s.txt"
 internal const val SUBMISSION_RELEASE_TEMPLATE = "release/%s.txt"
 internal const val SUCCESSFUL_SUBMISSION_TEMPLATE = "submission/%s.txt"
 internal const val SUCCESSFUL_RESUBMISSION_TEMPLATE = "resubmission/%s.txt"
@@ -20,7 +23,7 @@ class RtNotificationService(
     private val rtTicketService: RtTicketService
 ) {
     fun notifySuccessfulSubmission(sub: ExtSubmission, ownerFullName: String, uiUrl: String, stUrl: String) {
-        val subject = "BioStudies Submission - ${sub.accNo}"
+        val subject = notificationSubject(sub)
         val template = if (sub.version == 1) SUCCESSFUL_SUBMISSION_TEMPLATE else SUCCESSFUL_RESUBMISSION_TEMPLATE
         val model = successfulSubmissionModel(sub, uiUrl, stUrl, ownerFullName)
         val content = SuccessfulSubmissionTemplate(templateLoader.loadTemplateOrDefault(sub, template)).render(model)
@@ -29,12 +32,19 @@ class RtNotificationService(
     }
 
     fun notifySubmissionRelease(sub: ExtSubmission, ownerFullName: String, uiUrl: String, stUrl: String) {
-        val subject = "BioStudies Submission - ${sub.accNo}"
+        val subject = notificationSubject(sub)
         val model = submissionReleaseModel(sub, uiUrl, stUrl, ownerFullName)
         val template = templateLoader.loadTemplateOrDefault(sub, SUBMISSION_RELEASE_TEMPLATE)
         val content = SubmissionReleaseTemplate(template).render(model)
 
         rtTicketService.saveRtTicket(sub.accNo, subject, sub.owner, content)
+    }
+
+    private fun notificationSubject(sub: ExtSubmission): String {
+        val model = NotificationSubjectModel(sub.accNo)
+        val template = templateLoader.loadTemplateOrDefault(sub, EMAIL_SUBJECT_TEMPLATE)
+
+        return NotificationSubjectTemplate(template).render(model)
     }
 
     companion object {

--- a/submission/notifications/src/main/resources/templates/subject/BioImages.txt
+++ b/submission/notifications/src/main/resources/templates/subject/BioImages.txt
@@ -1,0 +1,1 @@
+BioImage Archive Submission - ${ACC_NO}

--- a/submission/notifications/src/main/resources/templates/subject/Default.txt
+++ b/submission/notifications/src/main/resources/templates/subject/Default.txt
@@ -1,0 +1,1 @@
+BioStudies Submission - ${ACC_NO}

--- a/submission/submission-config/src/main/kotlin/ac/uk/ebi/biostd/common/properties/NotificationProperties.kt
+++ b/submission/submission-config/src/main/kotlin/ac/uk/ebi/biostd/common/properties/NotificationProperties.kt
@@ -1,23 +1,20 @@
 package ac.uk.ebi.biostd.common.properties
 
-import org.springframework.boot.context.properties.NestedConfigurationProperty
 import java.util.Properties
 
-class NotificationProperties {
-    lateinit var smtp: String
-    lateinit var uiUrl: String
-    lateinit var stUrl: String
-    lateinit var slackUrl: String
-
-    @NestedConfigurationProperty
-    var rt: RtConfig = RtConfig()
-
+data class NotificationProperties(
+    val smtp: String,
+    val uiUrl: String,
+    val stUrl: String,
+    val slackUrl: String,
+    val rt: RtConfig,
+) {
     fun asProperties(): Properties = Properties().apply { setProperty("mail.host", smtp) }
 }
 
-class RtConfig {
-    lateinit var host: String
-    lateinit var queue: String
-    lateinit var user: String
-    lateinit var password: String
-}
+data class RtConfig(
+    val host: String,
+    val queue: String,
+    val user: String,
+    val password: String,
+)

--- a/submission/submission-handlers/src/main/kotlin/ac/uk/ebi/biostd/handlers/config/ApplicationConfig.kt
+++ b/submission/submission-handlers/src/main/kotlin/ac/uk/ebi/biostd/handlers/config/ApplicationConfig.kt
@@ -17,6 +17,7 @@ import org.springframework.amqp.rabbit.core.RabbitTemplate
 import org.springframework.amqp.rabbit.listener.ConditionalRejectingErrorHandler
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter
 import org.springframework.boot.autoconfigure.amqp.SimpleRabbitListenerContainerFactoryConfigurer
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
@@ -27,6 +28,7 @@ import uk.ac.ebi.extended.serialization.service.ExtSerializationService
 
 @Configuration
 @Import(NotificationPersistenceConfig::class)
+@EnableConfigurationProperties(ApplicationProperties::class)
 class Listeners {
     @Bean
     fun logListener(): LogSubmissionListener = LogSubmissionListener()

--- a/submission/submission-handlers/src/main/kotlin/ac/uk/ebi/biostd/handlers/config/ApplicationProperties.kt
+++ b/submission/submission-handlers/src/main/kotlin/ac/uk/ebi/biostd/handlers/config/ApplicationProperties.kt
@@ -2,14 +2,10 @@ package ac.uk.ebi.biostd.handlers.config
 
 import ac.uk.ebi.biostd.common.properties.NotificationProperties
 import org.springframework.boot.context.properties.ConfigurationProperties
-import org.springframework.boot.context.properties.NestedConfigurationProperty
-import org.springframework.stereotype.Component
+import org.springframework.boot.context.properties.ConstructorBinding
 
-@Component
 @ConfigurationProperties(prefix = "app")
-class ApplicationProperties {
-    lateinit var baseInstanceUrl: String
-
-    @NestedConfigurationProperty
-    var notifications: NotificationProperties = NotificationProperties()
-}
+@ConstructorBinding
+data class ApplicationProperties(
+    val notifications: NotificationProperties,
+)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186547510

- Use the configuration mechanism to set the e-mail subject
- Use constructor binding for the handlers app configuration in order to avoid missing properties
- Remove unused properties
- Improve tests
