### PR TITLE
Pivotal ID # 188847155: Files Endpoint Unresponsive For FTP Users

### DIFF
--- a/client/ftp-webclient/src/main/kotlin/ebi/ac/uk/ftp/FtpClient.kt
+++ b/client/ftp-webclient/src/main/kotlin/ebi/ac/uk/ftp/FtpClient.kt
@@ -50,14 +50,27 @@ interface FtpClient {
     fun deleteFile(path: Path)
 
     companion object {
+        @Suppress("LongParameterList")
         fun create(
             ftpUser: String,
             ftpPassword: String,
             ftpUrl: String,
             ftpPort: Int,
             ftpRootPath: String,
+            defaultTimeout: Long,
+            connectionTimeout: Long,
         ): FtpClient {
-            val connectionPool = FTPClientPool(ftpUser, ftpPassword, ftpUrl, ftpPort, ftpRootPath)
+            val connectionPool =
+                FTPClientPool(
+                    ftpUser,
+                    ftpPassword,
+                    ftpUrl,
+                    ftpPort,
+                    ftpRootPath,
+                    defaultTimeout,
+                    connectionTimeout,
+                )
+
             return SimpleFtpClient(connectionPool)
         }
     }

--- a/client/ftp-webclient/src/test/kotlin/ebi/ac/uk/ftp/FtpClientTest.kt
+++ b/client/ftp-webclient/src/test/kotlin/ebi/ac/uk/ftp/FtpClientTest.kt
@@ -15,6 +15,8 @@ class FtpClientTest {
             ftpServer.getUrl(),
             ftpServer.ftpPort,
             FTP_ROOT_PATH,
+            FTP_TIMEOUT,
+            FTP_TIMEOUT,
         )
 
     @RetryingTest(TEST_RETRY)
@@ -77,20 +79,20 @@ class FtpClientTest {
     }
 
     companion object {
-        fun createFtpServer(): FtpServer {
-            return FtpServer.createServer(
+        fun createFtpServer(): FtpServer =
+            FtpServer.createServer(
                 FtpConfig(
                     sslConfig = SslConfig(File(this::class.java.getResource("/mykeystore.jks")!!.toURI()), "123456"),
                     userName = FTP_USER,
                     password = FTP_PASSWORD,
                 ),
             )
-        }
 
         private val HOME = Paths.get("")
         const val FTP_USER = "ftpUser"
         const val FTP_PASSWORD = "ftpPassword"
         const val FTP_ROOT_PATH = ".test"
         const val TEST_RETRY = 3
+        const val FTP_TIMEOUT = 3000L
     }
 }

--- a/submission/file-sources/build.gradle.kts
+++ b/submission/file-sources/build.gradle.kts
@@ -1,4 +1,5 @@
 import Dependencies.CommonsNet
+import Dependencies.KotlinLogging
 import Projects.CommonsBio
 import Projects.CommonsModelExtended
 import Projects.CommonsModelExtendedMapping
@@ -24,6 +25,7 @@ dependencies {
     api(project(SubmissionSecurity))
     api(project(SubmissionPersistenceCommonApi))
     implementation(CommonsNet)
+    implementation(KotlinLogging)
 
     testApi(project(CommonsTest))
     BaseTestCompileDependencies.forEach { testImplementation(it) }

--- a/submission/file-sources/src/main/kotlin/uk/ac/ebi/io/builder/FilesSourceListBuilder.kt
+++ b/submission/file-sources/src/main/kotlin/uk/ac/ebi/io/builder/FilesSourceListBuilder.kt
@@ -29,7 +29,7 @@ class FilesSourceListBuilder(
     private val filesRepository: SubmissionFilesPersistenceService,
     private val sources: MutableList<FilesSource> = mutableListOf(),
 ) {
-    fun build(): FileSourcesList = FileSourcesList(checkFilesPath, sources.toList())
+    private fun build(): FileSourcesList = FileSourcesList(checkFilesPath, sources.toList())
 
     fun buildFilesSourceList(builderAction: FilesSourceListBuilder.() -> Unit): FileSourcesList {
         this.sources.clear()

--- a/submission/file-sources/src/main/kotlin/uk/ac/ebi/io/sources/FtpSource.kt
+++ b/submission/file-sources/src/main/kotlin/uk/ac/ebi/io/sources/FtpSource.kt
@@ -7,6 +7,7 @@ import ebi.ac.uk.ftp.FtpClient
 import ebi.ac.uk.io.sources.FilesSource
 import ebi.ac.uk.model.Attribute
 import ebi.ac.uk.model.constants.FileFields
+import mu.KotlinLogging
 import org.apache.commons.net.ftp.FTPFile
 import uk.ac.ebi.io.builder.createFile
 import java.io.File
@@ -14,10 +15,12 @@ import java.nio.file.Path
 import kotlin.io.path.createTempFile
 import kotlin.io.path.name
 
+private val logger = KotlinLogging.logger {}
+
 /**
  *  Ftp source. Mix both ftp protocol to validate file presence and direct ftp mount point to access file content.
  *  This separation is necessary as files are check in backend instance with no access to FTP file system while
- *  processing is executed in data mover which can access moint point.
+ *  processing is executed in data mover which can access mount point.
  */
 class FtpSource(
     override val description: String,
@@ -42,14 +45,24 @@ class FtpSource(
         }
     }
 
-    override suspend fun getFileList(path: String): File? {
-        return findFile(path)?.let { downloadFile(ftpUrl.resolve(path)) }
-    }
+    override suspend fun getFileList(path: String): File? = findFile(path)?.let { downloadFile(ftpUrl.resolve(path)) }
 
+    @Suppress("TooGenericExceptionCaught")
     private fun findFile(filePath: String): FTPFile? {
-        val ftpPath = ftpUrl.resolve(filePath)
-        val files = ftpClient.listFiles(ftpPath.parent)
-        return files.firstOrNull { it.name == ftpPath.name }
+        var attempt = 0
+
+        fun ftpResolve(): FTPFile? {
+            val ftpPath = ftpUrl.resolve(filePath)
+            val files = ftpClient.listFiles(ftpPath.parent)
+            return files.firstOrNull { it.name == ftpPath.name }
+        }
+
+        try {
+            return ftpResolve()
+        } catch (exception: Exception) {
+            logger.error(exception) { "Could not find FTP file $filePath. Retry attempt # ${attempt++}" }
+            return ftpResolve()
+        }
     }
 
     private fun downloadFile(path: Path): File {

--- a/submission/file-sources/src/test/kotlin/uk/ac/ebi/io/sources/FtpSourceTest.kt
+++ b/submission/file-sources/src/test/kotlin/uk/ac/ebi/io/sources/FtpSourceTest.kt
@@ -1,0 +1,64 @@
+package uk.ac.ebi.io.sources
+
+import ebi.ac.uk.ftp.FtpClient
+import ebi.ac.uk.model.constants.FileFields.FILE_TYPE
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import kotlinx.coroutines.test.runTest
+import org.apache.commons.net.ftp.FTPFile
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.io.File
+import java.net.SocketTimeoutException
+import java.nio.file.Path
+import kotlin.io.path.name
+
+@ExtendWith(MockKExtension::class)
+class FtpSourceTest(
+    @MockK private val file: File,
+    @MockK private val ftpUrl: Path,
+    @MockK private val ftpPath: Path,
+    @MockK private val ftpParentPath: Path,
+    @MockK private val nfsPath: Path,
+    @MockK private val filePath: Path,
+    @MockK private val ftpFile: FTPFile,
+    @MockK private val ftpClient: FtpClient,
+) {
+    private val testInstance = FtpSource(DESCRIPTION, ftpUrl, nfsPath, ftpClient)
+
+    @BeforeEach
+    fun beforeEach() {
+        every { ftpFile.size } returns 123L
+        every { ftpFile.name } returns FILE_NAME
+        every { ftpFile.isDirectory } returns false
+
+        every { ftpPath.name } returns FILE_NAME
+        every { ftpPath.parent } returns ftpParentPath
+
+        every { filePath.toFile() } returns file
+        every { file.absolutePath } returns FILE_PATH
+        every { ftpUrl.resolve(FILE_NAME) } returns ftpPath
+        every { nfsPath.resolve(FILE_NAME) } returns filePath
+    }
+
+    @Test
+    fun `find file when connection fails`() =
+        runTest {
+            every {
+                ftpClient.listFiles(ftpParentPath)
+            } throws SocketTimeoutException() andThenAnswer { listOf(ftpFile) }
+
+            val file = testInstance.getExtFile(FILE_NAME, FILE_TYPE.name, listOf())
+            assertThat(file).isNotNull()
+            assertThat(file!!.fileName).isEqualTo(FILE_NAME)
+        }
+
+    private companion object {
+        const val DESCRIPTION = "test-source"
+        const val FILE_NAME = "test-file"
+        const val FILE_PATH = "/a/path/test-file"
+    }
+}

--- a/submission/submission-config/src/main/kotlin/ac/uk/ebi/biostd/common/properties/SecurityProperties.kt
+++ b/submission/submission-config/src/main/kotlin/ac/uk/ebi/biostd/common/properties/SecurityProperties.kt
@@ -25,12 +25,19 @@ data class FilesProperties(
     val defaultMode: StorageMode,
     val filesDirPath: String,
     val magicDirPath: String,
+    @NestedConfigurationProperty
+    val ftp: FtpProperties,
+)
+
+data class FtpProperties(
     val ftpRootPath: String,
     val ftpDirPath: String,
     val ftpUser: String,
     val ftpPassword: String,
     val ftpUrl: String,
     val ftpPort: Int,
+    val defaultTimeout: Long,
+    val connectionTimeout: Long,
 )
 
 data class InstanceKeys(

--- a/submission/submission-core/src/main/kotlin/ac/uk/ebi/biostd/submission/domain/submission/SubmissionProcessor.kt
+++ b/submission/submission-core/src/main/kotlin/ac/uk/ebi/biostd/submission/domain/submission/SubmissionProcessor.kt
@@ -35,10 +35,11 @@ class SubmissionProcessor(
         val submission = rqt.submission
         val previousVersion = rqt.previousVersion
         val storageMode = rqt.storageMode
-        val doi = doiService.calculateDoi(accNoString, rqt)
         val secretKey = previousVersion?.secretKey ?: UUID.randomUUID().toString()
         val tags = getTags(rqt)
         val ownerEmail = rqt.onBehalfUser?.email ?: previousVersion?.owner ?: rqt.submitter.email
+        val rootSection = toExtSectionMapper.convert(accNoString, rqt.version, submission.section, rqt.sources)
+        val doi = doiService.calculateDoi(accNoString, rqt)
 
         return ExtSubmission(
             accNo = accNoString,
@@ -58,7 +59,7 @@ class SubmissionProcessor(
             creationTime = creationTime,
             tags = submission.tags.map { ExtTag(it.first, it.second) },
             collections = tags.map { ExtCollection(it) },
-            section = toExtSectionMapper.convert(accNoString, rqt.version, submission.section, rqt.sources),
+            section = rootSection,
             attributes = submission.attributes.toExtAttributes(SUBMISSION_RESERVED_ATTRIBUTES),
             storageMode = storageMode ?: if (properties.persistence.enableFire) StorageMode.FIRE else StorageMode.NFS,
         )

--- a/submission/submission-security/src/main/kotlin/ebi/ac/uk/security/integration/SecurityModuleConfig.kt
+++ b/submission/submission-security/src/main/kotlin/ebi/ac/uk/security/integration/SecurityModuleConfig.kt
@@ -95,9 +95,9 @@ class SecurityModuleConfig(
 
         fun profileService(props: SecurityProperties): ProfileService =
             ProfileService(
-                nfsUserFtpDirPath = Paths.get(props.filesProperties.ftpDirPath),
+                nfsUserFtpDirPath = Paths.get(props.filesProperties.ftp.ftpDirPath),
                 nfsUserFilesDirPath = Paths.get(props.filesProperties.filesDirPath),
-                ftpRootPath = props.filesProperties.ftpRootPath,
+                ftpRootPath = props.filesProperties.ftp.ftpRootPath,
             )
     }
 }

--- a/submission/submission-security/src/main/kotlin/ebi/ac/uk/security/service/SecurityService.kt
+++ b/submission/submission-security/src/main/kotlin/ebi/ac/uk/security/service/SecurityService.kt
@@ -157,9 +157,8 @@ open class SecurityService(
             val target = profileService.asSecurityUser(user.apply { this.storageMode = storageMode })
 
             createMagicFolder(target)
-            copyFilesClusterJob(source.userFolder.path, target.userFolder.path, days)
-
             userRepository.save(user)
+            copyFilesClusterJob(source.userFolder.path, target.userFolder.path, days)
         }
 
     private fun setPassword(

--- a/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/itest/ITestListener.kt
+++ b/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/itest/ITestListener.kt
@@ -88,15 +88,19 @@ class ITestListener : TestExecutionListener {
         ftpServer.start()
 
         val userFilesProperties = "$securityProperties.filesProperties"
-        properties.addProperty("$userFilesProperties.ftpUser", FTP_USER)
-        properties.addProperty("$userFilesProperties.ftpPassword", FTP_PASSWORD)
-        properties.addProperty("$userFilesProperties.ftpUrl", ftpServer.getUrl())
-        properties.addProperty("$userFilesProperties.ftpPort", ftpServer.ftpPort.toString())
-        properties.addProperty("$userFilesProperties.ftpDirPath", ftpServer.fileSystemDirectory.absolutePath)
-        properties.addProperty("$userFilesProperties.ftpRootPath", FTP_ROOT_PATH)
         properties.addProperty("$userFilesProperties.filesDirPath", dropboxPath.absolutePath)
         properties.addProperty("$userFilesProperties.magicDirPath", magicDirPath.absolutePath)
         Files.createDirectory(ftpServer.fileSystemDirectory.resolve(FTP_ROOT_PATH).toPath())
+
+        val ftpProperties = "$userFilesProperties.ftp"
+        properties.addProperty("$ftpProperties.ftpUser", FTP_USER)
+        properties.addProperty("$ftpProperties.ftpPassword", FTP_PASSWORD)
+        properties.addProperty("$ftpProperties.ftpUrl", ftpServer.getUrl())
+        properties.addProperty("$ftpProperties.ftpPort", ftpServer.ftpPort.toString())
+        properties.addProperty("$ftpProperties.ftpDirPath", ftpServer.fileSystemDirectory.absolutePath)
+        properties.addProperty("$ftpProperties.ftpRootPath", FTP_ROOT_PATH)
+        properties.addProperty("$ftpProperties.defaultTimeout", FTP_DEFAULT_TIMEOUT)
+        properties.addProperty("$ftpProperties.connectionTimeout", FTP_DEFAULT_TIMEOUT)
     }
 
     private fun fireSetup() {
@@ -180,6 +184,7 @@ class ITestListener : TestExecutionListener {
     companion object {
         private const val ENVIRONMENT = "TEST"
         private const val FTP_ROOT_PATH = ".test"
+        private const val FTP_DEFAULT_TIMEOUT = 3000L
         private val testAppFolder = Files.createTempDirectory("test-app-folder").toFile()
 
         private const val DEFAULT_BUCKET = "bio-fire-bucket"

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/files/FileConfig.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/files/FileConfig.kt
@@ -3,6 +3,7 @@ package ac.uk.ebi.biostd.files
 import ac.uk.ebi.biostd.files.service.FileServiceFactory
 import ac.uk.ebi.biostd.files.web.common.FilesMapper
 import ebi.ac.uk.ftp.FtpClient
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -12,5 +13,7 @@ class FileConfig {
     fun fileMapper() = FilesMapper()
 
     @Bean
-    fun fileServiceFactory(ftpClient: FtpClient) = FileServiceFactory(ftpClient)
+    fun fileServiceFactory(
+        @Qualifier("userFilesFtpClient") ftpClient: FtpClient,
+    ) = FileServiceFactory(ftpClient)
 }

--- a/submission/submission-webapp/src/main/resources/application.yml
+++ b/submission/submission-webapp/src/main/resources/application.yml
@@ -105,7 +105,7 @@ app:
     tokenHash: # Token used for hash authentication
     environment: # Current application execution environment
     requireActivation: # Indicates whether a new user need activation before being used
-    preventFileDeletion: # Indicates wheter or not to prevent public submission non pagetab file delitions
+    preventFileDeletion: # Indicates whether to prevent public submission non pagetab file delitions
     instanceKeys:
       dev: # Instance key for the submission tool DEV environment
       beta: # Instance key for the submission tool BETA environment
@@ -114,12 +114,15 @@ app:
       defaultMode: # The default mode to create user folder. Valid values are: NFS, FTP
       filesDirPath: # Absolute path to the folder to be used for the user/groups files
       magicDirPath: # Absolute path to create user magic folder for dropbox simple access
-      ftpDirPath: # Absolute path of the FTP-IN folder in NFS
-      ftpRootPath: # Root path to find the user files in the FTP-IN folder. If blank, root level FTP-IN will be used
-      ftpUser: # FTP user
-      ftpPassword: # FTP password
-      ftpUrl: # FTP url without port
-      ftpPort: # FTP port
+      ftp:
+        ftpDirPath: # Absolute path of the FTP-IN folder in NFS
+        ftpRootPath: # Root path to find the user files in the FTP-IN folder. If blank, root level FTP-IN will be used
+        ftpUser: # FTP user
+        ftpPassword: # FTP password
+        ftpUrl: # FTP url without port
+        ftpPort: # FTP port
+        defaultTimeout: # FTP connection pool default timeout
+        connectionTimeout: # FTP connection pool connection timeout
   persistence:
     enableFire: # Boolean flag to indicate whether the files are stored on FIRE if true or NFS if false
     concurrency: # Number of files processed concurrently


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/188847155

- Create separate qualified beans for the FTP connection pools used by the files source and file list services
- Implement a retry mechanism for finding files through FTP
- Add configuration properties for the FTP connection pool timeout
- Generate the DOI as a las step, after the ExtSubmission object has been created
