### PR TITLE
Pivotal ID # 188837317: Allow Files Deletion For Collection ADMIN

### DIFF
--- a/submission/submission-security/src/main/kotlin/ebi/ac/uk/security/service/UserPrivilegesService.kt
+++ b/submission/submission-security/src/main/kotlin/ebi/ac/uk/security/service/UserPrivilegesService.kt
@@ -70,7 +70,7 @@ internal class UserPrivilegesService(
     override suspend fun canDeleteFiles(
         submitter: String,
         accNo: String,
-    ): Boolean = hasPermissions(submitter, accNo, DELETE_FILES)
+    ): Boolean = isAdmin(submitter, accNo) || hasPermissions(submitter, accNo, DELETE_FILES)
 
     override fun canRelease(email: String): Boolean = isSuperUser(email)
 

--- a/submission/submission-webapp/src/itest/itestsInventory.md
+++ b/submission/submission-webapp/src/itest/itestsInventory.md
@@ -24,12 +24,14 @@ Contains test related to submission deletion.
 
 Contains test related to submission file deletion.
 
-| Class                     | Test No | Test name                                                                                  |
-|---------------------------|---------|--------------------------------------------------------------------------------------------|
-| DeleteFilesPermissionTest | 1-14    | Regular user deletes their own public submission files                                     |
-| DeleteFilesPermissionTest | 1-15    | Regular user with UPDATE_PUBLIC permission delete their own public submission files        |
-| DeleteFilesPermissionTest | 1-16    | Regular user deletes their own public submission filelist files                            |
-| DeleteFilesPermissionTest | 1-16    | Regular user deletes their own public submission files when preventFileDeletion is disable |
+| Class                     | Test No | Test name                                                                                   |
+|---------------------------|---------|---------------------------------------------------------------------------------------------|
+| DeleteFilesPermissionTest | 1-14    | Regular user deletes their own public submission files                                      |
+| DeleteFilesPermissionTest | 1-15    | Regular user with DELETE_FILES permission delete their own public submission files          |
+| DeleteFilesPermissionTest | 1-16    | Regular user deletes their own public submission filelist files                             |
+| DeleteFilesPermissionTest | 1-16    | Regular user deletes their own public submission filelist files                             |
+| DeleteFilesPermissionTest | 1-17    | Collection ADMIN user deletes public submission files                                       |
+| DeleteFilesPermissionTest | 1-18    | Regular user deletes their own public submission files when preventFileDeletion is disabled |
 
 ### Submit Permission Test Suite
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/188837317

- Update logic to allow admin users to delete files on public submissions
- Update iTests to use regular user web client
