### PR TITLE
BIOSTD-421: Skip Path Validation For Metadata Updates

### DIFF
--- a/commons/commons-bio/src/main/kotlin/ebi/ac/uk/io/sources/AdminUpdateFilesSource.kt
+++ b/commons/commons-bio/src/main/kotlin/ebi/ac/uk/io/sources/AdminUpdateFilesSource.kt
@@ -1,0 +1,22 @@
+package ebi.ac.uk.io.sources
+
+import ebi.ac.uk.extended.model.ExtAttribute
+import ebi.ac.uk.extended.model.ExtFile
+import java.io.File
+
+/**
+ * Source that allows the submitter to bypass the file path check. It's intended to be used ONLY by admins to update
+ * submissions made before the system started enforcing file path S3 compliance so existing data isn't affected.
+ */
+object AdminUpdateFilesSource : FilesSource {
+    override val description: String
+        get() = "Admin Metadata Update"
+
+    override suspend fun getExtFile(
+        path: String,
+        type: String,
+        attributes: List<ExtAttribute>,
+    ): ExtFile? = null
+
+    override suspend fun getFileList(path: String): File? = null
+}

--- a/commons/commons-bio/src/main/kotlin/ebi/ac/uk/io/sources/FileSourcesList.kt
+++ b/commons/commons-bio/src/main/kotlin/ebi/ac/uk/io/sources/FileSourcesList.kt
@@ -79,7 +79,7 @@ class SourcesList(
         attributes: List<ExtAttribute>,
         fileListName: String?,
     ): ExtFile? {
-        require(validPathPattern.matches(path)) { throw InvalidPathException(path, fileListName) }
+        validatePath(path, fileListName)
         return sources.firstNotNullOfOrNull { it.getExtFile(path, type, attributes) }
     }
 
@@ -96,7 +96,15 @@ class SourcesList(
         path: String,
         fileListName: String?,
     ): File? {
-        require(validPathPattern.matches(path)) { throw InvalidPathException(path, fileListName) }
+        validatePath(path, fileListName)
         return sources.firstNotNullOfOrNull { it.getFileList(path) }
+    }
+
+    private fun validatePath(
+        path: String,
+        fileListName: String?,
+    ) {
+        val canSkipCheck = sources.any { it.javaClass == AdminUpdateFilesSource::class.java }
+        require(canSkipCheck || validPathPattern.matches(path)) { throw InvalidPathException(path, fileListName) }
     }
 }

--- a/commons/commons-bio/src/test/kotlin/ebi/ac/uk/io/sources/SourcesListTest.kt
+++ b/commons/commons-bio/src/test/kotlin/ebi/ac/uk/io/sources/SourcesListTest.kt
@@ -19,9 +19,9 @@ import kotlin.test.assertFailsWith
 
 @ExtendWith(MockKExtension::class)
 internal class SourcesListTest(
-    @MockK private val file: ExtFile,
-    @MockK private val oneFileSource: FilesSource,
-    @MockK private val anotherFileSource: FilesSource,
+    @param:MockK private val file: ExtFile,
+    @param:MockK private val oneFileSource: FilesSource,
+    @param:MockK private val anotherFileSource: FilesSource,
 ) {
     private val testInstance = SourcesList(listOf(oneFileSource, anotherFileSource))
 
@@ -55,6 +55,17 @@ internal class SourcesListTest(
                 coEvery { oneFileSource.getExtFile(filePath, FILE_TYPE.value, attributes) } returns null
                 coEvery { anotherFileSource.getExtFile(filePath, FILE_TYPE.value, attributes) } returns null
                 assertThat(testInstance.findExtFile(filePath, FILE_TYPE.value, attributes)).isNull()
+            }
+
+        @Test
+        fun `admin metadata source skips path checks`() =
+            runTest {
+                val path = "folder/filé.txt"
+                val sourcesList = SourcesList(listOf(AdminUpdateFilesSource, oneFileSource))
+
+                coEvery { oneFileSource.getExtFile(path, FILE_TYPE.value, attributes) } returns file
+
+                assertThat(sourcesList.findExtFile(path, FILE_TYPE.value, attributes)).isEqualTo(file)
             }
     }
 

--- a/submission/file-sources/src/main/kotlin/uk/ac/ebi/io/builder/FilesSourceListBuilder.kt
+++ b/submission/file-sources/src/main/kotlin/uk/ac/ebi/io/builder/FilesSourceListBuilder.kt
@@ -4,6 +4,7 @@ import ac.uk.ebi.biostd.persistence.common.service.SubmissionFilesPersistenceSer
 import ebi.ac.uk.extended.model.ExtSubmission
 import ebi.ac.uk.extended.model.allInnerSubmissionFiles
 import ebi.ac.uk.ftp.FtpClient
+import ebi.ac.uk.io.sources.AdminUpdateFilesSource
 import ebi.ac.uk.io.sources.FileSourcesList
 import ebi.ac.uk.io.sources.FilesSource
 import ebi.ac.uk.io.sources.SourcesList
@@ -41,6 +42,10 @@ class FilesSourceListBuilder(
     fun buildFilesSourceList(builderAction: FilesSourceListBuilder.() -> Unit): FileSourcesList {
         this.sources.clear()
         return this.apply { builderAction() }.build()
+    }
+
+    fun addAdminMetadataFilesSource() {
+        sources.add(AdminUpdateFilesSource)
     }
 
     fun addDbFilesSource() {

--- a/submission/file-sources/src/main/kotlin/uk/ac/ebi/io/sources/DbFilesSource.kt
+++ b/submission/file-sources/src/main/kotlin/uk/ac/ebi/io/sources/DbFilesSource.kt
@@ -14,7 +14,7 @@ import ebi.ac.uk.model.constants.FileFields.DB_SIZE
 import java.io.File
 
 /**
- * Source that allows the submitter to use store files directly in fire and bypass backend mechanism.
+ * Source that allows the submitter to use files stored in FIRE and bypass the backend mechanism.
  */
 internal object DbFilesSource : FilesSource {
     override val description: String
@@ -27,7 +27,7 @@ internal object DbFilesSource : FilesSource {
     ): ExtFile? {
         val valuesMap = attributes.associateBy({ it.name }, { it.value })
         val dbFile = getDbFile(valuesMap)
-        return if (dbFile != null) return asFireFile(path, dbFile, attributes) else null
+        return if (dbFile != null) asFireFile(path, dbFile, attributes) else null
     }
 
     override suspend fun getFileList(path: String): File? = null

--- a/submission/persistence-common-api/src/main/kotlin/ac/uk/ebi/biostd/persistence/common/model/SubmissionRequest.kt
+++ b/submission/persistence-common-api/src/main/kotlin/ac/uk/ebi/biostd/persistence/common/model/SubmissionRequest.kt
@@ -93,7 +93,7 @@ data class SubmissionRequest(
     )
 
     /**
-     * Update request by setting new status, resetting current Index and updating modification date.
+     * Update the request by setting a new status, resetting the current Index and updating the modification date.
      */
     fun withNewStatus(status: RequestStatus): SubmissionRequest =
         copy(
@@ -105,7 +105,8 @@ data class SubmissionRequest(
     fun withErrors(errors: List<String>): SubmissionRequest = copy(errors = errors, status = INVALID)
 
     /**
-     * Update request by setting new status, resetting current Index, submission body and updating modification date.
+     * Update the request by setting a new status, resetting the current index, submission body, and updating the
+     * modification date.
      */
     fun withNewStatus(
         status: RequestStatus,
@@ -118,7 +119,7 @@ data class SubmissionRequest(
         )
 
     /**
-     * Create a Submission Request after indexing stage setting total files field.
+     * Create a Submission Request after the indexing stage setting the total files field.
      */
     fun indexed(totalFiles: Int): SubmissionRequest =
         copy(
@@ -143,7 +144,7 @@ data class SubmissionRequest(
 }
 
 /**
- * Retrieves the expected action to be performed when submission request is the given status.
+ * Retrieves the expected action to be performed when the submission request is the given status.
  */
 val RequestStatus.action: String
     get() {

--- a/submission/submission-core/src/main/kotlin/ac/uk/ebi/biostd/submission/config/GeneralConfig.kt
+++ b/submission/submission-core/src/main/kotlin/ac/uk/ebi/biostd/submission/config/GeneralConfig.kt
@@ -12,6 +12,7 @@ import ebi.ac.uk.coroutines.SuspendRetryTemplate
 import ebi.ac.uk.ftp.FtpClient
 import ebi.ac.uk.ftp.RetryFtpClient
 import ebi.ac.uk.paths.SubmissionFolderResolver
+import ebi.ac.uk.security.integration.components.IUserPrivilegesService
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -40,7 +41,10 @@ class GeneralConfig {
     fun filesSourceListBuilder(config: FilesSourceConfig): FilesSourceListBuilder = config.filesSourceListBuilder()
 
     @Bean
-    fun fileSourcesService(builder: FilesSourceListBuilder): FileSourcesService = FileSourcesService(builder)
+    fun fileSourcesService(
+        builder: FilesSourceListBuilder,
+        userPrivilegesService: IUserPrivilegesService,
+    ): FileSourcesService = FileSourcesService(builder, userPrivilegesService)
 
     @Bean
     fun extFilesResolver(properties: ApplicationProperties): FilesResolver = FilesResolver(File(properties.persistence.requestFilesPath))

--- a/submission/submission-core/src/main/kotlin/ac/uk/ebi/biostd/submission/domain/request/SubmissionRequestFilesValidator.kt
+++ b/submission/submission-core/src/main/kotlin/ac/uk/ebi/biostd/submission/domain/request/SubmissionRequestFilesValidator.kt
@@ -115,16 +115,17 @@ class SubmissionRequestFilesValidator(
         val request = submissionRequest.process!!
         val submission = request.submission
         val previous = request.previousVersion?.let { queryService.getExtByAccNoAndVersion(submission.accNo, it) }
-        var sourceRequest =
+        val sourceRequest =
             FileSourcesRequest(
                 folderType = FolderType.NFS,
                 onBehalfUser = submissionRequest.onBehalfUser?.let { securityService.getUser(it) },
                 files = submissionRequest.files,
                 submitter = securityService.getUser(submission.submitter),
                 rootPath = submission.rootPath,
-                submission = previous,
+                previousVersion = previous,
                 preferredSources = submissionRequest.preferredSources,
             )
+
         return fileSourcesService.submissionSources(sourceRequest)
     }
 }

--- a/submission/submission-core/src/main/kotlin/ac/uk/ebi/biostd/submission/service/FileSourcesService.kt
+++ b/submission/submission-core/src/main/kotlin/ac/uk/ebi/biostd/submission/service/FileSourcesService.kt
@@ -6,6 +6,7 @@ import ebi.ac.uk.io.sources.PreferredSource
 import ebi.ac.uk.io.sources.PreferredSource.SUBMISSION
 import ebi.ac.uk.io.sources.PreferredSource.USER_SPACE
 import ebi.ac.uk.paths.FolderType
+import ebi.ac.uk.security.integration.components.IUserPrivilegesService
 import ebi.ac.uk.security.integration.model.api.SecurityUser
 import uk.ac.ebi.io.builder.FilesSourceListBuilder
 import java.io.File
@@ -14,29 +15,34 @@ private val DEFAULT_SOURCES = listOf(USER_SPACE, SUBMISSION)
 
 class FileSourcesService(
     private val builder: FilesSourceListBuilder,
+    private val userPrivilegesService: IUserPrivilegesService,
 ) {
-    fun submissionSources(rqt: FileSourcesRequest): FileSourcesList {
+    suspend fun submissionSources(rqt: FileSourcesRequest): FileSourcesList {
         val folderType = rqt.folderType
         val onBehalfUser = rqt.onBehalfUser
         val submitter = rqt.submitter
         val files = rqt.files
         val rootPath = rqt.rootPath
-        val submission = rqt.submission
-        val preferred = rqt.preferredSources.ifEmpty { DEFAULT_SOURCES }
+        val sub = rqt.previousVersion
 
-        val sources =
-            builder.buildFilesSourceList {
-                if (submitter.superuser) addDbFilesSource()
-                if (files != null) addFilesListSource(files)
-                preferred.forEach {
-                    when (it) {
-                        USER_SPACE -> addUserSources(rootPath, onBehalfUser, submitter, folderType, this)
-                        SUBMISSION -> if (submission != null) addSubmissionSource(submission, folderType)
-                    }
+        if (rqt.isMetadataUpdate && userPrivilegesService.canSkipFilesValidation(submitter.email, sub!!.accNo)) {
+            return builder.buildFilesSourceList {
+                addAdminMetadataFilesSource()
+                addSubmissionSource(sub, folderType)
+            }
+        }
+
+        val preferred = rqt.preferredSources.ifEmpty { DEFAULT_SOURCES }
+        return builder.buildFilesSourceList {
+            if (submitter.superuser) addDbFilesSource()
+            if (files != null) addFilesListSource(files)
+            preferred.forEach {
+                when (it) {
+                    USER_SPACE -> addUserSources(rootPath, onBehalfUser, submitter, folderType, this)
+                    SUBMISSION -> if (sub != null) addSubmissionSource(sub, folderType)
                 }
             }
-
-        return sources
+        }
     }
 
     private fun addUserSources(
@@ -75,6 +81,9 @@ data class FileSourcesRequest(
     val submitter: SecurityUser,
     val files: List<File>?,
     val rootPath: String?,
-    val submission: ExtSubmission?,
+    val previousVersion: ExtSubmission?,
     val preferredSources: List<PreferredSource>,
-)
+) {
+    val isMetadataUpdate: Boolean
+        get() = previousVersion != null && preferredSources.size == 1 && preferredSources.first() == SUBMISSION
+}

--- a/submission/submission-core/src/main/kotlin/ac/uk/ebi/biostd/submission/validator/filelist/FileListValidator.kt
+++ b/submission/submission-core/src/main/kotlin/ac/uk/ebi/biostd/submission/validator/filelist/FileListValidator.kt
@@ -39,7 +39,7 @@ class FileListValidator(
                 submitter = submitter,
                 files = null,
                 rootPath = rootPath,
-                submission = submission,
+                previousVersion = submission,
                 preferredSources = emptyList(),
             )
         val fileSources = fileSourcesService.submissionSources(fileSourcesRequest)

--- a/submission/submission-core/src/test/kotlin/ac/uk/ebi/biostd/submission/service/FileSourcesServiceTest.kt
+++ b/submission/submission-core/src/test/kotlin/ac/uk/ebi/biostd/submission/service/FileSourcesServiceTest.kt
@@ -7,6 +7,7 @@ import ebi.ac.uk.io.sources.PreferredSource.SUBMISSION
 import ebi.ac.uk.io.sources.SourcesList
 import ebi.ac.uk.paths.FolderType
 import ebi.ac.uk.paths.SubmissionFolderResolver
+import ebi.ac.uk.security.integration.components.IUserPrivilegesService
 import ebi.ac.uk.security.integration.model.api.GroupFolder
 import ebi.ac.uk.security.integration.model.api.NfsUserFolder
 import ebi.ac.uk.security.integration.model.api.SecurityUser
@@ -14,9 +15,11 @@ import ebi.ac.uk.test.basicExtSubmission
 import io.github.glytching.junit.extension.folder.TemporaryFolder
 import io.github.glytching.junit.extension.folder.TemporaryFolderExtension
 import io.mockk.clearAllMocks
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
+import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -30,17 +33,18 @@ import java.time.LocalDateTime
 @ExtendWith(MockKExtension::class, TemporaryFolderExtension::class)
 class FileSourcesServiceTest(
     tempFolder: TemporaryFolder,
-    @MockK private val fireClient: FireClient,
-    @MockK private val subFtp: FtpClient,
-    @MockK private val ftpClient: FtpClient,
-    @MockK private val filesRepo: SubmissionFilesPersistenceService,
-    @MockK private val folderResolver: SubmissionFolderResolver,
+    @param:MockK private val fireClient: FireClient,
+    @param:MockK private val subFtp: FtpClient,
+    @param:MockK private val ftpClient: FtpClient,
+    @param:MockK private val filesRepo: SubmissionFilesPersistenceService,
+    @param:MockK private val folderResolver: SubmissionFolderResolver,
+    @param:MockK private val userPrivilegesService: IUserPrivilegesService,
 ) {
     private val tempFile = tempFolder.createFile("test.txt")
     private val filesFolder = tempFolder.createDirectory("files")
     private val subFolder = tempFolder.createDirectory("submissions")
     private val builder = FilesSourceListBuilder(folderResolver, fireClient, ftpClient, subFtp, filesRepo)
-    private val testInstance = FileSourcesService(builder)
+    private val testInstance = FileSourcesService(builder, userPrivilegesService)
     private val extSubmission = basicExtSubmission.copy(storageMode = StorageMode.FIRE)
 
     @AfterEach
@@ -52,101 +56,132 @@ class FileSourcesServiceTest(
     }
 
     @Test
-    fun `default submission sources with FIRE submission`() {
-        val request =
-            FileSourcesRequest(
-                folderType = FolderType.NFS,
-                onBehalfUser = onBehalfUser(),
-                submitter = submitter(),
-                files = listOf(tempFile),
-                rootPath = "root-path",
-                submission = extSubmission,
-                preferredSources = emptyList(),
-            )
+    fun `default submission sources with FIRE submission`() =
+        runTest {
+            val request =
+                FileSourcesRequest(
+                    folderType = FolderType.NFS,
+                    onBehalfUser = onBehalfUser(),
+                    submitter = submitter(),
+                    files = listOf(tempFile),
+                    rootPath = "root-path",
+                    previousVersion = extSubmission,
+                    preferredSources = emptyList(),
+                )
 
-        val fileSources = testInstance.submissionSources(request) as SourcesList
+            val fileSources = testInstance.submissionSources(request) as SourcesList
 
-        val sources = fileSources.sources
-        assertThat(sources).hasSize(7)
-        assertThat(sources[0].description).isEqualTo("Provided Db files")
-        assertThat(sources[1].description).isEqualTo("Request files [test.txt]")
-        assertThat(sources[2].description).isEqualTo("admin_user@ebi.ac.uk user files in /root-path")
-        assertThat(sources[3].description).isEqualTo("Group 'Test Group' files")
-        assertThat(sources[4].description).isEqualTo("regular@ebi.ac.uk user files in /root-path")
-        assertThat(sources[5].description).isEqualTo("Group 'Test Group' files")
-        assertThat(sources[6].description).isEqualTo("Previous version files [File System]")
-    }
-
-    @Test
-    fun `default submission sources with NFS submission`() {
-        val request =
-            FileSourcesRequest(
-                folderType = FolderType.NFS,
-                onBehalfUser = onBehalfUser(),
-                submitter = submitter(),
-                files = listOf(tempFile),
-                rootPath = "root-path",
-                submission = extSubmission,
-                preferredSources = emptyList(),
-            )
-
-        val fileSources = testInstance.submissionSources(request) as SourcesList
-
-        val sources = fileSources.sources
-        assertThat(sources).hasSize(7)
-        assertThat(sources[0].description).isEqualTo("Provided Db files")
-        assertThat(sources[1].description).isEqualTo("Request files [test.txt]")
-        assertThat(sources[2].description).isEqualTo("admin_user@ebi.ac.uk user files in /root-path")
-        assertThat(sources[3].description).isEqualTo("Group 'Test Group' files")
-        assertThat(sources[4].description).isEqualTo("regular@ebi.ac.uk user files in /root-path")
-        assertThat(sources[5].description).isEqualTo("Group 'Test Group' files")
-        assertThat(sources[6].description).isEqualTo("Previous version files [File System]")
-    }
+            val sources = fileSources.sources
+            assertThat(sources).hasSize(7)
+            assertThat(sources[0].description).isEqualTo("Provided Db files")
+            assertThat(sources[1].description).isEqualTo("Request files [test.txt]")
+            assertThat(sources[2].description).isEqualTo("admin_user@ebi.ac.uk user files in /root-path")
+            assertThat(sources[3].description).isEqualTo("Group 'Test Group' files")
+            assertThat(sources[4].description).isEqualTo("regular@ebi.ac.uk user files in /root-path")
+            assertThat(sources[5].description).isEqualTo("Group 'Test Group' files")
+            assertThat(sources[6].description).isEqualTo("Previous version files [File System]")
+        }
 
     @Test
-    fun `default submission sources with no onBehalfUser`() {
-        val request =
-            FileSourcesRequest(
-                folderType = FolderType.NFS,
-                onBehalfUser = null,
-                submitter = submitter(),
-                files = listOf(tempFile),
-                rootPath = "root-path",
-                submission = extSubmission,
-                preferredSources = emptyList(),
-            )
+    fun `default submission sources with NFS submission`() =
+        runTest {
+            val request =
+                FileSourcesRequest(
+                    folderType = FolderType.NFS,
+                    onBehalfUser = onBehalfUser(),
+                    submitter = submitter(),
+                    files = listOf(tempFile),
+                    rootPath = "root-path",
+                    previousVersion = extSubmission,
+                    preferredSources = emptyList(),
+                )
 
-        val fileSources = testInstance.submissionSources(request) as SourcesList
+            val fileSources = testInstance.submissionSources(request) as SourcesList
 
-        val sources = fileSources.sources
-        assertThat(sources).hasSize(5)
-        assertThat(sources[0].description).isEqualTo("Provided Db files")
-        assertThat(sources[1].description).isEqualTo("Request files [test.txt]")
-        assertThat(sources[2].description).isEqualTo("admin_user@ebi.ac.uk user files in /root-path")
-        assertThat(sources[3].description).isEqualTo("Group 'Test Group' files")
-        assertThat(sources[4].description).isEqualTo("Previous version files [File System]")
-    }
+            val sources = fileSources.sources
+            assertThat(sources).hasSize(7)
+            assertThat(sources[0].description).isEqualTo("Provided Db files")
+            assertThat(sources[1].description).isEqualTo("Request files [test.txt]")
+            assertThat(sources[2].description).isEqualTo("admin_user@ebi.ac.uk user files in /root-path")
+            assertThat(sources[3].description).isEqualTo("Group 'Test Group' files")
+            assertThat(sources[4].description).isEqualTo("regular@ebi.ac.uk user files in /root-path")
+            assertThat(sources[5].description).isEqualTo("Group 'Test Group' files")
+            assertThat(sources[6].description).isEqualTo("Previous version files [File System]")
+        }
 
     @Test
-    fun `submission sources with preferred sources`() {
-        val request =
-            FileSourcesRequest(
-                folderType = FolderType.NFS,
-                onBehalfUser = null,
-                submitter = submitter(),
-                files = null,
-                rootPath = null,
-                submission = extSubmission,
-                preferredSources = listOf(SUBMISSION),
-            )
+    fun `default submission sources with no onBehalfUser`() =
+        runTest {
+            val request =
+                FileSourcesRequest(
+                    folderType = FolderType.NFS,
+                    onBehalfUser = null,
+                    submitter = submitter(),
+                    files = listOf(tempFile),
+                    rootPath = "root-path",
+                    previousVersion = extSubmission,
+                    preferredSources = emptyList(),
+                )
 
-        val fileSources = testInstance.submissionSources(request) as SourcesList
+            val fileSources = testInstance.submissionSources(request) as SourcesList
 
-        val sources = fileSources.sources
-        assertThat(sources).hasSize(2)
-        assertThat(sources[0].description).isEqualTo("Provided Db files")
-        assertThat(sources[1].description).isEqualTo("Previous version files [File System]")
-    }
+            val sources = fileSources.sources
+            assertThat(sources).hasSize(5)
+            assertThat(sources[0].description).isEqualTo("Provided Db files")
+            assertThat(sources[1].description).isEqualTo("Request files [test.txt]")
+            assertThat(sources[2].description).isEqualTo("admin_user@ebi.ac.uk user files in /root-path")
+            assertThat(sources[3].description).isEqualTo("Group 'Test Group' files")
+            assertThat(sources[4].description).isEqualTo("Previous version files [File System]")
+        }
+
+    @Test
+    fun `submission sources with preferred sources`() =
+        runTest {
+            val request =
+                FileSourcesRequest(
+                    folderType = FolderType.NFS,
+                    onBehalfUser = null,
+                    submitter = submitter(),
+                    files = null,
+                    rootPath = null,
+                    previousVersion = extSubmission,
+                    preferredSources = listOf(SUBMISSION),
+                )
+
+            coEvery { userPrivilegesService.canSkipFilesValidation(submitter().email, extSubmission.accNo) } returns false
+
+            val fileSources = testInstance.submissionSources(request) as SourcesList
+
+            val sources = fileSources.sources
+            assertThat(sources).hasSize(2)
+            assertThat(sources[0].description).isEqualTo("Provided Db files")
+            assertThat(sources[1].description).isEqualTo("Previous version files [File System]")
+        }
+
+    @Test
+    fun `metadata update sources for privileged user skip path validation`() =
+        runTest {
+            val submitter = submitter()
+            val request =
+                FileSourcesRequest(
+                    folderType = FolderType.NFS,
+                    onBehalfUser = onBehalfUser(),
+                    submitter = submitter,
+                    files = listOf(tempFile),
+                    rootPath = "root-path",
+                    previousVersion = extSubmission,
+                    preferredSources = listOf(SUBMISSION),
+                )
+
+            coEvery { userPrivilegesService.canSkipFilesValidation(submitter.email, extSubmission.accNo) } returns true
+
+            val fileSources = testInstance.submissionSources(request) as SourcesList
+
+            val sources = fileSources.sources
+            assertThat(sources).hasSize(2)
+            assertThat(sources[0].description).isEqualTo("Admin Metadata Update")
+            assertThat(sources[1].description).isEqualTo("Previous version files [File System]")
+        }
 
     private fun submitter(): SecurityUser {
         val userFolder =

--- a/submission/submission-core/src/test/kotlin/ac/uk/ebi/biostd/submission/validator/filelist/FileListValidatorTest.kt
+++ b/submission/submission-core/src/test/kotlin/ac/uk/ebi/biostd/submission/validator/filelist/FileListValidatorTest.kt
@@ -23,7 +23,6 @@ import io.mockk.called
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.slot
@@ -38,10 +37,10 @@ import org.junit.jupiter.api.extension.ExtendWith
 @ExtendWith(MockKExtension::class, TemporaryFolderExtension::class)
 class FileListValidatorTest(
     private val tempFolder: TemporaryFolder,
-    @MockK private val extFile: ExtFile,
-    @MockK private val source: FilesSource,
-    @MockK private val fileSourcesService: FileSourcesService,
-    @MockK private val submissionQueryService: SubmissionPersistenceQueryService,
+    @param:MockK private val extFile: ExtFile,
+    @param:MockK private val source: FilesSource,
+    @param:MockK private val fileSourcesService: FileSourcesService,
+    @param:MockK private val submissionQueryService: SubmissionPersistenceQueryService,
 ) {
     private val serializationService = SerializationConfig.serializationService()
     private val filesSource = SourcesList(listOf(source))
@@ -71,7 +70,7 @@ class FileListValidatorTest(
 
         coEvery { source.getFileList("valid.tsv") } returns valid
         coEvery { submissionQueryService.findExtByAccNo("S-BSST0") } returns extSubmission
-        every { fileSourcesService.submissionSources(capture(fileSourcesSlot)) } returns filesSource
+        coEvery { fileSourcesService.submissionSources(capture(fileSourcesSlot)) } returns filesSource
 
         val request = FileListValidationRequest("S-BSST0", "root-path", "valid.tsv", submitter, onBehalfUser)
         testInstance.validateFileList(request)
@@ -81,7 +80,7 @@ class FileListValidatorTest(
         assertThat(fileSourceRequest.preferredSources).isEmpty()
         assertThat(fileSourceRequest.submitter).isEqualTo(submitter)
         assertThat(fileSourceRequest.rootPath).isEqualTo("root-path")
-        assertThat(fileSourceRequest.submission).isEqualTo(extSubmission)
+        assertThat(fileSourceRequest.previousVersion).isEqualTo(extSubmission)
         assertThat(fileSourceRequest.onBehalfUser).isEqualTo(onBehalfUser)
 
         coVerify(exactly = 1) {
@@ -100,7 +99,7 @@ class FileListValidatorTest(
 
         coEvery { source.getFileList("fail.xlsx") } returns invalid
         coEvery { submissionQueryService.findExtByAccNo("S-BSST0") } returns extSubmission
-        every { fileSourcesService.submissionSources(capture(fileSourcesSlot)) } returns filesSource
+        coEvery { fileSourcesService.submissionSources(capture(fileSourcesSlot)) } returns filesSource
         coEvery { source.getExtFile("ghost.txt", "file", listOf(ExtAttribute("Type", "fail"))) } returns null
 
         excel(invalid) {
@@ -126,13 +125,13 @@ class FileListValidatorTest(
         val fileSourceRequest = fileSourcesSlot.captured
         assertThat(fileSourceRequest.files).isNull()
         assertThat(fileSourceRequest.rootPath).isNull()
-        assertThat(fileSourceRequest.submission).isNull()
+        assertThat(fileSourceRequest.previousVersion).isNull()
         assertThat(fileSourceRequest.onBehalfUser).isNull()
         assertThat(fileSourceRequest.preferredSources).isEmpty()
         assertThat(fileSourceRequest.submitter).isEqualTo(submitter)
 
         coVerify(exactly = 0) { submissionQueryService.findExtByAccNo("S-BSST0") }
-        verify(exactly = 1) { fileSourcesService.submissionSources(fileSourceRequest) }
+        coVerify(exactly = 1) { fileSourcesService.submissionSources(fileSourceRequest) }
     }
 
     @Test
@@ -144,7 +143,7 @@ class FileListValidatorTest(
         val empty = tempFolder.createFile("empty.tsv", "Files\tType")
 
         coEvery { source.getFileList("empty.tsv") } returns empty
-        every { fileSourcesService.submissionSources(capture(fileSourcesSlot)) } returns filesSource
+        coEvery { fileSourcesService.submissionSources(capture(fileSourcesSlot)) } returns filesSource
 
         val request = FileListValidationRequest(null, null, "empty.tsv", submitter, onBehalfUser)
         val exception = assertThrows<InvalidFileListException> { testInstance.validateFileList(request) }

--- a/submission/submission-security/src/main/kotlin/ebi/ac/uk/security/integration/components/IUserPrivilegesService.kt
+++ b/submission/submission-security/src/main/kotlin/ebi/ac/uk/security/integration/components/IUserPrivilegesService.kt
@@ -53,4 +53,9 @@ interface IUserPrivilegesService {
         email: String,
         accNo: String,
     ): Boolean
+
+    suspend fun canSkipFilesValidation(
+        email: String,
+        accNo: String,
+    ): Boolean
 }

--- a/submission/submission-security/src/main/kotlin/ebi/ac/uk/security/service/UserPrivilegesService.kt
+++ b/submission/submission-security/src/main/kotlin/ebi/ac/uk/security/service/UserPrivilegesService.kt
@@ -43,12 +43,16 @@ internal class UserPrivilegesService(
         accessType: AccessType,
     ): List<String> =
         when {
-            isSuperUser(email) -> tagsDataRepository.findAll().map { it.name }
-            else ->
+            isSuperUser(email) -> {
+                tagsDataRepository.findAll().map { it.name }
+            }
+
+            else -> {
                 permissionsService
                     .allowedTags(email, accessType)
                     .map { it.accessTag.name }
                     .distinct()
+            }
         }
 
     override suspend fun canResubmit(
@@ -84,6 +88,11 @@ internal class UserPrivilegesService(
         }
 
     override suspend fun canTransferSubmission(
+        email: String,
+        accNo: String,
+    ): Boolean = isSuperUser(email) || isCollectionAdmin(email, accNo)
+
+    override suspend fun canSkipFilesValidation(
         email: String,
         accNo: String,
     ): Boolean = isSuperUser(email) || isCollectionAdmin(email, accNo)

--- a/submission/submission-security/src/test/kotlin/ebi/ac/uk/security/service/UserPrivilegesServiceTest.kt
+++ b/submission/submission-security/src/test/kotlin/ebi/ac/uk/security/service/UserPrivilegesServiceTest.kt
@@ -26,14 +26,14 @@ import ac.uk.ebi.biostd.persistence.model.DbUser as UserDB
 
 @ExtendWith(MockKExtension::class)
 class UserPrivilegesServiceTest(
-    @MockK private val author: UserDB,
-    @MockK private val otherAuthor: UserDB,
-    @MockK private val user: UserDB,
-    @MockK private val basicSubmission: BasicSubmission,
-    @MockK private val userRepository: UserDataRepository,
-    @MockK private val queryService: SubmissionMetaQueryService,
-    @MockK private val tagsDataRepository: AccessTagDataRepo,
-    @MockK private val userPermissionsService: UserPermissionsService,
+    @param:MockK private val author: UserDB,
+    @param:MockK private val otherAuthor: UserDB,
+    @param:MockK private val user: UserDB,
+    @param:MockK private val basicSubmission: BasicSubmission,
+    @param:MockK private val userRepository: UserDataRepository,
+    @param:MockK private val queryService: SubmissionMetaQueryService,
+    @param:MockK private val tagsDataRepository: AccessTagDataRepo,
+    @param:MockK private val userPermissionsService: UserPermissionsService,
 ) {
     private val testInstance =
         UserPrivilegesService(userRepository, tagsDataRepository, queryService, userPermissionsService)
@@ -227,6 +227,19 @@ class UserPrivilegesServiceTest(
         every { userPermissionsService.hasPermission("superuser@mail.com", "any_project", ADMIN) } returns true
         assertThat(testInstance.canUpdateReleaseDate("superuser@mail.com", "any_project")).isTrue()
     }
+
+    @Test
+    fun `can skip files validation for superuser and collection admin only`() =
+        runTest {
+            assertThat(testInstance.canSkipFilesValidation("superuser@mail.com", "accNo")).isTrue()
+
+            coEvery { queryService.getCollections("accNo") } returns listOf("A-Collection")
+            every { userPermissionsService.isAdmin("author@mail.com", "A-Collection") } returns true
+            assertThat(testInstance.canSkipFilesValidation("author@mail.com", "accNo")).isTrue()
+
+            every { userPermissionsService.isAdmin("otherAuthor@mail.com", "A-Collection") } returns false
+            assertThat(testInstance.canSkipFilesValidation("otherAuthor@mail.com", "accNo")).isFalse()
+        }
 
     private fun initUsers() {
         every { user.id } returns 123

--- a/submission/submission-webapp/src/itest/itestsInventory.md
+++ b/submission/submission-webapp/src/itest/itestsInventory.md
@@ -74,7 +74,7 @@ Contains permissions API test.
 
 ## File List Test Suite
 
-Contains test related to file list.
+Contains test related to the file list functionality.
 
 | Class                  | Test No | Test name                                                         |
 |------------------------|---------|-------------------------------------------------------------------|
@@ -140,14 +140,14 @@ Contains test related to submission
 
 Contains test related to resubmission
 
-| Class               | Test No | Test name                                      |
-|---------------------|---------|------------------------------------------------|
-| ResubmissionApiTest | 5-1     | Resubmit study updating a file content         |
-| ResubmissionApiTest | 5-2     | Resubmit study with the same files             |
-| ResubmissionApiTest | 5-3     | Resubmit study with rootPath                   |
-| ResubmissionApiTest | 5-4     | Resubmit study updating only metadata          |
-| ResubmissionApiTest | 5-5     | Resubmit study adding new files                |
-| ResubmissionApiTest | 5-6     | Resubmit study currenlty being flag as invalid |
+| Class               | Test No | Test name                                         |
+|---------------------|---------|---------------------------------------------------|
+| ResubmissionApiTest | 5-1     | Resubmit study updating a file content            |
+| ResubmissionApiTest | 5-2     | Resubmit study with the same files                |
+| ResubmissionApiTest | 5-3     | Resubmit study with rootPath                      |
+| ResubmissionApiTest | 5-4     | Resubmit study updating only metadata             |
+| ResubmissionApiTest | 5-5     | Resubmit study adding new files                   |
+| ResubmissionApiTest | 5-6     | Resubmit study currenlty being flagged as invalid |
 
 ### Stats Test suite
 

--- a/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/test/submission/submit/ResubmissionApiTest.kt
+++ b/submission/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/test/submission/submit/ResubmissionApiTest.kt
@@ -366,7 +366,7 @@ class ResubmissionApiTest(
         }
 
     @Test
-    fun `5-6 Resubmit study currenlty being flag as invalid`() =
+    fun `5-6 Resubmit study currenlty being flagged as invalid`() =
         runTest {
             val version1 =
                 tsv {

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/web/handlers/SubmitWebHandler.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/submission/web/handlers/SubmitWebHandler.kt
@@ -181,11 +181,11 @@ class SubmitWebHandler(
                 files = requestFiles,
                 onBehalfUser = onBehalfUser,
                 rootPath = rootPath,
-                submission = previous,
+                previousVersion = previous,
                 preferredSources = preferredSources,
             )
 
-        fun getSources(sourceRequest: FileSourcesRequest): FileSourcesList =
+        suspend fun getSources(sourceRequest: FileSourcesRequest): FileSourcesList =
             when (appProperties.asyncMode) {
                 true -> ByPassSourceList(fileSourcesService.submissionSources(sourceRequest))
                 false -> fileSourcesService.submissionSources(sourceRequest)
@@ -196,7 +196,7 @@ class SubmitWebHandler(
          *
          * 1. AccNo, RootPath attributes are extracted from the submission.
          * 2. Submission file sources are obtained.
-         * 3. Submission is deserialized including file sources to check both pagetab structure and file presence.
+         * 3. Submission is deserialized, including file sources, to check both pagetab structure and file presence.
          * 4. Overridden attributes are set.
          * 5. AccNo and version are calculated.
          * 6. Request draft is created if it doesn't exist.


### PR DESCRIPTION
https://embl.atlassian.net/browse/BIOSTD-421

- Introduces a mechanism for superusers and collection administrators to bypass file path compliance checks when updating metadata for existing submissions.
-  This is necessary for managing legacy submissions that may contain non-S3 compliant file paths.
- Adds `AdminUpdateFilesSource` as a flag and integrates privilege checks in the file source resolution.
