### PR TITLE
BIOSTD-284: Prevent Empty URL Links

### DIFF
--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/json/deserialization/LinkJsonDeserializer.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/json/deserialization/LinkJsonDeserializer.kt
@@ -1,5 +1,7 @@
 package ac.uk.ebi.biostd.json.deserialization
 
+import ac.uk.ebi.biostd.validation.InvalidElementException
+import ac.uk.ebi.biostd.validation.REQUIRED_LINK_URL
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.JsonNode
@@ -19,9 +21,11 @@ internal class LinkJsonDeserializer : StdDeserializer<Link>(Link::class.java) {
     ): Link {
         val mapper = jp.codec as ObjectMapper
         val node: JsonNode = mapper.readTree(jp)
+        val url = node.getNode<TextNode>(LinkFields.URL.value).textValue()
+        require(url.isNotBlank()) { throw InvalidElementException(REQUIRED_LINK_URL) }
 
         return Link(
-            url = node.getNode<TextNode>(LinkFields.URL.value).textValue(),
+            url = url,
             attributes = mapper.convertOrDefault(node, ATTRIBUTES) { emptyList() },
         )
     }

--- a/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/json/deserialization/LinkDeserializerTest.kt
+++ b/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/json/deserialization/LinkDeserializerTest.kt
@@ -1,6 +1,7 @@
 package ac.uk.ebi.biostd.json.deserialization
 
 import ac.uk.ebi.biostd.json.JsonSerializer
+import ac.uk.ebi.biostd.validation.InvalidElementException
 import com.fasterxml.jackson.module.kotlin.readValue
 import ebi.ac.uk.dsl.json.jsonArray
 import ebi.ac.uk.dsl.json.jsonObj
@@ -32,6 +33,37 @@ class LinkDeserializerTest {
         assertThat(exception.message).isEqualTo(
             "Expecting node: '$node', property: 'url' to be of type 'TextNode' but 'ArrayNode' was found instead",
         )
+    }
+
+    @Test
+    fun `deserialize without url`() {
+        val invalidJson =
+            jsonObj {
+                "attributes" to
+                    jsonArray({
+                        "name" to "attr name"
+                        "value" to "attr value"
+                    })
+            }.toString()
+
+        val exception = assertThrows<IllegalStateException> { testInstance.readValue<Link>(invalidJson) }
+        assertThat(exception).hasMessageContaining("Expecting to find property with 'url' in node")
+    }
+
+    @Test
+    fun `deserialize with empty url`() {
+        val invalidJson =
+            jsonObj {
+                "url" to ""
+                "attributes" to
+                    jsonArray({
+                        "name" to "attr name"
+                        "value" to "attr value"
+                    })
+            }.toString()
+
+        val exception = assertThrows<InvalidElementException> { testInstance.readValue<Link>(invalidJson) }
+        assertThat(exception.message).isEqualTo("Link Url is required. Element was not created.")
     }
 
     @Test

--- a/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/test/TsvTestFactory.kt
+++ b/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/test/TsvTestFactory.kt
@@ -186,6 +186,12 @@ fun submissionWithLinks() =
         line()
     }
 
+fun submissionWithEmptyLinks() =
+    submissionWithRootSection().apply {
+        line("Link", "")
+        line()
+    }
+
 fun submissionWithLinksTable() =
     submissionWithRootSection().apply {
         line("Links", "Type", "(TermId)", "[Ontology]")

--- a/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/tsv/TsvDeserializerTest.kt
+++ b/commons/commons-serialization/src/test/kotlin/ac/uk/ebi/biostd/tsv/TsvDeserializerTest.kt
@@ -7,6 +7,7 @@ import ac.uk.ebi.biostd.test.sectionWithEmptyAccParentSection
 import ac.uk.ebi.biostd.test.submissionWithBlankAttribute
 import ac.uk.ebi.biostd.test.submissionWithDetailedAttributes
 import ac.uk.ebi.biostd.test.submissionWithEmptyAttribute
+import ac.uk.ebi.biostd.test.submissionWithEmptyLinks
 import ac.uk.ebi.biostd.test.submissionWithFiles
 import ac.uk.ebi.biostd.test.submissionWithFilesTable
 import ac.uk.ebi.biostd.test.submissionWithGenericRootSection
@@ -452,6 +453,15 @@ class TsvDeserializerTest {
                 }
             },
         )
+    }
+
+    @Test
+    fun `link with empty url`() {
+        val submission = submissionWithEmptyLinks()
+        val exception = assertThrows<SerializationException> { deserializer.deserialize(submission.toString()) }
+        val errors = exception.errors.entries().map { it.value.cause }
+        assertThat(errors).hasSize(1)
+        assertThat(errors.first()).hasMessage("Link Url is required. Element was not created.")
     }
 
     @Test

--- a/commons/commons-util/src/main/kotlin/ebi/ac/uk/base/StringExt.kt
+++ b/commons/commons-util/src/main/kotlin/ebi/ac/uk/base/StringExt.kt
@@ -25,12 +25,12 @@ fun String?.isNotBlank() = !isNullOrEmpty()
 inline fun String?.applyIfNotBlank(func: (String) -> Unit) = takeIf { it.isNotBlank() }?.let { func(it) }
 
 /**
- * Compare if string representation of objects are equivalent, ignoring case.
+ * Compare if string representations of the given objects are equivalent, ignoring its case.
  */
 infix fun String.like(other: Any) = other.toString().equals(this, ignoreCase = true)
 
 /**
- * Split the string by the given regex ignoring empty results.
+ * Split the string by the given regex, ignoring empty results.
  */
 fun String.splitIgnoringEmpty(regex: Regex) = this.split(regex).filter { it.isNotBlank() }
 


### PR DESCRIPTION
https://embl.atlassian.net/browse/BIOSTD-284

Ensures that the URL field of a link is not blank during JSON and TSV deserialization.
