### PR TITLE
BIOSTD-406: Automated User Space Clean Up

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,10 @@
 - itest-fire: unset ITEST_FAIL_FACTOR && ./gradlew clean :submission:submission-webapp:itest -PenableFire=true --rerun-tasks
 - itest-chaos: export ITEST_FAIL_FACTOR=8 && ./gradlew clean :submission:submission-webapp:itest -PenableFire=true --rerun-tasks
 
+## Skills Used
+- grill-with-docs: used to clarify and document the user-space cleanup design.
+- domain-modeling: requested through grill-with-docs; not installed locally, so the design was modeled from repository code and captured in ADR/glossary docs.
+
 ## Definition of Done
 Before marking the work as complete:
 

--- a/docs/adr/0001-user-space-auto-cleanup.md
+++ b/docs/adr/0001-user-space-auto-cleanup.md
@@ -1,0 +1,76 @@
+# ADR 0001: Automatic user space cleanup
+
+## Status
+
+Proposed
+
+## Context
+
+BioStudies tracks each user's `lastActivity` in SQL. Cleanup notification logic already uses
+`ApplicationProperties.cleanUp.cleanUpPeriodDays` and the warning day properties to notify users whose private
+workspace has been inactive for configured periods.
+
+The web application already has a daily scheduled cleanup notification process in `OperationsScheduler`, and the
+submission task application can run cleanup notification work remotely through `RemoteSubmitterExecutor` and the
+cluster client.
+
+The missing behavior is automatic deletion of files from inactive user spaces. The requirement is:
+
+- run once per day;
+- find users whose `lastActivity` is at least `cleanUpPeriodDays` days old;
+- dispatch a cluster job for each matching user;
+- delete all files in that user's user space.
+
+## Decision
+
+Use the existing cleanup boundary and cluster task infrastructure:
+
+- extend `LocalUserSpaceCleanUpService` with two responsibilities:
+  - discover active users eligible for cleanup using an exact cutoff day derived from
+    `today - cleanUpPeriodDays`;
+  - skip users whose user space is empty;
+  - clean a single user's user-space folder by email;
+- extend `ExtUserSpaceCleanUpService.CleanUpMode.CLEAN_UP` to:
+  - discover eligible users locally when invoked by the web scheduler;
+  - submit one cluster task per eligible user with an email argument;
+- add a new task mode, for example `CLEAN_UP_USER_SPACE`, that runs in `submission-task` and deletes the single
+  user's files on the cluster filesystem;
+- schedule cleanup separately from notifications in `OperationsScheduler`, behind `app.cleanup.enabled`, close to the
+  end of the day.
+
+Cleanup deletes the contents of `SecurityUser.userFolder.path`, including nested and hidden files, while preserving the
+root user folder itself.
+
+The deletion task does not re-check eligibility before deleting. Users receive three warning emails before the cleanup
+date, and the cleanup job is intentionally scheduled near the end of that date.
+
+Add Mongo audit documents alongside the existing notification audit documents:
+
+- `DocCleanUpLog` for successful scheduler dispatch records, including:
+  - exact date-time when cleanup is started at scheduler dispatch time;
+  - cluster job id;
+  - user email;
+  - user `lastActivity` at the time cleanup is selected;
+  - absolute path to the user space.
+- `DocCleanUpError` for any error while trying to cleanup, including:
+  - error message;
+  - cluster job id when available;
+  - user email when available;
+  - absolute path to the user space when available.
+
+Create `cleanup_logs` and `cleanup_errors` collections through the Mongo migration flow in `DatabaseChangeLog.kt`,
+following the `notification_logs` and `notification_errors` pattern. Add a background index on `email` only for each
+cleanup collection.
+
+Use `LocalDate.now()` for cutoff calculation, matching the existing cleanup notification implementation.
+
+## Consequences
+
+- The web scheduler remains the orchestrator and the cluster performs filesystem deletion.
+- Per-user jobs isolate failures and make logs easier to correlate to one account.
+- The task must be idempotent: an empty or missing folder should not cause repeated harmful failures.
+- Only active users are considered for cleanup.
+- Users with empty user spaces are skipped and no cleanup job is dispatched for them.
+- Exact cutoff discovery avoids repeatedly dispatching cleanup jobs for older users on every daily run.
+- Failed cleanup attempts are captured in Mongo for later operational decisions.
+- One cluster job per user is accepted because the expected matching population per day is small.

--- a/docs/adr/0001-user-space-auto-cleanup.md
+++ b/docs/adr/0001-user-space-auto-cleanup.md
@@ -18,7 +18,7 @@ The missing behavior is automatic deletion of files from inactive user spaces. T
 
 - run once per day;
 - find users whose `lastActivity` is at least `cleanUpPeriodDays` days old;
-- dispatch a cluster job for each matching user;
+- dispatch a data-mover cluster job for each matching user;
 - delete all files in that user's user space.
 
 ## Decision
@@ -29,12 +29,10 @@ Use the existing cleanup boundary and cluster task infrastructure:
   - discover active users eligible for cleanup using an exact cutoff day derived from
     `today - cleanUpPeriodDays`;
   - skip users whose user space is empty;
-  - clean a single user's user-space folder by email;
+  - submit one data-mover cluster job per eligible user;
 - extend `ExtUserSpaceCleanUpService.CleanUpMode.CLEAN_UP` to:
-  - discover eligible users locally when invoked by the web scheduler;
-  - submit one cluster task per eligible user with an email argument;
-- add a new task mode, for example `CLEAN_UP_USER_SPACE`, that runs in `submission-task` and deletes the single
-  user's files on the cluster filesystem;
+  - execute the cleanup flow locally when invoked by the submission task;
+  - execute the cleanup flow remotely through a submission-task cluster job when invoked by the web scheduler;
 - schedule cleanup separately from notifications in `OperationsScheduler`, behind `app.cleanup.enabled`, close to the
   end of the day.
 
@@ -55,8 +53,8 @@ Add Mongo audit documents alongside the existing notification audit documents:
 - `DocCleanUpError` for any error while trying to cleanup, including:
   - error message;
   - cluster job id when available;
-  - user email when available;
-  - absolute path to the user space when available.
+  - user email;
+  - absolute path to the user space.
 
 Create `cleanup_logs` and `cleanup_errors` collections through the Mongo migration flow in `DatabaseChangeLog.kt`,
 following the `notification_logs` and `notification_errors` pattern. Add a background index on `email` only for each

--- a/docs/glossary/user-space-cleanup.md
+++ b/docs/glossary/user-space-cleanup.md
@@ -27,11 +27,11 @@ space is not empty.
 
 ## Cleanup dispatch
 
-The orchestration step that submits one cluster job per eligible user.
+The orchestration step that submits one data-mover cluster job per eligible user.
 
 ## Cleanup task
 
-The cluster-executed task that deletes files for a single user's workspace.
+The cluster-executed command that deletes files for a single user's workspace.
 
 ## Root user folder
 
@@ -47,8 +47,8 @@ cluster job id, user email, the user's `lastActivity` at selection time, and the
 ## Cleanup error
 
 Mongo document proposed as `DocCleanUpError`. Records failures that happen while trying to cleanup a user's workspace,
-including the error message, cluster job id when available, user email when available, and absolute path to the user
-space when available. The `cleanup_errors` collection has an `email` index.
+including the error message, cluster job id when available, user email, and absolute path to the user space. The
+`cleanup_errors` collection has an `email` index.
 
 ## Exact cutoff
 

--- a/docs/glossary/user-space-cleanup.md
+++ b/docs/glossary/user-space-cleanup.md
@@ -1,0 +1,62 @@
+# User space cleanup glossary
+
+## User space
+
+The private upload workspace associated with a BioStudies user. In code this is exposed through
+`SecurityUser.userFolder`.
+
+## Last activity
+
+The `DbUser.lastActivity` timestamp updated when a user authenticates or performs tracked security activity. Cleanup
+eligibility is calculated from this value.
+
+## Cleanup period
+
+The configured number of days after `lastActivity` when a user's private workspace becomes eligible for deletion.
+Configured as `app.cleanup.cleanUpPeriodDays`.
+
+## Cleanup notification
+
+An email warning sent before deletion. Existing warning thresholds are configured by `firstWarningDays`,
+`secondWarningDays`, and `thirdWarningDays`.
+
+## Cleanup discovery
+
+The daily process that finds active users whose `lastActivity` falls exactly on the cleanup cutoff day and whose user
+space is not empty.
+
+## Cleanup dispatch
+
+The orchestration step that submits one cluster job per eligible user.
+
+## Cleanup task
+
+The cluster-executed task that deletes files for a single user's workspace.
+
+## Root user folder
+
+The directory represented by `SecurityUser.userFolder.path`. The proposed cleanup deletes the contents of this
+directory, not the directory itself, unless the policy is changed explicitly.
+
+## Cleanup log
+
+Mongo document proposed as `DocCleanUpLog`. Records scheduler dispatch information, including cleanup date-time,
+cluster job id, user email, the user's `lastActivity` at selection time, and the absolute path to the user space. The
+`cleanup_logs` collection has an `email` index.
+
+## Cleanup error
+
+Mongo document proposed as `DocCleanUpError`. Records failures that happen while trying to cleanup a user's workspace,
+including the error message, cluster job id when available, user email when available, and absolute path to the user
+space when available. The `cleanup_errors` collection has an `email` index.
+
+## Exact cutoff
+
+The cleanup policy where only users whose `lastActivity` falls on `today - cleanUpPeriodDays` are selected. Older users
+are not repeatedly selected on every later daily run. The cutoff uses `LocalDate.now()`, matching the existing cleanup
+notification implementation.
+
+## Empty user space
+
+A user folder with no files to delete. These users are skipped during cleanup discovery and no cluster cleanup job is
+dispatched for them.

--- a/submission/persistence-common-api/src/main/kotlin/ac/uk/ebi/biostd/persistence/common/service/CleanUpLogDataService.kt
+++ b/submission/persistence-common-api/src/main/kotlin/ac/uk/ebi/biostd/persistence/common/service/CleanUpLogDataService.kt
@@ -1,0 +1,19 @@
+package ac.uk.ebi.biostd.persistence.common.service
+
+import java.time.LocalDateTime
+
+interface CleanUpLogDataService {
+    suspend fun logCleanUp(
+        email: String,
+        jobId: String,
+        lastActivity: LocalDateTime,
+        userSpacePath: String,
+    )
+
+    suspend fun logCleanUpError(
+        email: String,
+        errorMessage: String,
+        userSpacePath: String,
+        jobId: String? = null,
+    )
+}

--- a/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/db/converters/shared/ConverterCommonsFields.kt
+++ b/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/db/converters/shared/ConverterCommonsFields.kt
@@ -210,3 +210,7 @@ object DocStatsFields {
 object DocNotificationFields {
     const val NOTIFICATION_KEY = "key"
 }
+
+object DocCleanUpFields {
+    const val CLEANUP_EMAIL = "email"
+}

--- a/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/db/reactive/repositories/Repositories.kt
+++ b/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/db/reactive/repositories/Repositories.kt
@@ -5,6 +5,8 @@ import ac.uk.ebi.biostd.persistence.common.model.RequestFileStatus
 import ac.uk.ebi.biostd.persistence.common.model.SubmissionStatType
 import ac.uk.ebi.biostd.persistence.doc.db.repositories.MigrationData
 import ac.uk.ebi.biostd.persistence.doc.db.repositories.SubmissionCollections
+import ac.uk.ebi.biostd.persistence.doc.model.DocCleanUpError
+import ac.uk.ebi.biostd.persistence.doc.model.DocCleanUpLog
 import ac.uk.ebi.biostd.persistence.doc.model.DocNotificationError
 import ac.uk.ebi.biostd.persistence.doc.model.DocNotificationLog
 import ac.uk.ebi.biostd.persistence.doc.model.DocSubmission
@@ -312,3 +314,7 @@ interface LinkListDocLinkRepository : CoroutineCrudRepository<LinkListDocLink, O
 interface NotificationLogMongoRepository : CoroutineCrudRepository<DocNotificationLog, ObjectId>
 
 interface NotificationErrorMongoRepository : CoroutineCrudRepository<DocNotificationError, ObjectId>
+
+interface CleanUpLogMongoRepository : CoroutineCrudRepository<DocCleanUpLog, ObjectId>
+
+interface CleanUpErrorMongoRepository : CoroutineCrudRepository<DocCleanUpError, ObjectId>

--- a/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/migrations/DatabaseChangeLog.kt
+++ b/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/migrations/DatabaseChangeLog.kt
@@ -3,6 +3,7 @@
 package ac.uk.ebi.biostd.persistence.doc.migrations
 
 import ac.uk.ebi.biostd.persistence.doc.commons.ensureExists
+import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.DocCleanUpFields.CLEANUP_EMAIL
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.DocFileFields.FILE_DOC_FILEPATH
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.DocNotificationFields.NOTIFICATION_KEY
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.DocRequestFields.RQT_MODIFICATION_TIME
@@ -48,6 +49,8 @@ import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.FileListDocFileFiel
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.FileListDocFileFields.FILE_LIST_DOC_FILE_SUBMISSION_ACC_NO
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.FileListDocFileFields.FILE_LIST_DOC_FILE_SUBMISSION_ID
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.FileListDocFileFields.FILE_LIST_DOC_FILE_SUBMISSION_VERSION
+import ac.uk.ebi.biostd.persistence.doc.model.DocCleanUpError
+import ac.uk.ebi.biostd.persistence.doc.model.DocCleanUpLog
 import ac.uk.ebi.biostd.persistence.doc.model.DocNotificationError
 import ac.uk.ebi.biostd.persistence.doc.model.DocNotificationLog
 import ac.uk.ebi.biostd.persistence.doc.model.DocSubmission
@@ -76,6 +79,8 @@ suspend fun ReactiveMongoTemplate.executeMigrations() {
 
     ensureNotificationLogsIndexes()
     ensureNotificationErrorsIndexes()
+    ensureCleanUpLogsIndexes()
+    ensureCleanUpErrorsIndexes()
 }
 
 suspend fun ReactiveMongoOperations.ensureSubmissionIndexes() = ensureSubmissionIndexes<DocSubmission>()
@@ -269,5 +274,27 @@ suspend fun ReactiveMongoOperations.ensureNotificationErrorsIndexes() {
     ensureExists(DocNotificationError::class.java)
     indexOps<DocNotificationError>().apply {
         createIndex(backgroundIndex().on(NOTIFICATION_KEY, ASC)).awaitSingleOrNull()
+    }
+}
+
+/**
+ * cleanup_logs collection indexes
+ * 1. email
+ */
+suspend fun ReactiveMongoOperations.ensureCleanUpLogsIndexes() {
+    ensureExists(DocCleanUpLog::class.java)
+    indexOps<DocCleanUpLog>().apply {
+        createIndex(backgroundIndex().on(CLEANUP_EMAIL, ASC)).awaitSingleOrNull()
+    }
+}
+
+/**
+ * cleanup_errors collection indexes
+ * 1. email
+ */
+suspend fun ReactiveMongoOperations.ensureCleanUpErrorsIndexes() {
+    ensureExists(DocCleanUpError::class.java)
+    indexOps<DocCleanUpError>().apply {
+        createIndex(backgroundIndex().on(CLEANUP_EMAIL, ASC)).awaitSingleOrNull()
     }
 }

--- a/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/model/CleanUpLogModel.kt
+++ b/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/model/CleanUpLogModel.kt
@@ -1,0 +1,29 @@
+package ac.uk.ebi.biostd.persistence.doc.model
+
+import org.bson.types.ObjectId
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.mapping.Document
+import java.time.Instant
+import java.time.LocalDateTime
+
+@Document(collection = "cleanup_logs")
+data class DocCleanUpLog(
+    @Id
+    val id: ObjectId,
+    val email: String,
+    val date: Instant,
+    val jobId: String,
+    val lastActivity: LocalDateTime,
+    val userSpacePath: String,
+)
+
+@Document(collection = "cleanup_errors")
+data class DocCleanUpError(
+    @Id
+    val id: ObjectId,
+    val email: String,
+    val date: Instant,
+    val errorMessage: String,
+    val jobId: String?,
+    val userSpacePath: String?,
+)

--- a/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/service/CleanUpLogMongoDataService.kt
+++ b/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/service/CleanUpLogMongoDataService.kt
@@ -32,18 +32,18 @@ class CleanUpLogMongoDataService(
     }
 
     override suspend fun logCleanUpError(
-        email: String?,
+        email: String,
         errorMessage: String,
+        userSpacePath: String,
         jobId: String?,
-        userSpacePath: String?,
     ) {
         cleanUpErrorMongoRepository.save(
             DocCleanUpError(
                 id = ObjectId(),
+                email = email,
                 date = Instant.now(),
                 errorMessage = errorMessage,
                 jobId = jobId,
-                email = email,
                 userSpacePath = userSpacePath,
             ),
         )

--- a/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/service/CleanUpLogMongoDataService.kt
+++ b/submission/persistence-mongo/src/main/kotlin/ac/uk/ebi/biostd/persistence/doc/service/CleanUpLogMongoDataService.kt
@@ -1,0 +1,51 @@
+package ac.uk.ebi.biostd.persistence.doc.service
+
+import ac.uk.ebi.biostd.persistence.common.service.CleanUpLogDataService
+import ac.uk.ebi.biostd.persistence.doc.db.reactive.repositories.CleanUpErrorMongoRepository
+import ac.uk.ebi.biostd.persistence.doc.db.reactive.repositories.CleanUpLogMongoRepository
+import ac.uk.ebi.biostd.persistence.doc.model.DocCleanUpError
+import ac.uk.ebi.biostd.persistence.doc.model.DocCleanUpLog
+import org.bson.types.ObjectId
+import java.time.Instant
+import java.time.LocalDateTime
+
+class CleanUpLogMongoDataService(
+    private val cleanUpLogMongoRepository: CleanUpLogMongoRepository,
+    private val cleanUpErrorMongoRepository: CleanUpErrorMongoRepository,
+) : CleanUpLogDataService {
+    override suspend fun logCleanUp(
+        email: String,
+        jobId: String,
+        lastActivity: LocalDateTime,
+        userSpacePath: String,
+    ) {
+        cleanUpLogMongoRepository.save(
+            DocCleanUpLog(
+                id = ObjectId(),
+                date = Instant.now(),
+                jobId = jobId,
+                email = email,
+                lastActivity = lastActivity,
+                userSpacePath = userSpacePath,
+            ),
+        )
+    }
+
+    override suspend fun logCleanUpError(
+        email: String?,
+        errorMessage: String,
+        jobId: String?,
+        userSpacePath: String?,
+    ) {
+        cleanUpErrorMongoRepository.save(
+            DocCleanUpError(
+                id = ObjectId(),
+                date = Instant.now(),
+                errorMessage = errorMessage,
+                jobId = jobId,
+                email = email,
+                userSpacePath = userSpacePath,
+            ),
+        )
+    }
+}

--- a/submission/persistence-mongo/src/test/kotlin/ac/uk/ebi/biostd/persistence/doc/migrations/DatabaseChangeLogTest.kt
+++ b/submission/persistence-mongo/src/test/kotlin/ac/uk/ebi/biostd/persistence/doc/migrations/DatabaseChangeLogTest.kt
@@ -2,6 +2,7 @@ package ac.uk.ebi.biostd.persistence.doc.migrations
 
 import ac.uk.ebi.biostd.persistence.doc.MongoDbReactiveConfig
 import ac.uk.ebi.biostd.persistence.doc.commons.collection
+import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.DocCleanUpFields.CLEANUP_EMAIL
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.DocFileFields.FILE_DOC_FILEPATH
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.DocRequestFields.RQT_MODIFICATION_TIME
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.DocRequestFields.RQT_PROCESS
@@ -46,6 +47,8 @@ import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.FileListDocFileFiel
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.FileListDocFileFields.FILE_LIST_DOC_FILE_SUBMISSION_ACC_NO
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.FileListDocFileFields.FILE_LIST_DOC_FILE_SUBMISSION_ID
 import ac.uk.ebi.biostd.persistence.doc.db.converters.shared.FileListDocFileFields.FILE_LIST_DOC_FILE_SUBMISSION_VERSION
+import ac.uk.ebi.biostd.persistence.doc.model.DocCleanUpError
+import ac.uk.ebi.biostd.persistence.doc.model.DocCleanUpLog
 import ac.uk.ebi.biostd.persistence.doc.model.DocSubmission
 import ac.uk.ebi.biostd.persistence.doc.model.DocSubmissionFile
 import ac.uk.ebi.biostd.persistence.doc.model.DocSubmissionRequest
@@ -91,6 +94,8 @@ internal class DatabaseChangeLogTest(
         mongoTemplate.dropCollection<DocSubmissionRequest>()
         mongoTemplate.dropCollection<DocSubmissionRequestFile>()
         mongoTemplate.dropCollection<FileListDocFile>()
+        mongoTemplate.dropCollection<DocCleanUpLog>()
+        mongoTemplate.dropCollection<DocCleanUpError>()
     }
 
     @Test
@@ -220,6 +225,34 @@ internal class DatabaseChangeLogTest(
                 )
             }
 
+            suspend fun assertCleanUpLogsIndexes() {
+                val cleanupLogsIndexes =
+                    mongoTemplate
+                        .collection<DocCleanUpLog>()
+                        .listIndexes()
+                        .asFlow()
+                        .toList()
+
+                assertThat(mongoTemplate.collectionExists<DocCleanUpLog>().awaitSingle()).isTrue()
+                assertThat(cleanupLogsIndexes).hasSize(2)
+                assertThat(cleanupLogsIndexes[0]).containsEntry("key", Document("_id", 1))
+                assertThat(cleanupLogsIndexes[1]).containsEntry("key", Document(CLEANUP_EMAIL, 1))
+            }
+
+            suspend fun assertCleanUpErrorsIndexes() {
+                val cleanupErrorsIndexes =
+                    mongoTemplate
+                        .collection<DocCleanUpError>()
+                        .listIndexes()
+                        .asFlow()
+                        .toList()
+
+                assertThat(mongoTemplate.collectionExists<DocCleanUpError>().awaitSingle()).isTrue()
+                assertThat(cleanupErrorsIndexes).hasSize(2)
+                assertThat(cleanupErrorsIndexes[0]).containsEntry("key", Document("_id", 1))
+                assertThat(cleanupErrorsIndexes[1]).containsEntry("key", Document(CLEANUP_EMAIL, 1))
+            }
+
             suspend fun assertRequestFileIndexes() {
                 val filesIndexes =
                     mongoTemplate
@@ -263,6 +296,8 @@ internal class DatabaseChangeLogTest(
             assertFileListIndexes()
             assertStatsIndexes()
             assertSubmissionFilesIndexes()
+            assertCleanUpLogsIndexes()
+            assertCleanUpErrorsIndexes()
         }
 
     companion object {

--- a/submission/persistence-sql/src/main/kotlin/ac/uk/ebi/biostd/persistence/repositories/Repositories.kt
+++ b/submission/persistence-sql/src/main/kotlin/ac/uk/ebi/biostd/persistence/repositories/Repositories.kt
@@ -62,8 +62,8 @@ interface UserDataRepository : JpaRepository<DbUser, Long> {
         active: Boolean,
     ): DbUser?
 
-    @Query("SELECT u.email FROM DbUser u WHERE u.lastActivity BETWEEN :start AND :end")
-    fun findAllByLastActivityIsBetween(
+    @Query("SELECT u.email FROM DbUser u WHERE u.active = true AND u.lastActivity BETWEEN :start AND :end")
+    fun findAllByLastActivityIsBetweenAndActive(
         start: LocalDateTime,
         end: LocalDateTime,
     ): List<String>

--- a/submission/submission-config/src/main/kotlin/ac/uk/ebi/biostd/common/properties/TaskProperties.kt
+++ b/submission/submission-config/src/main/kotlin/ac/uk/ebi/biostd/common/properties/TaskProperties.kt
@@ -20,4 +20,5 @@ enum class Mode {
     POST_PROCESS_DOI,
     LOAD_PMC_LINKS,
     NOTIFY_USER_SPACE_CLEAN_UP,
+    CLEAN_UP_USER_SPACE,
 }

--- a/submission/submission-core/src/main/kotlin/ac/uk/ebi/biostd/submission/config/SubmitterConfig.kt
+++ b/submission/submission-core/src/main/kotlin/ac/uk/ebi/biostd/submission/config/SubmitterConfig.kt
@@ -73,6 +73,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
 import org.springframework.web.reactive.function.client.WebClient
+import uk.ac.ebi.biostd.client.cluster.api.ClusterClient
 import uk.ac.ebi.events.service.EventsPublisherService
 import uk.ac.ebi.extended.serialization.service.ExtSerializationService
 import uk.ac.ebi.extended.serialization.service.FileProcessingService
@@ -325,6 +326,7 @@ class SubmitterConfig(
 
     @Bean
     fun localUserSpaceCleanUpService(
+        clusterClient: ClusterClient,
         userRepository: UserDataRepository,
         properties: ApplicationProperties,
         securityQueryService: SecurityQueryService,
@@ -333,21 +335,20 @@ class SubmitterConfig(
         cleanUpLogDataService: CleanUpLogDataService,
     ): LocalUserSpaceCleanUpService =
         LocalUserSpaceCleanUpService(
+            clusterClient,
             userRepository,
             properties.cleanUp,
             securityQueryService,
+            cleanUpLogDataService,
             eventsPublisherService,
             notificationErrorService,
-            cleanUpLogDataService,
         )
 
     @Bean
     fun extUserSpaceCleanUpService(
         localUserSpaceCleanUpService: LocalUserSpaceCleanUpService,
         remoteSubmitterExecutor: RemoteSubmitterExecutor,
-        cleanUpLogDataService: CleanUpLogDataService,
-    ): ExtUserSpaceCleanUpService =
-        ExtUserSpaceCleanUpService(remoteSubmitterExecutor, localUserSpaceCleanUpService, cleanUpLogDataService)
+    ): ExtUserSpaceCleanUpService = ExtUserSpaceCleanUpService(remoteSubmitterExecutor, localUserSpaceCleanUpService)
 
     @Bean
     fun submissionProcessor(

--- a/submission/submission-core/src/main/kotlin/ac/uk/ebi/biostd/submission/config/SubmitterConfig.kt
+++ b/submission/submission-core/src/main/kotlin/ac/uk/ebi/biostd/submission/config/SubmitterConfig.kt
@@ -2,6 +2,7 @@ package ac.uk.ebi.biostd.submission.config
 
 import ac.uk.ebi.biostd.common.properties.ApplicationProperties
 import ac.uk.ebi.biostd.integration.SerializationService
+import ac.uk.ebi.biostd.persistence.common.service.CleanUpLogDataService
 import ac.uk.ebi.biostd.persistence.common.service.NotificationLogDataService
 import ac.uk.ebi.biostd.persistence.common.service.PersistenceService
 import ac.uk.ebi.biostd.persistence.common.service.StatsDataService
@@ -11,10 +12,13 @@ import ac.uk.ebi.biostd.persistence.common.service.SubmissionPersistenceService
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionRequestFilesPersistenceService
 import ac.uk.ebi.biostd.persistence.common.service.SubmissionRequestPersistenceService
 import ac.uk.ebi.biostd.persistence.doc.db.data.SubmissionFilesDocDataRepository
+import ac.uk.ebi.biostd.persistence.doc.db.reactive.repositories.CleanUpErrorMongoRepository
+import ac.uk.ebi.biostd.persistence.doc.db.reactive.repositories.CleanUpLogMongoRepository
 import ac.uk.ebi.biostd.persistence.doc.db.reactive.repositories.NotificationErrorMongoRepository
 import ac.uk.ebi.biostd.persistence.doc.db.reactive.repositories.NotificationLogMongoRepository
 import ac.uk.ebi.biostd.persistence.doc.integration.ExternalConfig
 import ac.uk.ebi.biostd.persistence.doc.integration.SerializationConfiguration
+import ac.uk.ebi.biostd.persistence.doc.service.CleanUpLogMongoDataService
 import ac.uk.ebi.biostd.persistence.doc.service.NotificationLogMongoDataService
 import ac.uk.ebi.biostd.persistence.filesystem.api.FileStorageService
 import ac.uk.ebi.biostd.persistence.filesystem.pagetab.PageTabService
@@ -308,6 +312,12 @@ class SubmitterConfig(
     ): NotificationLogDataService = NotificationLogMongoDataService(notificationLogRepo, notificationErrorMongoRepo)
 
     @Bean
+    fun cleanUpLogDataService(
+        cleanUpLogMongoRepository: CleanUpLogMongoRepository,
+        cleanUpErrorMongoRepository: CleanUpErrorMongoRepository,
+    ): CleanUpLogDataService = CleanUpLogMongoDataService(cleanUpLogMongoRepository, cleanUpErrorMongoRepository)
+
+    @Bean
     fun extPostProcessingService(
         localPostProcessingService: LocalPostProcessingService,
         remoteSubmitterExecutor: RemoteSubmitterExecutor,
@@ -320,6 +330,7 @@ class SubmitterConfig(
         securityQueryService: SecurityQueryService,
         eventsPublisherService: EventsPublisherService,
         notificationErrorService: NotificationLogDataService,
+        cleanUpLogDataService: CleanUpLogDataService,
     ): LocalUserSpaceCleanUpService =
         LocalUserSpaceCleanUpService(
             userRepository,
@@ -327,13 +338,16 @@ class SubmitterConfig(
             securityQueryService,
             eventsPublisherService,
             notificationErrorService,
+            cleanUpLogDataService,
         )
 
     @Bean
     fun extUserSpaceCleanUpService(
         localUserSpaceCleanUpService: LocalUserSpaceCleanUpService,
         remoteSubmitterExecutor: RemoteSubmitterExecutor,
-    ): ExtUserSpaceCleanUpService = ExtUserSpaceCleanUpService(remoteSubmitterExecutor, localUserSpaceCleanUpService)
+        cleanUpLogDataService: CleanUpLogDataService,
+    ): ExtUserSpaceCleanUpService =
+        ExtUserSpaceCleanUpService(remoteSubmitterExecutor, localUserSpaceCleanUpService, cleanUpLogDataService)
 
     @Bean
     fun submissionProcessor(

--- a/submission/submission-core/src/main/kotlin/ac/uk/ebi/biostd/submission/domain/cleanup/ExtUserSpaceCleanUpService.kt
+++ b/submission/submission-core/src/main/kotlin/ac/uk/ebi/biostd/submission/domain/cleanup/ExtUserSpaceCleanUpService.kt
@@ -2,7 +2,6 @@ package ac.uk.ebi.biostd.submission.domain.cleanup
 
 import ac.uk.ebi.biostd.common.properties.Mode
 import ac.uk.ebi.biostd.common.properties.Mode.CLEAN_UP_USER_SPACE
-import ac.uk.ebi.biostd.persistence.common.service.CleanUpLogDataService
 import ac.uk.ebi.biostd.submission.domain.cleanup.ExtUserSpaceCleanUpService.CleanUpMode.CLEAN_UP
 import ac.uk.ebi.biostd.submission.domain.cleanup.ExtUserSpaceCleanUpService.CleanUpMode.NOTIFY
 import ac.uk.ebi.biostd.submission.domain.submitter.RemoteSubmitterExecutor
@@ -10,7 +9,6 @@ import ac.uk.ebi.biostd.submission.domain.submitter.RemoteSubmitterExecutor
 class ExtUserSpaceCleanUpService(
     private val remoteSubmitterExecutor: RemoteSubmitterExecutor,
     private val localUserSpaceCleanUpService: LocalUserSpaceCleanUpService,
-    private val cleanUpLogDataService: CleanUpLogDataService,
 ) {
     suspend fun cleanUp(
         mode: CleanUpMode,

--- a/submission/submission-core/src/main/kotlin/ac/uk/ebi/biostd/submission/domain/cleanup/ExtUserSpaceCleanUpService.kt
+++ b/submission/submission-core/src/main/kotlin/ac/uk/ebi/biostd/submission/domain/cleanup/ExtUserSpaceCleanUpService.kt
@@ -1,6 +1,8 @@
 package ac.uk.ebi.biostd.submission.domain.cleanup
 
 import ac.uk.ebi.biostd.common.properties.Mode
+import ac.uk.ebi.biostd.common.properties.Mode.CLEAN_UP_USER_SPACE
+import ac.uk.ebi.biostd.persistence.common.service.CleanUpLogDataService
 import ac.uk.ebi.biostd.submission.domain.cleanup.ExtUserSpaceCleanUpService.CleanUpMode.CLEAN_UP
 import ac.uk.ebi.biostd.submission.domain.cleanup.ExtUserSpaceCleanUpService.CleanUpMode.NOTIFY
 import ac.uk.ebi.biostd.submission.domain.submitter.RemoteSubmitterExecutor
@@ -8,6 +10,7 @@ import ac.uk.ebi.biostd.submission.domain.submitter.RemoteSubmitterExecutor
 class ExtUserSpaceCleanUpService(
     private val remoteSubmitterExecutor: RemoteSubmitterExecutor,
     private val localUserSpaceCleanUpService: LocalUserSpaceCleanUpService,
+    private val cleanUpLogDataService: CleanUpLogDataService,
 ) {
     suspend fun cleanUp(
         mode: CleanUpMode,
@@ -21,9 +24,17 @@ class ExtUserSpaceCleanUpService(
             }
         }
 
+        suspend fun cleanUpUserSpaces() {
+            if (remote.not()) {
+                localUserSpaceCleanUpService.cleanUpUserSpaces()
+            } else {
+                remoteSubmitterExecutor.executeRemotely(emptyList(), CLEAN_UP_USER_SPACE)
+            }
+        }
+
         when (mode) {
             NOTIFY -> notify()
-            CLEAN_UP -> TODO()
+            CLEAN_UP -> cleanUpUserSpaces()
         }
     }
 

--- a/submission/submission-core/src/main/kotlin/ac/uk/ebi/biostd/submission/domain/cleanup/LocalUserSpaceCleanUpService.kt
+++ b/submission/submission-core/src/main/kotlin/ac/uk/ebi/biostd/submission/domain/cleanup/LocalUserSpaceCleanUpService.kt
@@ -1,6 +1,7 @@
 package ac.uk.ebi.biostd.submission.domain.cleanup
 
 import ac.uk.ebi.biostd.common.properties.CleanUpProperties
+import ac.uk.ebi.biostd.persistence.common.service.CleanUpLogDataService
 import ac.uk.ebi.biostd.persistence.common.service.NotificationLogDataService
 import ac.uk.ebi.biostd.persistence.repositories.UserDataRepository
 import ac.uk.ebi.biostd.submission.domain.cleanup.LocalUserSpaceCleanUpService.NotificationType.FINAL_WARNING
@@ -13,15 +14,21 @@ import ebi.ac.uk.security.integration.model.api.SecurityUser
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import mu.KotlinLogging
+import uk.ac.ebi.biostd.client.cluster.api.ClusterClient
+import uk.ac.ebi.biostd.client.cluster.model.DataMoverQueue
+import uk.ac.ebi.biostd.client.cluster.model.JobSpec
 import uk.ac.ebi.events.service.EventsPublisherService
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+import kotlin.io.path.absolutePathString
 
 class LocalUserSpaceCleanUpService(
+    private val clusterClient: ClusterClient,
     private val userRepository: UserDataRepository,
     private val cleanUpProperties: CleanUpProperties,
     private val securityQueryService: SecurityQueryService,
+    private val cleanUpLogDataService: CleanUpLogDataService,
     private val eventsPublisherService: EventsPublisherService,
     private val notificationLogDataService: NotificationLogDataService,
 ) {
@@ -38,7 +45,7 @@ class LocalUserSpaceCleanUpService(
     ) = withContext(Dispatchers.IO) {
         logger.info { "Sending ${type.name} cleanup notifications for users with last activity at $date" }
         userRepository
-            .findAllByLastActivityIsBetween(date.atStartOfDay(), date.atEndOfDay())
+            .findAllByLastActivityIsBetweenAndActive(date.atStartOfDay(), date.atEndOfDay())
             .map { securityQueryService.getUser(it) }
             .filterNot { isUserSpaceEmpty(it) }
             .forEach { notifyCleanUp(it, type) }
@@ -72,6 +79,31 @@ class LocalUserSpaceCleanUpService(
                 lastActivityDate = user.lastActivity.formatted(),
             )
         eventsPublisherService.cleanupNotification(notification)
+    }
+
+    suspend fun cleanUpUserSpaces() =
+        withContext(Dispatchers.IO) {
+            val cleanUpDate = LocalDate.now().minusDays(cleanUpProperties.cleanUpPeriodDays)
+            logger.info { "Cleaning up users with last activity at $cleanUpDate" }
+            userRepository
+                .findAllByLastActivityIsBetweenAndActive(cleanUpDate.atStartOfDay(), cleanUpDate.atEndOfDay())
+                .map { securityQueryService.getUser(it) }
+                .filterNot { isUserSpaceEmpty(it) }
+                .forEach { cleanUpUserSpace(it) }
+        }
+
+    private suspend fun cleanUpUserSpace(user: SecurityUser) {
+        val path = user.userFolder.path.absolutePathString()
+        logger.info { "Dispatching user space clean up job for user ${user.email} at $path" }
+        val job = JobSpec(queue = DataMoverQueue, command = "rm -rf $path/*")
+        val jobTry = clusterClient.triggerJobAsync(job)
+        jobTry.fold({
+            cleanUpLogDataService.logCleanUp(user.email, it.id, user.lastActivity, path)
+            logger.info { "User space clean up job dispatched for user ${user.email}. Job id: ${it.id}" }
+        }, {
+            cleanUpLogDataService.logCleanUpError(user.email, it.message ?: it.localizedMessage, path)
+            logger.error { "Failed to dispatch user space clean up job for user ${user.email}. Error: ${it.message}" }
+        })
     }
 
     private fun LocalDateTime.formatted() = format(DateTimeFormatter.ofPattern(DATE_FORMAT))

--- a/submission/submission-core/src/main/kotlin/ac/uk/ebi/biostd/submission/domain/cleanup/LocalUserSpaceCleanUpService.kt
+++ b/submission/submission-core/src/main/kotlin/ac/uk/ebi/biostd/submission/domain/cleanup/LocalUserSpaceCleanUpService.kt
@@ -23,6 +23,7 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import kotlin.io.path.absolutePathString
 
+@Suppress("LongParameterList")
 class LocalUserSpaceCleanUpService(
     private val clusterClient: ClusterClient,
     private val userRepository: UserDataRepository,
@@ -47,20 +48,22 @@ class LocalUserSpaceCleanUpService(
         userRepository
             .findAllByLastActivityIsBetweenAndActive(date.atStartOfDay(), date.atEndOfDay())
             .map { securityQueryService.getUser(it) }
-            .filterNot { isUserSpaceEmpty(it) }
+            .filterNot { isUserSpaceEmpty(it, NOTIFICATION_ERROR) }
             .forEach { notifyCleanUp(it, type) }
     }
 
-    private suspend fun isUserSpaceEmpty(user: SecurityUser) =
-        runCatching {
-            user.userFolder.path
-                .toFile()
-                .isEmpty()
-        }.onFailure {
-            val error = "Error checking user folder for '${user.email}', secret: ${user.userFolder.path}"
-            logger.error { error }
-            notificationLogDataService.logNotificationError(user.email, it.localizedMessage, USER_SPACE_ERROR, error)
-        }.getOrDefault(true)
+    private suspend fun isUserSpaceEmpty(
+        user: SecurityUser,
+        errorType: String,
+    ) = runCatching {
+        user.userFolder.path
+            .toFile()
+            .isEmpty()
+    }.onFailure {
+        val error = "Error checking user folder for '${user.email}', secret: ${user.userFolder.path}"
+        logger.error { error }
+        notificationLogDataService.logNotificationError(user.email, it.localizedMessage, errorType, error)
+    }.getOrDefault(true)
 
     private fun notifyCleanUp(
         user: SecurityUser,
@@ -88,14 +91,14 @@ class LocalUserSpaceCleanUpService(
             userRepository
                 .findAllByLastActivityIsBetweenAndActive(cleanUpDate.atStartOfDay(), cleanUpDate.atEndOfDay())
                 .map { securityQueryService.getUser(it) }
-                .filterNot { isUserSpaceEmpty(it) }
+                .filterNot { isUserSpaceEmpty(it, CLEAN_UP_ERROR) }
                 .forEach { cleanUpUserSpace(it) }
         }
 
     private suspend fun cleanUpUserSpace(user: SecurityUser) {
         val path = user.userFolder.path.absolutePathString()
         logger.info { "Dispatching user space clean up job for user ${user.email} at $path" }
-        val job = JobSpec(queue = DataMoverQueue, command = "rm -rf $path/*")
+        val job = JobSpec(queue = DataMoverQueue, command = "find ${path.shellQuoted()} -mindepth 1 -delete")
         val jobTry = clusterClient.triggerJobAsync(job)
         jobTry.fold({
             cleanUpLogDataService.logCleanUp(user.email, it.id, user.lastActivity, path)
@@ -110,9 +113,12 @@ class LocalUserSpaceCleanUpService(
 
     private fun LocalDate.atEndOfDay() = plusDays(1).atStartOfDay().minusSeconds(1)
 
+    private fun String.shellQuoted() = "'${replace("'", "'\"'\"'")}'"
+
     companion object {
         const val DATE_FORMAT = "dd MMMM yyyy"
-        const val USER_SPACE_ERROR = "USER_SPACE_ERROR"
+        const val CLEAN_UP_ERROR = "CLEAN_UP_ERROR"
+        const val NOTIFICATION_ERROR = "CLEAN_UP_NOTIFICATION_ERROR"
         const val WARNING_TEMPLATE = "clean-up-warning"
         const val FINAL_WARNING_TEMPLATE = "clean-up-final-warning"
         const val WARNING_SUBJECT = "Inactivity notice – Cleanup of your BioStudies workspace"

--- a/submission/submission-core/src/test/kotlin/ac/uk/ebi/biostd/submission/domain/cleanup/ExtUserSpaceCleanUpServiceTest.kt
+++ b/submission/submission-core/src/test/kotlin/ac/uk/ebi/biostd/submission/domain/cleanup/ExtUserSpaceCleanUpServiceTest.kt
@@ -1,65 +1,94 @@
 package ac.uk.ebi.biostd.submission.domain.cleanup
 
 import ac.uk.ebi.biostd.common.properties.Mode.CLEAN_UP_USER_SPACE
-import ac.uk.ebi.biostd.persistence.common.service.CleanUpLogDataService
+import ac.uk.ebi.biostd.common.properties.Mode.NOTIFY_USER_SPACE_CLEAN_UP
 import ac.uk.ebi.biostd.submission.domain.cleanup.ExtUserSpaceCleanUpService.CleanUpMode.CLEAN_UP
-import ac.uk.ebi.biostd.submission.domain.cleanup.LocalUserSpaceCleanUpService.CleanUpUser
-import ac.uk.ebi.biostd.submission.domain.submitter.ExecutionArg
+import ac.uk.ebi.biostd.submission.domain.cleanup.ExtUserSpaceCleanUpService.CleanUpMode.NOTIFY
 import ac.uk.ebi.biostd.submission.domain.submitter.RemoteSubmitterExecutor
+import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import uk.ac.ebi.biostd.client.cluster.model.Job
-import java.time.LocalDateTime
 
 @ExtendWith(MockKExtension::class)
 class ExtUserSpaceCleanUpServiceTest(
     @param:MockK private val remoteSubmitterExecutor: RemoteSubmitterExecutor,
     @param:MockK private val localUserSpaceCleanUpService: LocalUserSpaceCleanUpService,
-    @param:MockK private val cleanUpLogDataService: CleanUpLogDataService,
 ) {
     private val testInstance =
         ExtUserSpaceCleanUpService(
             remoteSubmitterExecutor,
             localUserSpaceCleanUpService,
-            cleanUpLogDataService,
         )
 
-    @Test
-    fun `clean up dispatches one remote job per user and logs dispatch`() =
-        runTest {
-            val lastActivity = LocalDateTime.parse("2026-02-16T10:00:00")
-            val cleanUpUser =
-                CleanUpUser(
-                    email = "cleanup@ebi.ac.uk",
-                    lastActivity = lastActivity,
-                    userSpacePath = "/data/users/cleanup@ebi.ac.uk",
-                )
-            val job = Job("12345", "datamover", "/logs/12345")
+    @BeforeEach
+    fun beforeEach() = clearAllMocks()
 
-            coEvery { localUserSpaceCleanUpService.cleanUpUserSpaces() } returns listOf(cleanUpUser)
-            coEvery {
-                remoteSubmitterExecutor.executeRemotely(listOf(ExecutionArg("email", cleanUpUser.email)), CLEAN_UP_USER_SPACE)
-            } returns job
-            coEvery { cleanUpLogDataService.logCleanUp(any(), any(), any(), any()) } returns Unit
+    @Test
+    fun `notify executes remotely when remote is enabled`() =
+        runTest {
+            coEvery { remoteSubmitterExecutor.executeRemotely(emptyList(), NOTIFY_USER_SPACE_CLEAN_UP) } returns remoteJob()
+
+            testInstance.cleanUp(NOTIFY, remote = true)
+
+            coVerify(exactly = 1) {
+                remoteSubmitterExecutor.executeRemotely(emptyList(), NOTIFY_USER_SPACE_CLEAN_UP)
+            }
+            coVerify(exactly = 0) {
+                localUserSpaceCleanUpService.sendNotifications()
+            }
+        }
+
+    @Test
+    fun `notify executes locally when remote is disabled`() =
+        runTest {
+            coEvery { localUserSpaceCleanUpService.sendNotifications() } returns Unit
+
+            testInstance.cleanUp(NOTIFY, remote = false)
+
+            coVerify(exactly = 1) {
+                localUserSpaceCleanUpService.sendNotifications()
+            }
+            coVerify(exactly = 0) {
+                remoteSubmitterExecutor.executeRemotely(any(), any())
+            }
+        }
+
+    @Test
+    fun `clean up executes remotely when remote is enabled`() =
+        runTest {
+            coEvery { remoteSubmitterExecutor.executeRemotely(emptyList(), CLEAN_UP_USER_SPACE) } returns remoteJob()
 
             testInstance.cleanUp(CLEAN_UP, remote = true)
 
             coVerify(exactly = 1) {
-                remoteSubmitterExecutor.executeRemotely(listOf(ExecutionArg("email", cleanUpUser.email)), CLEAN_UP_USER_SPACE)
-                cleanUpLogDataService.logCleanUp(
-                    cleanUpUser.email,
-                    job.id,
-                    lastActivity,
-                    cleanUpUser.userSpacePath,
-                )
+                remoteSubmitterExecutor.executeRemotely(emptyList(), CLEAN_UP_USER_SPACE)
             }
             coVerify(exactly = 0) {
-                cleanUpLogDataService.logCleanUpError(any(), any(), any(), any())
+                localUserSpaceCleanUpService.cleanUpUserSpaces()
             }
         }
+
+    @Test
+    fun `clean up executes locally when remote is disabled`() =
+        runTest {
+            coEvery { localUserSpaceCleanUpService.cleanUpUserSpaces() } returns Unit
+
+            testInstance.cleanUp(CLEAN_UP, remote = false)
+
+            coVerify(exactly = 1) {
+                localUserSpaceCleanUpService.cleanUpUserSpaces()
+            }
+            coVerify(exactly = 0) {
+                remoteSubmitterExecutor.executeRemotely(any(), any())
+            }
+        }
+
+    private fun remoteJob() = Job("12345", "datamover", "/logs/12345")
 }

--- a/submission/submission-core/src/test/kotlin/ac/uk/ebi/biostd/submission/domain/cleanup/ExtUserSpaceCleanUpServiceTest.kt
+++ b/submission/submission-core/src/test/kotlin/ac/uk/ebi/biostd/submission/domain/cleanup/ExtUserSpaceCleanUpServiceTest.kt
@@ -1,0 +1,65 @@
+package ac.uk.ebi.biostd.submission.domain.cleanup
+
+import ac.uk.ebi.biostd.common.properties.Mode.CLEAN_UP_USER_SPACE
+import ac.uk.ebi.biostd.persistence.common.service.CleanUpLogDataService
+import ac.uk.ebi.biostd.submission.domain.cleanup.ExtUserSpaceCleanUpService.CleanUpMode.CLEAN_UP
+import ac.uk.ebi.biostd.submission.domain.cleanup.LocalUserSpaceCleanUpService.CleanUpUser
+import ac.uk.ebi.biostd.submission.domain.submitter.ExecutionArg
+import ac.uk.ebi.biostd.submission.domain.submitter.RemoteSubmitterExecutor
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.ac.ebi.biostd.client.cluster.model.Job
+import java.time.LocalDateTime
+
+@ExtendWith(MockKExtension::class)
+class ExtUserSpaceCleanUpServiceTest(
+    @param:MockK private val remoteSubmitterExecutor: RemoteSubmitterExecutor,
+    @param:MockK private val localUserSpaceCleanUpService: LocalUserSpaceCleanUpService,
+    @param:MockK private val cleanUpLogDataService: CleanUpLogDataService,
+) {
+    private val testInstance =
+        ExtUserSpaceCleanUpService(
+            remoteSubmitterExecutor,
+            localUserSpaceCleanUpService,
+            cleanUpLogDataService,
+        )
+
+    @Test
+    fun `clean up dispatches one remote job per user and logs dispatch`() =
+        runTest {
+            val lastActivity = LocalDateTime.parse("2026-02-16T10:00:00")
+            val cleanUpUser =
+                CleanUpUser(
+                    email = "cleanup@ebi.ac.uk",
+                    lastActivity = lastActivity,
+                    userSpacePath = "/data/users/cleanup@ebi.ac.uk",
+                )
+            val job = Job("12345", "datamover", "/logs/12345")
+
+            coEvery { localUserSpaceCleanUpService.cleanUpUserSpaces() } returns listOf(cleanUpUser)
+            coEvery {
+                remoteSubmitterExecutor.executeRemotely(listOf(ExecutionArg("email", cleanUpUser.email)), CLEAN_UP_USER_SPACE)
+            } returns job
+            coEvery { cleanUpLogDataService.logCleanUp(any(), any(), any(), any()) } returns Unit
+
+            testInstance.cleanUp(CLEAN_UP, remote = true)
+
+            coVerify(exactly = 1) {
+                remoteSubmitterExecutor.executeRemotely(listOf(ExecutionArg("email", cleanUpUser.email)), CLEAN_UP_USER_SPACE)
+                cleanUpLogDataService.logCleanUp(
+                    cleanUpUser.email,
+                    job.id,
+                    lastActivity,
+                    cleanUpUser.userSpacePath,
+                )
+            }
+            coVerify(exactly = 0) {
+                cleanUpLogDataService.logCleanUpError(any(), any(), any(), any())
+            }
+        }
+}

--- a/submission/submission-core/src/test/kotlin/ac/uk/ebi/biostd/submission/domain/cleanup/LocalUserSpaceCleanUpServiceTest.kt
+++ b/submission/submission-core/src/test/kotlin/ac/uk/ebi/biostd/submission/domain/cleanup/LocalUserSpaceCleanUpServiceTest.kt
@@ -1,6 +1,7 @@
 package ac.uk.ebi.biostd.submission.domain.cleanup
 
 import ac.uk.ebi.biostd.common.properties.CleanUpProperties
+import ac.uk.ebi.biostd.persistence.common.service.CleanUpLogDataService
 import ac.uk.ebi.biostd.persistence.common.service.NotificationLogDataService
 import ac.uk.ebi.biostd.persistence.repositories.UserDataRepository
 import ac.uk.ebi.biostd.submission.domain.cleanup.LocalUserSpaceCleanUpService.Companion.FINAL_WARNING_SUBJECT
@@ -32,7 +33,9 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.time.LocalDate
 import java.time.LocalDateTime
+import kotlin.io.path.absolutePathString
 import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
 
 @ExtendWith(MockKExtension::class)
 class LocalUserSpaceCleanUpServiceTest(
@@ -40,6 +43,7 @@ class LocalUserSpaceCleanUpServiceTest(
     @param:MockK private val securityQueryService: SecurityQueryService,
     @param:MockK private val eventsPublisherService: EventsPublisherService,
     @param:MockK private val notificationErrorService: NotificationLogDataService,
+    @param:MockK private val cleanUpLogDataService: CleanUpLogDataService,
 ) {
     private val cleanUpProperties =
         CleanUpProperties(
@@ -57,6 +61,7 @@ class LocalUserSpaceCleanUpServiceTest(
             securityQueryService,
             eventsPublisherService,
             notificationErrorService,
+            cleanUpLogDataService,
         )
 
     @BeforeEach
@@ -192,6 +197,69 @@ class LocalUserSpaceCleanUpServiceTest(
                 )
             }
             verify(exactly = 0) { eventsPublisherService.cleanupNotification(any()) }
+        }
+
+    @Test
+    fun `find users to cleanup uses exact cutoff and skips empty user spaces`() =
+        runTest {
+            val today = LocalDate.parse("2026-06-16")
+            val userToClean = createUser("cleanup@ebi.ac.uk", "Cleanup User", today.minusDays(120).atTime(10, 0))
+            val emptyUser =
+                createUser(
+                    "empty@ebi.ac.uk",
+                    "Empty User",
+                    today.minusDays(120).atTime(11, 0),
+                    Files.createTempDirectory("cleanup-empty"),
+                )
+
+            every { LocalDate.now() } returns today
+            every {
+                userRepository.findAllByLastActivityIsBetweenAndActive(
+                    today.minusDays(120).atStartOfDay(),
+                    today
+                        .minusDays(120)
+                        .plusDays(1)
+                        .atStartOfDay()
+                        .minusSeconds(1),
+                )
+            } returns listOf(userToClean.email, emptyUser.email)
+            every { securityQueryService.getUser(userToClean.email) } returns userToClean
+            every { securityQueryService.getUser(emptyUser.email) } returns emptyUser
+
+            val users = testInstance.cleanUpUserSpaces()
+
+            assertThat(users).containsExactly(
+                LocalUserSpaceCleanUpService.CleanUpUser(
+                    email = userToClean.email,
+                    lastActivity = userToClean.lastActivity,
+                    userSpacePath = userToClean.userFolder.path.absolutePathString(),
+                ),
+            )
+            coVerify(exactly = 0) {
+                cleanUpLogDataService.logCleanUpError(any(), any(), any(), any())
+            }
+        }
+
+    @Test
+    fun `clean up user deletes user space contents and preserves root folder`() =
+        runTest {
+            val folder = Files.createTempDirectory("cleanup-user")
+            val nestedFolder = folder.resolve("nested").createDirectories()
+            val hiddenFile = folder.resolve(".hidden")
+            val nestedFile = nestedFolder.resolve("file.txt")
+            Files.writeString(hiddenFile, "hidden")
+            Files.writeString(nestedFile, "nested")
+            val user = createUser("cleanup@ebi.ac.uk", "Cleanup User", LocalDateTime.parse("2026-02-16T10:00:00"), folder)
+
+            every { securityQueryService.getUser(user.email) } returns user
+
+            testInstance.cleanUpUser(user.email)
+
+            assertThat(folder.exists()).isTrue()
+            assertThat(folder.toFile().listFiles()).isEmpty()
+            coVerify(exactly = 0) {
+                cleanUpLogDataService.logCleanUpError(any(), any(), any(), any())
+            }
         }
 
     private fun createUser(

--- a/submission/submission-core/src/test/kotlin/ac/uk/ebi/biostd/submission/domain/cleanup/LocalUserSpaceCleanUpServiceTest.kt
+++ b/submission/submission-core/src/test/kotlin/ac/uk/ebi/biostd/submission/domain/cleanup/LocalUserSpaceCleanUpServiceTest.kt
@@ -6,7 +6,7 @@ import ac.uk.ebi.biostd.persistence.common.service.NotificationLogDataService
 import ac.uk.ebi.biostd.persistence.repositories.UserDataRepository
 import ac.uk.ebi.biostd.submission.domain.cleanup.LocalUserSpaceCleanUpService.Companion.FINAL_WARNING_SUBJECT
 import ac.uk.ebi.biostd.submission.domain.cleanup.LocalUserSpaceCleanUpService.Companion.FINAL_WARNING_TEMPLATE
-import ac.uk.ebi.biostd.submission.domain.cleanup.LocalUserSpaceCleanUpService.Companion.USER_SPACE_ERROR
+import ac.uk.ebi.biostd.submission.domain.cleanup.LocalUserSpaceCleanUpService.Companion.NOTIFICATION_ERROR
 import ac.uk.ebi.biostd.submission.domain.cleanup.LocalUserSpaceCleanUpService.Companion.WARNING_SUBJECT
 import ac.uk.ebi.biostd.submission.domain.cleanup.LocalUserSpaceCleanUpService.Companion.WARNING_TEMPLATE
 import ebi.ac.uk.extended.events.CleanUpNotification
@@ -20,6 +20,7 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockkStatic
+import io.mockk.slot
 import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.test.runTest
@@ -28,6 +29,10 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import uk.ac.ebi.biostd.client.cluster.api.ClusterClient
+import uk.ac.ebi.biostd.client.cluster.model.DataMoverQueue
+import uk.ac.ebi.biostd.client.cluster.model.Job
+import uk.ac.ebi.biostd.client.cluster.model.JobSpec
 import uk.ac.ebi.events.service.EventsPublisherService
 import java.nio.file.Files
 import java.nio.file.Path
@@ -35,10 +40,10 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import kotlin.io.path.absolutePathString
 import kotlin.io.path.createDirectories
-import kotlin.io.path.exists
 
 @ExtendWith(MockKExtension::class)
 class LocalUserSpaceCleanUpServiceTest(
+    @param:MockK private val clusterClient: ClusterClient,
     @param:MockK private val userRepository: UserDataRepository,
     @param:MockK private val securityQueryService: SecurityQueryService,
     @param:MockK private val eventsPublisherService: EventsPublisherService,
@@ -56,12 +61,13 @@ class LocalUserSpaceCleanUpServiceTest(
 
     private val testInstance =
         LocalUserSpaceCleanUpService(
+            clusterClient,
             userRepository,
             cleanUpProperties,
             securityQueryService,
+            cleanUpLogDataService,
             eventsPublisherService,
             notificationErrorService,
-            cleanUpLogDataService,
         )
 
     @BeforeEach
@@ -85,36 +91,9 @@ class LocalUserSpaceCleanUpServiceTest(
             val finalWarningUser = createUser("final@ebi.ac.uk", "Final User", today.minusDays(90).atTime(12, 0))
 
             every { LocalDate.now() } returns today
-            every {
-                userRepository.findAllByLastActivityIsBetween(
-                    today.minusDays(30).atStartOfDay(),
-                    today
-                        .minusDays(30)
-                        .plusDays(1)
-                        .atStartOfDay()
-                        .minusSeconds(1),
-                )
-            } returns listOf(firstWarningUser.email)
-            every {
-                userRepository.findAllByLastActivityIsBetween(
-                    today.minusDays(60).atStartOfDay(),
-                    today
-                        .minusDays(60)
-                        .plusDays(1)
-                        .atStartOfDay()
-                        .minusSeconds(1),
-                )
-            } returns listOf(secondWarningUser.email)
-            every {
-                userRepository.findAllByLastActivityIsBetween(
-                    today.minusDays(90).atStartOfDay(),
-                    today
-                        .minusDays(90)
-                        .plusDays(1)
-                        .atStartOfDay()
-                        .minusSeconds(1),
-                )
-            } returns listOf(finalWarningUser.email)
+            everyWarningUsers(today, 30, firstWarningUser.email)
+            everyWarningUsers(today, 60, secondWarningUser.email)
+            everyWarningUsers(today, 90, finalWarningUser.email)
             every { securityQueryService.getUser(firstWarningUser.email) } returns firstWarningUser
             every { securityQueryService.getUser(secondWarningUser.email) } returns secondWarningUser
             every { securityQueryService.getUser(finalWarningUser.email) } returns finalWarningUser
@@ -122,7 +101,6 @@ class LocalUserSpaceCleanUpServiceTest(
 
             testInstance.sendNotifications()
 
-            assertThat(notifications).hasSize(3)
             assertThat(notifications.map { it.email }).containsExactly(
                 firstWarningUser.email,
                 secondWarningUser.email,
@@ -152,36 +130,9 @@ class LocalUserSpaceCleanUpServiceTest(
                 "Error checking user folder for '${brokenUser.email}', secret: ${brokenUser.userFolder.path}"
 
             every { LocalDate.now() } returns today
-            every {
-                userRepository.findAllByLastActivityIsBetween(
-                    today.minusDays(30).atStartOfDay(),
-                    today
-                        .minusDays(30)
-                        .plusDays(1)
-                        .atStartOfDay()
-                        .minusSeconds(1),
-                )
-            } returns listOf(brokenUser.email)
-            every {
-                userRepository.findAllByLastActivityIsBetween(
-                    today.minusDays(60).atStartOfDay(),
-                    today
-                        .minusDays(60)
-                        .plusDays(1)
-                        .atStartOfDay()
-                        .minusSeconds(1),
-                )
-            } returns emptyList()
-            every {
-                userRepository.findAllByLastActivityIsBetween(
-                    today.minusDays(90).atStartOfDay(),
-                    today
-                        .minusDays(90)
-                        .plusDays(1)
-                        .atStartOfDay()
-                        .minusSeconds(1),
-                )
-            } returns emptyList()
+            everyWarningUsers(today, 30, brokenUser.email)
+            everyWarningUsers(today, 60)
+            everyWarningUsers(today, 90)
             every { securityQueryService.getUser(brokenUser.email) } returns brokenUser
             every { eventsPublisherService.cleanupNotification(any()) } answers { nothing }
             coEvery { notificationErrorService.logNotificationError(any(), any(), any(), any()) } returns Unit
@@ -192,7 +143,7 @@ class LocalUserSpaceCleanUpServiceTest(
                 notificationErrorService.logNotificationError(
                     brokenUser.email,
                     brokenUser.userFolder.path.toString(),
-                    USER_SPACE_ERROR,
+                    NOTIFICATION_ERROR,
                     expectedError,
                 )
             }
@@ -200,7 +151,7 @@ class LocalUserSpaceCleanUpServiceTest(
         }
 
     @Test
-    fun `find users to cleanup uses exact cutoff and skips empty user spaces`() =
+    fun `clean up dispatches a data mover job for each matching non-empty active user`() =
         runTest {
             val today = LocalDate.parse("2026-06-16")
             val userToClean = createUser("cleanup@ebi.ac.uk", "Cleanup User", today.minusDays(120).atTime(10, 0))
@@ -211,6 +162,8 @@ class LocalUserSpaceCleanUpServiceTest(
                     today.minusDays(120).atTime(11, 0),
                     Files.createTempDirectory("cleanup-empty"),
                 )
+            val job = Job("12345", "datamover", "/logs/12345")
+            val jobSpec = slot<JobSpec>()
 
             every { LocalDate.now() } returns today
             every {
@@ -225,42 +178,79 @@ class LocalUserSpaceCleanUpServiceTest(
             } returns listOf(userToClean.email, emptyUser.email)
             every { securityQueryService.getUser(userToClean.email) } returns userToClean
             every { securityQueryService.getUser(emptyUser.email) } returns emptyUser
+            coEvery { clusterClient.triggerJobAsync(capture(jobSpec)) } returns Result.success(job)
+            coEvery { cleanUpLogDataService.logCleanUp(any(), any(), any(), any()) } returns Unit
 
-            val users = testInstance.cleanUpUserSpaces()
+            testInstance.cleanUpUserSpaces()
 
-            assertThat(users).containsExactly(
-                LocalUserSpaceCleanUpService.CleanUpUser(
-                    email = userToClean.email,
-                    lastActivity = userToClean.lastActivity,
-                    userSpacePath = userToClean.userFolder.path.absolutePathString(),
-                ),
-            )
+            assertThat(jobSpec.captured.queue).isEqualTo(DataMoverQueue)
+            assertThat(jobSpec.captured.command)
+                .isEqualTo("find '${userToClean.userFolder.path.absolutePathString()}' -mindepth 1 -delete")
+            coVerify(exactly = 1) {
+                cleanUpLogDataService.logCleanUp(
+                    userToClean.email,
+                    job.id,
+                    userToClean.lastActivity,
+                    userToClean.userFolder.path.absolutePathString(),
+                )
+            }
             coVerify(exactly = 0) {
                 cleanUpLogDataService.logCleanUpError(any(), any(), any(), any())
             }
         }
 
     @Test
-    fun `clean up user deletes user space contents and preserves root folder`() =
+    fun `clean up logs dispatch errors with the user email and path`() =
         runTest {
-            val folder = Files.createTempDirectory("cleanup-user")
-            val nestedFolder = folder.resolve("nested").createDirectories()
-            val hiddenFile = folder.resolve(".hidden")
-            val nestedFile = nestedFolder.resolve("file.txt")
-            Files.writeString(hiddenFile, "hidden")
-            Files.writeString(nestedFile, "nested")
-            val user = createUser("cleanup@ebi.ac.uk", "Cleanup User", LocalDateTime.parse("2026-02-16T10:00:00"), folder)
+            val today = LocalDate.parse("2026-06-16")
+            val userToClean = createUser("cleanup@ebi.ac.uk", "Cleanup User", today.minusDays(120).atTime(10, 0))
+            val failure = IllegalStateException("cluster unavailable")
 
-            every { securityQueryService.getUser(user.email) } returns user
+            every { LocalDate.now() } returns today
+            every {
+                userRepository.findAllByLastActivityIsBetweenAndActive(
+                    today.minusDays(120).atStartOfDay(),
+                    today
+                        .minusDays(120)
+                        .plusDays(1)
+                        .atStartOfDay()
+                        .minusSeconds(1),
+                )
+            } returns listOf(userToClean.email)
+            every { securityQueryService.getUser(userToClean.email) } returns userToClean
+            coEvery { clusterClient.triggerJobAsync(any()) } returns Result.failure(failure)
+            coEvery { cleanUpLogDataService.logCleanUpError(any(), any(), any(), any()) } returns Unit
 
-            testInstance.cleanUpUser(user.email)
+            testInstance.cleanUpUserSpaces()
 
-            assertThat(folder.exists()).isTrue()
-            assertThat(folder.toFile().listFiles()).isEmpty()
+            coVerify(exactly = 1) {
+                cleanUpLogDataService.logCleanUpError(
+                    userToClean.email,
+                    failure.message.orEmpty(),
+                    userToClean.userFolder.path.absolutePathString(),
+                )
+            }
             coVerify(exactly = 0) {
-                cleanUpLogDataService.logCleanUpError(any(), any(), any(), any())
+                cleanUpLogDataService.logCleanUp(any(), any(), any(), any())
             }
         }
+
+    private fun everyWarningUsers(
+        today: LocalDate,
+        daysAgo: Long,
+        vararg emails: String,
+    ) {
+        every {
+            userRepository.findAllByLastActivityIsBetweenAndActive(
+                today.minusDays(daysAgo).atStartOfDay(),
+                today
+                    .minusDays(daysAgo)
+                    .plusDays(1)
+                    .atStartOfDay()
+                    .minusSeconds(1),
+            )
+        } returns emails.toList()
+    }
 
     private fun createUser(
         email: String,

--- a/submission/submission-task/src/main/kotlin/uk/ac/ebi/biostd/submission/SubmissionTaskApp.kt
+++ b/submission/submission-task/src/main/kotlin/uk/ac/ebi/biostd/submission/SubmissionTaskApp.kt
@@ -1,6 +1,7 @@
 package uk.ac.ebi.biostd.submission
 
 import ac.uk.ebi.biostd.common.properties.ApplicationProperties
+import ac.uk.ebi.biostd.common.properties.Mode.CLEAN_UP_USER_SPACE
 import ac.uk.ebi.biostd.common.properties.Mode.HANDLE_REQUEST
 import ac.uk.ebi.biostd.common.properties.Mode.LOAD_PMC_LINKS
 import ac.uk.ebi.biostd.common.properties.Mode.NOTIFY_USER_SPACE_CLEAN_UP
@@ -98,6 +99,7 @@ class Execute(
                 POST_PROCESS_DOI -> postProcessDoi()
                 LOAD_PMC_LINKS -> loadLinks()
                 NOTIFY_USER_SPACE_CLEAN_UP -> sendUserSpaceCleanUpNotifications()
+                CLEAN_UP_USER_SPACE -> cleanUpUserSpace()
             }
             exitProcess(SpringApplication.exit(context))
         }
@@ -145,6 +147,12 @@ class Execute(
         logger.info { "Started sending user space cleanup notifications--------------------------------" }
         userSpaceCleanUpService.sendNotifications()
         logger.info { "Finished sending user space cleanup notifications--------------------------------" }
+    }
+
+    private suspend fun cleanUpUserSpace() {
+        logger.info { "Started users space cleanup" }
+        userSpaceCleanUpService.cleanUpUserSpaces()
+        logger.info { "Finished users space cleanup" }
     }
 
     private suspend fun runProcess(

--- a/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/admin/operations/OperationsScheduler.kt
+++ b/submission/submission-webapp/src/main/kotlin/ac/uk/ebi/biostd/admin/operations/OperationsScheduler.kt
@@ -3,6 +3,7 @@ package ac.uk.ebi.biostd.admin.operations
 import ac.uk.ebi.biostd.common.properties.ApplicationProperties
 import ac.uk.ebi.biostd.migration.service.MigrationService
 import ac.uk.ebi.biostd.submission.domain.cleanup.ExtUserSpaceCleanUpService
+import ac.uk.ebi.biostd.submission.domain.cleanup.ExtUserSpaceCleanUpService.CleanUpMode.CLEAN_UP
 import ac.uk.ebi.biostd.submission.domain.cleanup.ExtUserSpaceCleanUpService.CleanUpMode.NOTIFY
 import ac.uk.ebi.biostd.submission.stats.service.StatsReporterService
 import kotlinx.coroutines.runBlocking
@@ -45,6 +46,14 @@ class OperationsScheduler(
     @Scheduled(cron = "0 0 6 * * *")
     fun sendUserSpaceCleanUpNotifications() {
         runBlocking { if (properties.cleanUp.enabled) userCleanUpService.cleanUp(NOTIFY, remote = true) }
+    }
+
+    /**
+     * Clean inactive user spaces every day at 11 pm.
+     */
+    @Scheduled(cron = "0 0 23 * * *")
+    fun cleanUserSpaces() {
+        runBlocking { if (properties.cleanUp.enabled) userCleanUpService.cleanUp(CLEAN_UP, remote = true) }
     }
 
     /**


### PR DESCRIPTION
https://embl.atlassian.net/browse/BIOSTD-406

Introduces automatic deletion of files from private user workspaces for accounts
inactive beyond the configured cleanup period, as defined in ADR 0001.

- Adds `CLEAN_UP_USER_SPACE` task mode and logic for discovering eligible users
  and dispatching per-user cluster cleanup jobs.
- Implements dedicated Mongo collections and services to audit cleanup
  dispatch and errors.
- Schedules daily cleanup orchestration via the web application.
