### PR TITLE
BIOSTD-277: Avoid Invalid FileList Extensions

### DIFF
--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/integration/SubFormat.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/integration/SubFormat.kt
@@ -9,12 +9,23 @@ sealed class SubFormat(
     private val description: String,
 ) {
     companion object {
+        const val JSON_EXTENSION = "json"
+        const val TSV_EXTENSION = "tsv"
+        const val XLSX_EXTENSION = "xlsx"
+
+        fun checkFileListExtension(fileName: String) {
+            val extension = fileName.substringAfterLast(".")
+            require(extension == JSON_EXTENSION || extension == TSV_EXTENSION || extension == XLSX_EXTENSION) {
+                throw InvalidFormatException(extension)
+            }
+        }
+
         fun fromFile(file: File): SubFormat = fromString(file.extension)
 
         fun fromString(format: String): SubFormat =
             when (format.lowercase()) {
-                "tsv" -> TsvFormat.Tsv
-                "json" -> PlainJson
+                TSV_EXTENSION -> TsvFormat.Tsv
+                JSON_EXTENSION -> PlainJson
                 else -> throw InvalidFormatException(format)
             }
 

--- a/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/service/PageTabFileReader.kt
+++ b/commons/commons-serialization/src/main/kotlin/ac/uk/ebi/biostd/service/PageTabFileReader.kt
@@ -2,6 +2,8 @@ package ac.uk.ebi.biostd.service
 
 import ac.uk.ebi.biostd.exception.EmptyPageTabFileException
 import ac.uk.ebi.biostd.exception.InvalidFileListException
+import ac.uk.ebi.biostd.integration.SubFormat.Companion.XLSX_EXTENSION
+import ac.uk.ebi.biostd.integration.SubFormat.Companion.checkFileListExtension
 import ebi.ac.uk.errors.FilesProcessingException
 import ebi.ac.uk.io.ext.size
 import ebi.ac.uk.io.sources.FileSourcesList
@@ -11,20 +13,22 @@ import java.io.File
 object PageTabFileReader {
     fun readAsPageTab(file: File): File {
         require(file.size() > 0) { throw EmptyPageTabFileException(file.name) }
-        return if (file.extension == "xlsx") asTsv(file) else file
+        return if (file.extension == XLSX_EXTENSION) asTsv(file) else file
     }
 
     suspend fun getFileListFile(
         fileListName: String,
         filesSource: FileSourcesList,
-    ): File =
-        when (val file = filesSource.getFileList(fileListName)) {
+    ): File {
+        checkFileListExtension(fileListName)
+        return when (val file = filesSource.getFileList(fileListName)) {
             null -> throw FilesProcessingException(fileListName, filesSource)
             else ->
                 when {
                     file.isFile.not() -> throw InvalidFileListException.directoryCantBeFileList(fileListName)
-                    file.extension == "xlsx" -> asTsv(file)
+                    file.extension == XLSX_EXTENSION -> asTsv(file)
                     else -> file
                 }
         }
+    }
 }

--- a/submission/submission-core/src/main/kotlin/ac/uk/ebi/biostd/submission/validator/collection/EuToxRiskValidator.kt
+++ b/submission/submission-core/src/main/kotlin/ac/uk/ebi/biostd/submission/validator/collection/EuToxRiskValidator.kt
@@ -1,6 +1,7 @@
 package ac.uk.ebi.biostd.submission.validator.collection
 
 import ac.uk.ebi.biostd.common.properties.ValidatorProperties
+import ac.uk.ebi.biostd.integration.SubFormat.Companion.XLSX_EXTENSION
 import ac.uk.ebi.biostd.persistence.common.exception.CollectionValidationException
 import ebi.ac.uk.commons.http.ext.RequestParams
 import ebi.ac.uk.commons.http.ext.postForObject
@@ -49,7 +50,7 @@ class EuToxRiskValidator(
         val subFile =
             submission
                 .allSectionsFiles
-                .find { it.fileName.endsWith("xlsx") }
+                .find { it.fileName.endsWith(XLSX_EXTENSION) }
                 ?: throw CollectionValidationException(listOf(EXCEL_FILE_REQUIRED))
         return FileSystemResource(asFile(subFile))
     }

--- a/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/test/filelist/FileListSubmissionTest.kt
+++ b/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/test/filelist/FileListSubmissionTest.kt
@@ -57,9 +57,9 @@ import java.nio.file.Paths
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Transactional
 class FileListSubmissionTest(
-    @Autowired private val securityTestService: SecurityTestService,
-    @Autowired private val subRepository: SubmissionPersistenceQueryService,
-    @LocalServerPort val serverPort: Int,
+    @param:Autowired private val securityTestService: SecurityTestService,
+    @param:Autowired private val subRepository: SubmissionPersistenceQueryService,
+    @param:LocalServerPort val serverPort: Int,
 ) {
     private lateinit var webClient: BioWebClient
 

--- a/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/test/submission/submit/MultipartAsyncTest.kt
+++ b/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/test/submission/submit/MultipartAsyncTest.kt
@@ -1,6 +1,7 @@
 package ac.uk.ebi.biostd.itest.test.submission.submit
 
 import ac.uk.ebi.biostd.client.integration.web.BioWebClient
+import ac.uk.ebi.biostd.integration.SubFormat.Companion.TSV_EXTENSION
 import ac.uk.ebi.biostd.itest.common.SecurityTestService
 import ac.uk.ebi.biostd.itest.entities.SuperUser
 import ac.uk.ebi.biostd.itest.itest.ITestListener.Companion.storageMode
@@ -31,9 +32,9 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 @ExtendWith(SpringExtension::class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class MultipartAsyncTest(
-    @Autowired private val securityTestService: SecurityTestService,
-    @Autowired val submissionRepository: SubmissionPersistenceQueryService,
-    @LocalServerPort val serverPort: Int,
+    @param:Autowired private val securityTestService: SecurityTestService,
+    @param:Autowired val submissionRepository: SubmissionPersistenceQueryService,
+    @param:LocalServerPort val serverPort: Int,
 ) {
     private lateinit var webClient: BioWebClient
 
@@ -79,7 +80,7 @@ class MultipartAsyncTest(
 
             val result =
                 webClient.submitMultipartAsync(
-                    format = "tsv",
+                    format = TSV_EXTENSION,
                     submissions = mapOf("SMulti-001" to submission, "SMulti-002" to submission2),
                     files = mapOf("SMulti-001" to listOf(file), "SMulti-002" to listOf(file2, file3)),
                     parameters = SubmitParameters(storageMode = storageMode),

--- a/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/test/submission/submit/SubmissionAsyncTest.kt
+++ b/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/test/submission/submit/SubmissionAsyncTest.kt
@@ -3,6 +3,7 @@ package ac.uk.ebi.biostd.itest.test.submission.submit
 import ac.uk.ebi.biostd.client.exception.WebClientException
 import ac.uk.ebi.biostd.client.integration.commons.SubmissionFormat.TSV
 import ac.uk.ebi.biostd.client.integration.web.BioWebClient
+import ac.uk.ebi.biostd.integration.SubFormat.Companion.TSV_EXTENSION
 import ac.uk.ebi.biostd.itest.common.SecurityTestService
 import ac.uk.ebi.biostd.itest.entities.SuperUser
 import ac.uk.ebi.biostd.itest.itest.ITestListener.Companion.storageMode
@@ -56,12 +57,12 @@ import java.time.Duration.ofMillis
 @ExtendWith(SpringExtension::class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class SubmissionAsyncTest(
-    @Autowired val securityTestService: SecurityTestService,
-    @Autowired val requestRepository: SubmissionRequestPersistenceService,
-    @Autowired val submissionRepository: SubmissionPersistenceQueryService,
-    @Autowired val toSubmissionMapper: ToSubmissionMapper,
-    @Autowired val extSubmissionSubmitter: ExtSubmissionSubmitter,
-    @LocalServerPort val serverPort: Int,
+    @param:Autowired val securityTestService: SecurityTestService,
+    @param:Autowired val requestRepository: SubmissionRequestPersistenceService,
+    @param:Autowired val submissionRepository: SubmissionPersistenceQueryService,
+    @param:Autowired val toSubmissionMapper: ToSubmissionMapper,
+    @param:Autowired val extSubmissionSubmitter: ExtSubmissionSubmitter,
+    @param:LocalServerPort val serverPort: Int,
 ) {
     private lateinit var webClient: BioWebClient
 
@@ -182,7 +183,7 @@ class SubmissionAsyncTest(
 
             val result =
                 webClient.submitMultipartAsync(
-                    format = "tsv",
+                    format = TSV_EXTENSION,
                     submissions = mapOf("SMulti-001" to submission, "SMulti-002" to submission2),
                     files = mapOf("SMulti-001" to listOf(file), "SMulti-002" to listOf(file2, file3)),
                     parameters = SubmitParameters(storageMode = storageMode),
@@ -238,7 +239,7 @@ class SubmissionAsyncTest(
             val exception =
                 assertThrows<WebClientException> {
                     webClient.submitMultipartAsync(
-                        format = "tsv",
+                        format = TSV_EXTENSION,
                         submissions = mapOf("SMulti-004" to submission1, "SMulti-005" to submission2),
                         files = emptyMap(),
                         parameters = SubmitParameters(storageMode = storageMode),

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/web/handlers/SubmitWebHandler.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/web/handlers/SubmitWebHandler.kt
@@ -141,7 +141,7 @@ class SubmitWebHandler(
         }
 
         /**
-         * Deserialize the submission and check file presence in the list of sources.
+         * Deserialize the submission and check the files are present in the list of sources.
          */
         suspend fun deserializeSubmission(source: FileSourcesList): Submission =
             when (rqt) {


### PR DESCRIPTION
https://embl.atlassian.net/browse/BIOSTD-277

Adds validation to ensure file list extensions are of the allowed types (json, tsv, xlsx).

This prevents unnecessarily downloading big files, specially from the FTP partition
